### PR TITLE
ルートディレクトリからhardhatコマンドを呼び出せるようにしました。READMEへ追記をしました。

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
        NEXT_PUBLIC_DEFENDER_SECRET_KEY=
        ```
 
-  - **smartconract**
+  - **smartcontract**
 
 - **install**
 
@@ -44,4 +44,16 @@
 
   ```bash
   yarn frontend dev
+  ```
+
+- **compile smartcontract**
+
+  ```bash
+  yarn contract compile
+  ```
+
+- **test smartcontract**
+
+  ```bash
+  yarn contract test
   ```

--- a/pkgs/contract/package.json
+++ b/pkgs/contract/package.json
@@ -4,6 +4,12 @@
   "private": true,
   "main": "index.js",
   "license": "MIT",
+  "scripts": {
+    "clean": "npx hardhat clean",
+    "compile": "npx hardhat compile",
+    "test": "npx hardhat test",
+    "local:start": "npx hardhat node"
+  },
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
     "@nomicfoundation/hardhat-ethers": "^3.0.0",


### PR DESCRIPTION
ルートディレクトリからhardhatコマンドを呼び出せるようにしました。READMEへ追記をしました。

例えば

スマコンをテストしたい時は

```bash
yarn contract test
```

で実行できます！