### PR TITLE
指定したHatIDに紐づくウォレットアドレス一覧を取得するメソッドを追加しました。

### DIFF
--- a/pkgs/cli/README.md
+++ b/pkgs/cli/README.md
@@ -57,3 +57,15 @@ yarn cli toban function show -t test
 ```bash
 yarn cli toban hats list --treeId 163
 ```
+
+HatId に紐づく全ての着用者のウォレットアドレス一覧を取得する。
+
+```bash
+yarn cli toban hats wears --hatId 0x000000a300010002000100000000000000000000000000000000000000000000
+```
+
+特定のウォレットアドレスに紐づく全ての Hats の情報を取得する。
+
+```bash
+yarn cli toban hats wear --address 0xfedfa388151b6f8d5901f5482564988ed87b64f1
+```

--- a/pkgs/cli/src/commands/hats.ts
+++ b/pkgs/cli/src/commands/hats.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
-import { optimism } from "viem/chains";
-import { hatsSubgraphClient } from "../modules/hatsProtocol";
+import { getTreeInfo, getWearersInfo } from "../modules/hatsProtocol";
 
 export const hatsCommands = new Command();
 
@@ -26,26 +25,21 @@ hatsCommands
 	.option("-id, --treeId <treeId>", "Tree ID")
 	.action(async (options) => {
 		// ツリー情報を全て取得する。
-		const tree = await hatsSubgraphClient.getTree({
-			chainId: optimism.id,
-			treeId: Number(options.treeId),
-			props: {
-				hats: {
-					props: {
-						prettyId: true,
-						status: true,
-						createdAt: true,
-						details: true,
-						maxSupply: true,
-						eligibility: true,
-						imageUri: true,
-						toggle: true,
-						levelAtLocalTree: true,
-						currentSupply: true,
-					},
-				},
-			},
-		});
+		const tree = await getTreeInfo(Number(options.treeId));
 
 		console.log(tree);
+	});
+
+/**
+ * HatIdに紐づく着用者の情報を表示するコマンド
+ */
+hatsCommands
+	.command("wears")
+	.description("Show all of the wears that are associated with the hat ID")
+	.option("-id, --hatId <hatId>", "Hat ID")
+	.action(async (options) => {
+		// ツリー情報を全て取得する。
+		const wearers = await getWearersInfo(options.hatId);
+
+		console.log(wearers);
 	});

--- a/pkgs/cli/src/commands/hats.ts
+++ b/pkgs/cli/src/commands/hats.ts
@@ -1,5 +1,9 @@
 import { Command } from "commander";
-import { getTreeInfo, getWearersInfo } from "../modules/hatsProtocol";
+import {
+	getTreeInfo,
+	getWearerInfo,
+	getWearersInfo,
+} from "../modules/hatsProtocol";
 
 export const hatsCommands = new Command();
 
@@ -42,4 +46,18 @@ hatsCommands
 		const wearers = await getWearersInfo(options.hatId);
 
 		console.log(wearers);
+	});
+
+/**
+ * ウォレットアドレスに紐づくhatの情報を取得するコマンド
+ */
+hatsCommands
+	.command("wear")
+	.description("Show all of the hat info that are associated with the hat ID")
+	.option("-addr, --address <address>", "Wallet Address")
+	.action(async (options) => {
+		// 特定のウォレットアドレスに紐づく情報を全て取得する。
+		const wearer = await getWearerInfo(options.address);
+
+		console.log(wearer);
 	});

--- a/pkgs/cli/src/modules/hatsProtocol.ts
+++ b/pkgs/cli/src/modules/hatsProtocol.ts
@@ -14,3 +14,47 @@ export const hatsSubgraphClient = new HatsSubgraphClient({
 		},
 	},
 });
+
+/**
+ * ツリー情報を取得するメソッド
+ */
+export const getTreeInfo = async (treeId: number) => {
+	const tree = await hatsSubgraphClient.getTree({
+		chainId: optimism.id,
+		treeId: treeId,
+		props: {
+			hats: {
+				props: {
+					prettyId: true,
+					status: true,
+					createdAt: true,
+					details: true,
+					maxSupply: true,
+					eligibility: true,
+					imageUri: true,
+					toggle: true,
+					levelAtLocalTree: true,
+					currentSupply: true,
+				},
+			},
+		},
+	});
+
+	return tree;
+};
+
+/**
+ * 帽子の着用者のウォレットアドレスを一覧を取得するメソッド
+ */
+export const getWearersInfo = async (hatId: string) => {
+	// get the first 10 wearers of a given hat
+	const wearers = await hatsSubgraphClient.getWearersOfHatPaginated({
+		chainId: optimism.id,
+		props: {},
+		hatId: BigInt(hatId),
+		page: 0,
+		perPage: 100,
+	});
+
+	return wearers;
+};

--- a/pkgs/cli/src/modules/hatsProtocol.ts
+++ b/pkgs/cli/src/modules/hatsProtocol.ts
@@ -58,3 +58,33 @@ export const getWearersInfo = async (hatId: string) => {
 
 	return wearers;
 };
+
+/**
+ * 特定のウォレットアドレスが着用している全てのHats情報を取得するメソッド
+ */
+export const getWearerInfo = async (walletAddress: string) => {
+	// get the wearer of a given hat
+	const wearer = await hatsSubgraphClient.getWearer({
+		chainId: optimism.id,
+		wearerAddress: walletAddress as `0x${string}`,
+		props: {
+			currentHats: {
+				props: {
+					prettyId: true,
+					status: true,
+					createdAt: true,
+					details: true,
+					maxSupply: true,
+					eligibility: true,
+					toggle: true,
+					mutable: true,
+					imageUri: true,
+					levelAtLocalTree: true,
+					currentSupply: true,
+				},
+			},
+		},
+	});
+
+	return wearer;
+};


### PR DESCRIPTION
例えば以下のように実行すると

```bash
yarn cli toban hats wears --hatId 0x000000a300010002000100000000000000000000000000000000000000000000
```

以下のように着用者のウォレットアドレスが一覧で取得できます！！

```bash
[
  { id: '0x019e9acc1ab9d5e20946e8b9c1036da842e41052' },
  { id: '0x3db725901779ea2e0d895f7b4c0cbae1a40cc2bc' },
  { id: '0x403e1cc42d92ca9ffe032ae5e232864e5ccbf705' },
  { id: '0x55a3a37f3b96c7e6166d09939c76383b0d269f3f' },
  { id: '0x7fb0881f54da02761cf49f51caaabd2386331258' },
  { id: '0x86d186eabf2d1318cab9ffabf345a13c0f903d72' },
  { id: '0xb43f18628a44007cb1896dfd28e2674058aba358' },
  { id: '0xe39777d0dbd658e34d58d427d0320269caeb2db8' },
  { id: '0xea1fd22d2eddcae24271e80a5843a8456bc8a7a9' },
  { id: '0xfedfa388151b6f8d5901f5482564988ed87b64f1' }
]
✨  Done in 1.05s.
```