### PR TITLE
Add namestone to use subname of toban.eth

### DIFF
--- a/pkgs/frontend/hooks/useENS.ts
+++ b/pkgs/frontend/hooks/useENS.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import NameStone, { NameData } from "namestone-sdk";
+
+const ns = new NameStone(import.meta.env.VITE_NAMESTONE_API_KEY);
+const domain = "toban.eth";
+
+export const useNamesByAddresses = (addresses: string[]) => {
+  const [names, setNames] = useState<NameData[][]>([]);
+
+  useEffect(() => {
+    const fetchNames = async () => {
+      try {
+        const data: NameData[][] = await Promise.all(
+          addresses.map((address) => ns.getNames({ domain, address }))
+        );
+        setNames(data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchNames();
+  }, [addresses]);
+
+  return names;
+};

--- a/pkgs/frontend/package.json
+++ b/pkgs/frontend/package.json
@@ -26,12 +26,13 @@
     "@solana/web3.js": "^1.95.5",
     "isbot": "^5.1.11",
     "lucide-react": "^0.399.0",
+    "namestone-sdk": "^0.2.11",
     "next-themes": "^0.4.3",
     "permissionless": "^0.2.20",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "viem": "^2.21.51",
-    "react-icons": "^5.3.0"
+    "react-icons": "^5.3.0",
+    "viem": "^2.21.51"
   },
   "devDependencies": {
     "@remix-run/dev": "^2.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13878,6 +13878,11 @@ multipipe@^1.0.2:
     duplexer2 "^0.1.2"
     object-assign "^4.1.0"
 
+namestone-sdk@^0.2.11:
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/namestone-sdk/-/namestone-sdk-0.2.11.tgz#a124c69b4a1cf87a4d3485c0b82f931d6c3411f9"
+  integrity sha512-18WFxic1Q2ATbdNBUAtN2MDC+/WuUB05CPKssbQvlVHKMor9zlgvIfq0S/jmblMa27JpDLdGm7mHE2QoMVAPoQ==
+
 nanoid@^3.3.7:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"


### PR DESCRIPTION
# Add namestone to use subname of toban.eth

## Description

toban.ethをベースにtaro.toban.ethのような名前をつけてユーザーやSplitterのアドレスを使いやすくするためにNameStoneを導入。まずはaddressをもとに、Nameをリゾルブするところだけ。

Fixes #184 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

If applicable, add screenshots to help explain your problem.
