### PR TITLE
Add Splits list page (mocked version)

### DIFF
--- a/pkgs/frontend/app/routes/$treeId_.splits._index.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.splits._index.tsx
@@ -3,7 +3,6 @@ import { useParams } from "@remix-run/react";
 import { useTreeInfo } from "hooks/useHats";
 import { FC, useCallback, useState } from "react";
 import { CommonButton } from "~/components/common/CommonButton";
-import { Button } from "~/components/ui/button";
 import { FaAngleDown } from "react-icons/fa6";
 import { UserIcon } from "~/components/icon/UserIcon";
 
@@ -34,11 +33,11 @@ const SplitInfoItem = () => {
           </Text>
         </Flex>
         {open || (
-          <Button color="#333" background="transparent" w="full" h="auto">
+          <CommonButton color="#333" background="transparent" w="full" h="auto">
             <FaAngleDown
               style={{ width: "16px", height: "16px", objectFit: "cover" }}
             />
-          </Button>
+          </CommonButton>
         )}
       </Collapsible.Trigger>
       <Collapsible.Content>

--- a/pkgs/frontend/app/routes/$treeId_.splits._index.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.splits._index.tsx
@@ -1,3 +1,4 @@
+import { type MouseEvent } from "react";
 import { Box, Collapsible, Flex, Text } from "@chakra-ui/react";
 import { useParams } from "@remix-run/react";
 import { useTreeInfo } from "hooks/useHats";
@@ -5,6 +6,7 @@ import { FC, useCallback, useState } from "react";
 import { CommonButton } from "~/components/common/CommonButton";
 import { FaAngleDown, FaRegCopy } from "react-icons/fa6";
 import { UserIcon } from "~/components/icon/UserIcon";
+import { useCopyToClipboard } from "hooks/useCopyToClipboard";
 
 const SplitInfoItem = () => {
   const dummyFromAddress = "0xabc89dsakdfasdfasdd123sdafsdfasdf";
@@ -12,6 +14,16 @@ const SplitInfoItem = () => {
   const onOpen = useCallback(() => {
     setOpen(true);
   }, [setOpen]);
+
+  const { copyToClipboardAction } = useCopyToClipboard(dummyFromAddress);
+
+  const onClickCopyButton = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      copyToClipboardAction();
+    },
+    [copyToClipboardAction]
+  );
 
   const dummyRatioBreakdown = [
     { name: "Ryoma", address: "0x12344sdfasdfadfaweifsd", ratio: 0.2 },
@@ -39,6 +51,7 @@ const SplitInfoItem = () => {
             h="auto"
             p="4px"
             minW="unset"
+            onClick={onClickCopyButton}
           >
             <FaRegCopy
               style={{ width: "16px", height: "16px", objectFit: "cover" }}

--- a/pkgs/frontend/app/routes/$treeId_.splits._index.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.splits._index.tsx
@@ -1,0 +1,30 @@
+import { Box, Flex, Text } from "@chakra-ui/react";
+import { useParams } from "@remix-run/react";
+import { useTreeInfo } from "hooks/useHats";
+import { FC } from "react";
+import CommonButton from "~/components/common/CommonButton";
+
+const WorkspaceTop: FC = () => {
+  const { treeId } = useParams();
+
+  treeId;
+  // const tree = useTreeInfo(Number(treeId));
+
+  return (
+    <Box w="100%">
+      <Flex my={4} placeItems="center">
+        <Text fontSize="lg" flexGrow={1}>
+          Splits
+        </Text>
+        <CommonButton w={"auto"} size="sm">
+          Create New
+        </CommonButton>
+      </Flex>
+      <Box px={2} py={2} borderRadius={8} border="1px solid #333">
+        {/* Info here */}
+      </Box>
+    </Box>
+  );
+};
+
+export default WorkspaceTop;

--- a/pkgs/frontend/app/routes/$treeId_.splits._index.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.splits._index.tsx
@@ -3,7 +3,7 @@ import { useParams } from "@remix-run/react";
 import { useTreeInfo } from "hooks/useHats";
 import { FC, useCallback, useState } from "react";
 import { CommonButton } from "~/components/common/CommonButton";
-import { FaAngleDown } from "react-icons/fa6";
+import { FaAngleDown, FaRegCopy } from "react-icons/fa6";
 import { UserIcon } from "~/components/icon/UserIcon";
 
 const SplitInfoItem = () => {
@@ -27,10 +27,22 @@ const SplitInfoItem = () => {
         </Flex>
         <Text textStyle="md">2024Q3_Rewards</Text>
         <Text textStyle="sm">Created at 2024/7/11</Text>
-        <Flex mt={4}>
+        <Flex mt={4} placeItems="center">
           <Text textStyle="sm" flexGrow={1}>
             0xabc89dsakdfasdfasdd123sdafsdfasdf
           </Text>
+          <CommonButton
+            color="#333"
+            background="transparent"
+            w="auto"
+            h="auto"
+            p="4px"
+            minW="unset"
+          >
+            <FaRegCopy
+              style={{ width: "16px", height: "16px", objectFit: "cover" }}
+            />
+          </CommonButton>
         </Flex>
         {open || (
           <CommonButton color="#333" background="transparent" w="full" h="auto">

--- a/pkgs/frontend/app/routes/$treeId_.splits._index.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.splits._index.tsx
@@ -1,10 +1,69 @@
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Box, Collapsible, Flex, Text } from "@chakra-ui/react";
 import { useParams } from "@remix-run/react";
 import { useTreeInfo } from "hooks/useHats";
-import { FC } from "react";
-import CommonButton from "~/components/common/CommonButton";
+import { FC, useCallback, useState } from "react";
+import { CommonButton } from "~/components/common/CommonButton";
+import { Button } from "~/components/ui/button";
+import { FaAngleDown } from "react-icons/fa6";
+import { UserIcon } from "~/components/icon/UserIcon";
 
-const WorkspaceTop: FC = () => {
+const SplitInfoItem = () => {
+  const [open, setOpen] = useState(false);
+  const onOpen = useCallback(() => {
+    setOpen(true);
+  }, [setOpen]);
+
+  const dummyRatioBreakdown = [
+    { name: "Ryoma", address: "0x12344sdfasdfadfaweifsd", ratio: 0.2 },
+    { name: "Taro", address: "0x12344sdfasdfadfaweifsd", ratio: 0.8 },
+  ];
+
+  return (
+    <Collapsible.Root disabled={open} onOpenChange={onOpen}>
+      <Collapsible.Trigger w="full" textAlign={"start"} cursor="pointer">
+        <Flex mb={2}>
+          <Text as="span" textStyle="xs">
+            Optimism
+          </Text>
+        </Flex>
+        <Text textStyle="md">2024Q3_Rewards</Text>
+        <Text textStyle="sm">Created at 2024/7/11</Text>
+        <Flex mt={4}>
+          <Text textStyle="sm" flexGrow={1}>
+            0xabc89dsakdfasdfasdd123sdafsdfasdf
+          </Text>
+        </Flex>
+        {open || (
+          <Button color="#333" background="transparent" w="full" h="auto">
+            <FaAngleDown
+              style={{ width: "16px", height: "16px", objectFit: "cover" }}
+            />
+          </Button>
+        )}
+      </Collapsible.Trigger>
+      <Collapsible.Content>
+        <Box
+          mx={2}
+          my={4}
+          borderTop="1px solid #868e96"
+          role="presentation"
+        ></Box>
+        {dummyRatioBreakdown.map((breakdown) => (
+          <Flex key={breakdown.name} my={2} alignItems="center" gap={2}>
+            <UserIcon size="40px" />
+            <Box flexGrow={1}>
+              <Text textStyle="sm">{breakdown.name}</Text>
+              <Text textStyle="sm">{breakdown.address}</Text>
+            </Box>
+            {breakdown.ratio * 100} %
+          </Flex>
+        ))}
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+};
+
+const SplitsIndex: FC = () => {
   const { treeId } = useParams();
 
   treeId;
@@ -20,11 +79,11 @@ const WorkspaceTop: FC = () => {
           Create New
         </CommonButton>
       </Flex>
-      <Box px={2} py={2} borderRadius={8} border="1px solid #333">
-        {/* Info here */}
+      <Box px={4} py={4} borderRadius={8} border="1px solid #333">
+        <SplitInfoItem />
       </Box>
     </Box>
   );
 };
 
-export default WorkspaceTop;
+export default SplitsIndex;

--- a/pkgs/frontend/app/routes/$treeId_.splits._index.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.splits._index.tsx
@@ -7,6 +7,7 @@ import { FaAngleDown, FaRegCopy } from "react-icons/fa6";
 import { UserIcon } from "~/components/icon/UserIcon";
 
 const SplitInfoItem = () => {
+  const dummyFromAddress = "0xabc89dsakdfasdfasdd123sdafsdfasdf";
   const [open, setOpen] = useState(false);
   const onOpen = useCallback(() => {
     setOpen(true);
@@ -29,7 +30,7 @@ const SplitInfoItem = () => {
         <Text textStyle="sm">Created at 2024/7/11</Text>
         <Flex mt={4} placeItems="center">
           <Text textStyle="sm" flexGrow={1}>
-            0xabc89dsakdfasdfasdd123sdafsdfasdf
+            {dummyFromAddress}
           </Text>
           <CommonButton
             color="#333"

--- a/pkgs/frontend/hooks/useCopyToClipboard.ts
+++ b/pkgs/frontend/hooks/useCopyToClipboard.ts
@@ -1,0 +1,9 @@
+import { useCallback } from "react";
+
+export const useCopyToClipboard = (content: string) => {
+  const copyToClipboardAction = useCallback(() => {
+    return navigator.clipboard.writeText(content);
+  }, [content]);
+
+  return { copyToClipboardAction };
+};


### PR DESCRIPTION
## Description

- Related: #199

Splits を一覧するページを追加
-  実際のデータを引っ張ってくるのはまだわからなかったので、いったん全部ハードコード

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![20241221-01](https://github.com/user-attachments/assets/977aa085-924f-4982-b4c2-edf2a0130e13)

## Anything else

### 別PRで対応

- [ ] QRコードの表示
- [ ] 実際のデータと紐づける実装