### PR TITLE
Issue/259

### DIFF
--- a/pkgs/frontend/app/root.tsx
+++ b/pkgs/frontend/app/root.tsx
@@ -3,13 +3,20 @@ import { Container } from "@chakra-ui/react";
 import { withEmotionCache } from "@emotion/react";
 import { PrivyProvider } from "@privy-io/react-auth";
 import {
+  type ClientLoaderFunctionArgs,
   Links,
   Meta,
   Outlet,
   Scripts,
   ScrollRestoration,
+  data,
+  useLoaderData,
 } from "@remix-run/react";
 import { currentChain } from "hooks/useViem";
+import { useEffect } from "react";
+import { ToastContainer, toast as notify } from "react-toastify";
+import toastStyles from "react-toastify/ReactToastify.css?url";
+import { getToast } from "remix-toast";
 import { goldskyClient } from "utils/apollo";
 import { Header } from "./components/Header";
 import { SwitchNetwork } from "./components/SwitchNetwork";
@@ -45,14 +52,33 @@ export const Layout = withEmotionCache((props: LayoutProps, cache) => {
   );
 });
 
+// Add the toast stylesheet
+export const links = () => [{ rel: "stylesheet", href: toastStyles }];
+// Implemented from above
+export const loader = async ({ request }: ClientLoaderFunctionArgs) => {
+  const { toast, headers } = await getToast(request);
+  return data({ toast }, { headers });
+};
+
 export default function App() {
+  const {
+    data: { toast },
+  } = useLoaderData<typeof loader>();
+  // Hook to show the toasts
+  useEffect(() => {
+    if (toast) {
+      // notify on a toast message
+      notify(toast.message, { type: toast.type });
+    }
+  }, [toast]);
+
   return (
     <ApolloProvider client={goldskyClient}>
       <PrivyProvider
         appId={import.meta.env.VITE_PRIVY_APP_ID}
         config={{
           appearance: {
-            walletList: ["coinbase_wallet"],
+            walletList: ["coinbase_wallet", "metamask"],
           },
           embeddedWallets: {
             createOnLogin: "users-without-wallets",
@@ -77,6 +103,7 @@ export default function App() {
             <Header />
             <Outlet />
           </Container>
+          <ToastContainer />
         </ChakraProvider>
       </PrivyProvider>
     </ApolloProvider>

--- a/pkgs/frontend/hooks/useFractionToken.ts
+++ b/pkgs/frontend/hooks/useFractionToken.ts
@@ -465,6 +465,7 @@ export const useTransferFractionToken = (hatId: bigint, wearer: Address) => {
       setIsLoading(true);
 
       let txHash: `0x${string}` | undefined = undefined;
+      let error: string | undefined = undefined;
       if (initialized) {
         try {
           txHash = await wallet.writeContract({
@@ -472,8 +473,8 @@ export const useTransferFractionToken = (hatId: bigint, wearer: Address) => {
             functionName: "safeTransferFrom",
             args: [wallet.account.address, to, tokenId, amount, "0x"],
           });
-        } catch (_) {
-          setIsLoading(false);
+        } catch {
+          error = "アシストクレジットの送信に失敗しました";
         } finally {
           setIsLoading(false);
         }
@@ -499,7 +500,6 @@ export const useTransferFractionToken = (hatId: bigint, wearer: Address) => {
           });
         } catch (error) {
           console.error(error);
-          setIsLoading(false);
         } finally {
           await publicClient.waitForTransactionReceipt({
             hash: txHash ?? "0x",
@@ -507,10 +507,11 @@ export const useTransferFractionToken = (hatId: bigint, wearer: Address) => {
           setIsLoading(false);
         }
       } else {
-        console.error("FractionToken is not initialized");
+        setIsLoading(false);
+        error = "この役割についてあなたはアシストクレジットの送信ができません";
       }
 
-      return txHash;
+      return { txHash, error };
     },
     [wallet, initialized, tokenId, hatId, wearer],
   );

--- a/pkgs/frontend/package.json
+++ b/pkgs/frontend/package.json
@@ -39,6 +39,8 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "react-icons": "^5.4.0",
+    "react-toastify": "^11.0.3",
+    "remix-toast": "1.2.2",
     "viem": "^2.21.51"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9272,7 +9272,7 @@ clsx@^1.2.1:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
-clsx@^2.0.0:
+clsx@^2.0.0, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
@@ -18402,6 +18402,13 @@ react-router@6.28.0:
   dependencies:
     "@remix-run/router" "1.21.0"
 
+react-toastify@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-11.0.3.tgz#1684de60baf745e761d3c608bb29581657e2fe01"
+  integrity sha512-cbPtHJPfc0sGqVwozBwaTrTu1ogB9+BLLjd4dDXd863qYLj7DGrQ2sg5RAChjFUB4yc3w8iXOtWcJqPK/6xqRQ==
+  dependencies:
+    clsx "^2.1.1"
+
 react@^18.0.0, react@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
@@ -18819,6 +18826,13 @@ remedial@^1.0.7:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/remedial/-/remedial-1.0.8.tgz#a5e4fd52a0e4956adbaf62da63a5a46a78c578a0"
   integrity sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==
+
+remix-toast@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/remix-toast/-/remix-toast-1.2.2.tgz#13150cd082e70a2a70bea07cc22d72ce9e6cbf3a"
+  integrity sha512-GayR/ozpqCZWI9AK0+wzp/SaD3jIUnx7IBSL4Oioglp1gs3waGWlHhgBtG+IbLmCR9iUzzrux0HiZQdk8uwYVg==
+  dependencies:
+    zod "^3.22.3"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -22178,6 +22192,11 @@ zod@^3.21.4, zod@^3.22.4, zod@^3.23.8:
   version "3.23.8"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
   integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
+
+zod@^3.22.3:
+  version "3.24.1"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.24.1.tgz#27445c912738c8ad1e9de1bea0359fa44d9d35ee"
+  integrity sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==
 
 zustand@^5.0.0:
   version "5.0.2"


### PR DESCRIPTION
## Description

Fixes #259 

remixではssrの関係で[remix-toast](https://remix.run/resources/remix-toast)がないとreact-toastifyなどのtoastライブラリが使えない

remix-toastの最新バージョンはreact-routerにしか対応していないので(remix-ってついているのに)、remix対応のv1.2.2に落としてインストールした

react-routerに移行する場合はremix-toastもバージョンを上げる必要があるかも

### 実装内容
- `root.tsx`にtoastを使うための設定を追加
- `transferFractionToken`関数内で発生したエラーごとのメッセージを`error`変数に格納し、onClickイベントでその内容がtoastとして表示されるようにした
- toastは`import { toast } from "react-toastify"`でどこでも使える

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

If applicable, add screenshots to help explain your problem.
