### PR TITLE
fix: type casting for exact match search parameter of name stone sear…

### DIFF
--- a/pkgs/frontend/app/routes/api.namestone.$action.tsx
+++ b/pkgs/frontend/app/routes/api.namestone.$action.tsx
@@ -57,7 +57,7 @@ export const action: ActionFunction = async ({ request, params }) => {
         const existingNames = await ns.searchNames({
           domain,
           name,
-          exact_match: true,
+          exact_match: 1 as unknown as boolean,
         });
 
         // If name exists and is owned by a different address, throw error


### PR DESCRIPTION
NameStoneで一部の名前が登録できないバグを修正しました！

具体的には、name stoneのsearchNamesのexact_matchが0または1の数字のみしか受け付けない仕様らしく、そこにtrueが入っていたため、exact_matchが機能していなかったようです。

例えば、 `yawnc` が登録されていると、`yawn` , `yaw` , `ya`  など一部マッチするより少ない文字列の名前が登録されないようになっていたみたいです。

りょーまさんが他の部分でexact_matchに使っていたコードを流用し、解決しました！