### PR TITLE
Add delay before navigating to splitter page

### DIFF
--- a/pkgs/frontend/app/routes/$treeId_.splits.new.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.splits.new.tsx
@@ -317,7 +317,9 @@ const SplitterNew: FC = () => {
         await setName({ name: `${splitterName}.split`, address: address });
       }
 
-      navigate(`/${treeId}/splits`);
+      setTimeout(() => {
+        navigate(`/${treeId}/splits`);
+      }, 5000);
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
# Pull Request Template

## Description

Graphに反映されるまでに遅延があるので、トランザクション成功後5秒ほど待機してから一覧画面に遷移するべき

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

If applicable, add screenshots to help explain your problem.
