### PR TITLE
Issue/318

### DIFF
--- a/pkgs/frontend/app/components/roles/RoleWithBalance.tsx
+++ b/pkgs/frontend/app/components/roles/RoleWithBalance.tsx
@@ -67,7 +67,7 @@ const RoleWithBalance: FC<RoleProps> = (params) => {
               w="auto"
               size="sm"
               onClick={() =>
-                navigate(`/${treeId}/${hatId}/${address}/assistcredit/send`)
+                navigate(`/${treeId}/${hatId}/${wearer}/assistcredit/send`)
               }
             >
               送る

--- a/pkgs/frontend/app/routes/$treeId_.$hatId_.$address_.assistcredit.send.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.$hatId_.$address_.assistcredit.send.tsx
@@ -18,6 +18,7 @@ import {
 } from "hooks/useENS";
 import {
   useBalanceOfFractionToken,
+  useBalanceOfFractionTokens,
   useFractionToken,
   useTransferFractionToken,
 } from "hooks/useFractionToken";
@@ -43,10 +44,17 @@ const AssistCreditSend: FC = () => {
   const { treeId, hatId, address } = useParams();
   const me = useActiveWalletIdentity();
 
-  const balanceOfToken = useBalanceOfFractionToken(
-    me.identity?.address as Address,
-    address as Address,
-    BigInt(hatId ?? ""),
+  const { data } = useBalanceOfFractionTokens({
+    where: {
+      workspaceId: treeId,
+      hatId: BigInt(hatId ?? "").toString(),
+      owner: address?.toLowerCase(),
+    },
+  });
+
+  const balanceOfToken = useMemo(
+    () => data?.balanceOfFractionTokens.at(0)?.balance,
+    [data],
   );
 
   const { hat } = useGetHat(hatId ?? "");

--- a/pkgs/frontend/app/routes/$treeId_.$hatId_.$address_.assistcredit.send.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.$hatId_.$address_.assistcredit.send.tsx
@@ -48,7 +48,7 @@ const AssistCreditSend: FC = () => {
     where: {
       workspaceId: treeId,
       hatId: BigInt(hatId ?? "").toString(),
-      owner: address?.toLowerCase(),
+      owner: me.identity?.address.toLowerCase(),
     },
   });
 

--- a/pkgs/frontend/app/routes/$treeId_.assistcredit._index.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.assistcredit._index.tsx
@@ -24,20 +24,25 @@ const WorkspaceWithBalance: FC = () => {
     },
   });
 
-  const hatIds = useMemo(
-    () => data?.balanceOfFractionTokens.map(({ hatId }) => hatId.toString()),
-    [data],
-  );
+  const hatIds = useMemo(() => {
+    return Array.from(
+      new Set(data?.balanceOfFractionTokens.map(({ hatId }) => hatId)),
+    );
+  }, [data]);
 
   const { hats } = useGetHats(hatIds || []);
 
   const hatsWithBalance = useMemo(() => {
     if (!hats) return [];
-    return hats.map((hat, index) => ({
-      hat,
-      ...data?.balanceOfFractionTokens[index],
-    }));
-  }, [data, hats]);
+    return hats
+      .map((hat) => {
+        const balance = data?.balanceOfFractionTokens.find(
+          ({ hatId }) => hatId === BigInt(hat.id).toString(),
+        );
+        if (balance) return { hat, ...balance };
+      })
+      .filter((hat) => !!hat);
+  }, [hats, data]);
 
   return (
     <Box>
@@ -46,7 +51,7 @@ const WorkspaceWithBalance: FC = () => {
         {wallet &&
           hatsWithBalance.map(({ hat, balance, wearer }) => (
             <HatsListItemParser
-              key={`${hat.id}${wearer}`}
+              key={hat.id}
               imageUri={hat.imageUri}
               detailUri={hat.details}
             >


### PR DESCRIPTION
## Description

- アシストクレジットの表示バグの修正
  - hatIdの重複をなくす処理をしました
  - goldskyから重複したhatIdが返されることがあり、「戻る」ボタンではうまく描画が更新されないことがあるためと思われます
  - 自分の手元ではバグはなくなりましたが、確認していただきたいです
- 人からもらったアシストクレジットが表示されない、送れない現象の解消
  - 量が表示されるように修正しました
  - `/{treeId}/assistcredit`からの遷移先が`/{treeId}/{hatId}/{me}`になっていましたが、正しくは`/{treeId}/{hatId}/{wearer}`でした
  - ちゃんと送れることを確認しました

Fixes #318 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

If applicable, add screenshots to help explain your problem.
