### PR TITLE
fix: upload image file to IPFS without hooks in role edit page

### DIFF
--- a/pkgs/frontend/package.json
+++ b/pkgs/frontend/package.json
@@ -24,7 +24,7 @@
     "@emotion/server": "^11.11.0",
     "@hatsprotocol/sdk-v1-core": "^0.10.0",
     "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",
-    "@privy-io/react-auth": ">=2.4.2 <2.7.0",
+    "@privy-io/react-auth": ">=2.4.2 <=2.5.0",
     "@remix-run/node": "^2.15.0",
     "@remix-run/react": "^2.15.0",
     "@remix-run/serve": "^2.15.0",

--- a/pkgs/frontend/package.json
+++ b/pkgs/frontend/package.json
@@ -24,7 +24,7 @@
     "@emotion/server": "^11.11.0",
     "@hatsprotocol/sdk-v1-core": "^0.10.0",
     "@hatsprotocol/sdk-v1-subgraph": "^1.0.0",
-    "@privy-io/react-auth": "^2.4.2",
+    "@privy-io/react-auth": ">=2.4.2 <2.7.0",
     "@remix-run/node": "^2.15.0",
     "@remix-run/react": "^2.15.0",
     "@remix-run/serve": "^2.15.0",

--- a/pkgs/frontend/utils/ipfs.ts
+++ b/pkgs/frontend/utils/ipfs.ts
@@ -55,6 +55,14 @@ export const ipfsUploadFile = async (file: File) => {
   }
 };
 
+export const ipfsUploadImageFile = async (imageFile: File) => {
+  if (!imageFile) throw new Error("Invalid or no image file selected");
+  if (!imageFile?.type.startsWith("image/"))
+    throw new Error("Invalid or no image file selected");
+
+  return await ipfsUploadFile(imageFile);
+};
+
 export const ipfs2https = (ipfsUri?: string | undefined) => {
   if (!ipfsUri) return undefined;
 


### PR DESCRIPTION
# ロールの編集画面で、画像がアップロードできなかった問題を修正

## Description

IPFSに画像をアップロードするhooksを使用していましたが、JSのform機能を使って送信ボタン押下時の内容をコントロールしているため、画像ファイルをuseStateで保存することを義務付けているuseUploadImageFileToIpfsではなく、utils/ipfs.tsにシンプルに画像をアップする関数を作成して代用しました。

Fixes # (issue)
- #337 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

