### PR TITLE
Feat: change hat max supply

### DIFF
--- a/pkgs/frontend/app/components/input/InputNumber.tsx
+++ b/pkgs/frontend/app/components/input/InputNumber.tsx
@@ -1,0 +1,48 @@
+import { Box, type BoxProps } from "@chakra-ui/react";
+import { CommonInput } from "../common/CommonInput";
+
+export const InputNumber = ({
+  number,
+  setNumber,
+  ...boxProps
+}: {
+  number: number | undefined;
+  setNumber: (number: number | undefined) => void;
+  placeholder?: string;
+} & BoxProps) => {
+  return (
+    <Box w="100%" {...boxProps}>
+      <CommonInput
+        minHeight="45px"
+        value={number}
+        onChange={(e) => {
+          const value = e.target.value;
+          if (value === undefined) {
+            setNumber(undefined);
+          } else {
+            // Try to parse as an integer
+            const intVal = Number.parseInt(value, 10);
+
+            // Check if it's a positive integer and the parsed value matches the input string
+            // (to prevent things like "1.2" being parsed as 1, or "1abc" as 1)
+            if (
+              !Number.isNaN(intVal) &&
+              intVal.toString() === value &&
+              intVal > 0
+            ) {
+              setNumber(intVal);
+            } else if (value === "") {
+              // This case is already handled by the outer if, but kept for clarity during refactor
+              setNumber("");
+            }
+            // If not a valid positive integer string (e.g., "abc", "1.2", "-5", "0"),
+            // do nothing, effectively rejecting the invalid input.
+            // This allows the user to type, but only valid positive integers will update the state.
+          }
+        }}
+        type="number"
+        w="100%"
+      />
+    </Box>
+  );
+};

--- a/pkgs/frontend/app/components/input/InputNumber.tsx
+++ b/pkgs/frontend/app/components/input/InputNumber.tsx
@@ -1,4 +1,4 @@
-import { NumberInput, type BoxProps } from "@chakra-ui/react";
+import { type BoxProps, NumberInput } from "@chakra-ui/react";
 
 type ValueChangeDetails = { value: number; valueAsString: string };
 

--- a/pkgs/frontend/app/components/input/InputNumber.tsx
+++ b/pkgs/frontend/app/components/input/InputNumber.tsx
@@ -1,48 +1,41 @@
-import { Box, type BoxProps } from "@chakra-ui/react";
-import { CommonInput } from "../common/CommonInput";
+import { NumberInput, type BoxProps } from "@chakra-ui/react";
+
+type ValueChangeDetails = { value: number; valueAsString: string };
 
 export const InputNumber = ({
   number,
   setNumber,
+  defaultValue,
   ...boxProps
 }: {
   number: number | undefined;
-  setNumber: (number: number | undefined) => void;
-  placeholder?: string;
+  setNumber: (value: number | undefined) => void;
+  defaultValue?: number;
 } & BoxProps) => {
   return (
-    <Box w="100%" {...boxProps}>
-      <CommonInput
+    <NumberInput.Root
+      w="100%"
+      {...boxProps}
+      value={number}
+      onValueChange={(e: ValueChangeDetails) => setNumber(e.value)}
+      defaultValue={defaultValue}
+      min={1}
+      precision={0}
+      formatOptions={{}}
+      allowMouseWheel
+      borderColor="gray.800"
+      borderRadius="3xl"
+      backgroundColor="white"
+    >
+      <NumberInput.Input
         minHeight="45px"
-        value={number}
-        onChange={(e) => {
-          const value = e.target.value;
-          if (value === undefined) {
-            setNumber(undefined);
-          } else {
-            // Try to parse as an integer
-            const intVal = Number.parseInt(value, 10);
-
-            // Check if it's a positive integer and the parsed value matches the input string
-            // (to prevent things like "1.2" being parsed as 1, or "1abc" as 1)
-            if (
-              !Number.isNaN(intVal) &&
-              intVal.toString() === value &&
-              intVal > 0
-            ) {
-              setNumber(intVal);
-            } else if (value === "") {
-              // This case is already handled by the outer if, but kept for clarity during refactor
-              setNumber("");
-            }
-            // If not a valid positive integer string (e.g., "abc", "1.2", "-5", "0"),
-            // do nothing, effectively rejecting the invalid input.
-            // This allows the user to type, but only valid positive integers will update the state.
-          }
-        }}
-        type="number"
-        w="100%"
+        textAlign="right"
+        paddingRight="2.5rem"
       />
-    </Box>
+      <NumberInput.Control>
+        <NumberInput.IncrementTrigger />
+        <NumberInput.DecrementTrigger />
+      </NumberInput.Control>
+    </NumberInput.Root>
   );
 };

--- a/pkgs/frontend/app/routes/$treeId_.$hatId_.edit.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.$hatId_.edit.tsx
@@ -22,6 +22,7 @@ import { RoleAttributesList } from "~/components/RoleAttributesList";
 import { InputDescription } from "~/components/input/InputDescription";
 import { InputImage } from "~/components/input/InputImage";
 import { InputName } from "~/components/input/InputName";
+import { InputNumber } from "~/components/input/InputNumber";
 import { AddRoleAttributeDialog } from "~/components/roleAttributeDialog/AddRoleAttributeDialog";
 import { RoleImageLibrarySelector } from "~/components/roles/RoleImageLibrarySelector";
 
@@ -36,6 +37,7 @@ interface FormData {
   selectedImageCid: string;
   responsibilities: HatsDetailsResponsabilities;
   authorities: HatsDetailsAuthorities;
+  maxSupply: number | undefined;
 }
 
 const EditRole: FC = () => {
@@ -43,7 +45,7 @@ const EditRole: FC = () => {
   const navigate = useNavigate();
   const { wallet } = useActiveWallet();
   const { hat } = useGetHat(hatId || "");
-  const { changeHatDetails, changeHatImageURI } = useHats();
+  const { changeHatDetails, changeHatImageURI, changeHatMaxSupply } = useHats();
   const { uploadHatsDetailsToIpfs } = useUploadHatsDetailsToIpfs();
   const { uploadImageFileToIpfs } = useUploadImageFileToIpfs();
 
@@ -56,6 +58,7 @@ const EditRole: FC = () => {
         description: "",
         responsibilities: [],
         authorities: [],
+        maxSupply: undefined,
       },
     });
 
@@ -76,10 +79,11 @@ const EditRole: FC = () => {
         setValue("description", hatDetailJson.data.description || "");
         setValue("responsibilities", hatDetailJson.data.responsabilities || []);
         setValue("authorities", hatDetailJson.data.authorities || []);
+        setValue("maxSupply", Number(hat?.maxSupply) || undefined);
       }
     };
     setInitialValues();
-  }, [hatDetailJson, setValue]);
+  }, [hatDetailJson, hat?.maxSupply, setValue]);
 
   const isChangedDetails = useCallback(
     (currentDetails: FormData) => {
@@ -106,10 +110,11 @@ const EditRole: FC = () => {
           hatDetailJson.data.authorities || [],
         ) ||
         currentDetails.image ||
-        currentDetails.selectedImageCid
+        currentDetails.selectedImageCid ||
+        currentDetails.maxSupply !== Number(hat?.maxSupply)
       );
     },
-    [hatDetailJson],
+    [hatDetailJson, hat?.maxSupply],
   );
 
   const onSubmit = async (data: FormData) => {
@@ -165,6 +170,16 @@ const EditRole: FC = () => {
             }),
           );
         }
+      }
+
+      // Handle max supply change
+      if (data.maxSupply && data.maxSupply !== Number(hat?.maxSupply)) {
+        promises.push(
+          changeHatMaxSupply({
+            hatId: BigInt(hatId),
+            newMaxSupply: data.maxSupply,
+          }),
+        );
       }
 
       await Promise.all(promises);
@@ -266,6 +281,22 @@ const EditRole: FC = () => {
             type="authority"
             attributes={authorities.fields}
             setAttributes={authorities.append}
+          />
+        </ContentContainer>
+
+        <SectionHeading>ロールの上限人数</SectionHeading>
+        <ContentContainer>
+          <Controller
+            control={control}
+            name="maxSupply"
+            render={({ field: { onChange, value } }) => (
+              <InputNumber
+                mt={3}
+                number={value}
+                setNumber={onChange}
+                defaultValue={hatDetailJson?.data.maxSupply}
+              />
+            )}
           />
         </ContentContainer>
 

--- a/pkgs/frontend/app/routes/$treeId_.roles_.new.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.roles_.new.tsx
@@ -89,12 +89,6 @@ const NewRole: FC = () => {
         return;
       }
 
-      // const maxSupplyValue = Number(data.maxSupply);
-      // if (Number.isNaN(maxSupplyValue) || maxSupplyValue <= 0) {
-      //   alert("ロールの上限人数は正の整数である必要があります。");
-      //   return;
-      // }
-
       try {
         const [resUploadHatsDetails, resUploadImage, treeInfo] =
           await Promise.all([

--- a/pkgs/frontend/app/routes/$treeId_.roles_.new.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.roles_.new.tsx
@@ -8,7 +8,7 @@ import {
 } from "hooks/useIpfs";
 import { useActiveWallet } from "hooks/useWallet";
 import { useGetWorkspace } from "hooks/useWorkspace";
-import { type FC, useCallback, useState } from "react";
+import { type FC, useCallback } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 import type {
   HatsDetailsAttributes,
@@ -24,6 +24,7 @@ import { RoleAttributesList } from "~/components/RoleAttributesList";
 import { InputDescription } from "~/components/input/InputDescription";
 import { InputImage } from "~/components/input/InputImage";
 import { InputName } from "~/components/input/InputName";
+import { InputNumber } from "~/components/input/InputNumber";
 import { AddRoleAttributeDialog } from "~/components/roleAttributeDialog/AddRoleAttributeDialog";
 import { RoleImageLibrarySelector } from "~/components/roles/RoleImageLibrarySelector";
 
@@ -34,6 +35,7 @@ interface FormData {
   selectedImageCid: string;
   responsibilities: HatsDetailsResponsabilities;
   authorities: HatsDetailsAuthorities;
+  maxSupply: number | undefined;
 }
 
 const SectionHeading: FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -50,6 +52,7 @@ const NewRole: FC = () => {
         description: "",
         responsibilities: [],
         authorities: [],
+        maxSupply: 10,
       },
     });
 
@@ -84,6 +87,12 @@ const NewRole: FC = () => {
         return;
       }
 
+      // const maxSupplyValue = Number(data.maxSupply);
+      // if (Number.isNaN(maxSupplyValue) || maxSupplyValue <= 0) {
+      //   alert("ロールの上限人数は正の整数である必要があります。");
+      //   return;
+      // }
+
       try {
         const [resUploadHatsDetails, resUploadImage, treeInfo] =
           await Promise.all([
@@ -106,6 +115,7 @@ const NewRole: FC = () => {
         const parsedLog = await createHat({
           parentHatId: BigInt(hatterHatId),
           details: resUploadHatsDetails?.ipfsUri,
+          maxSupply: Number(data.maxSupply),
           imageURI:
             resUploadImage?.ipfsUri ||
             (data.selectedImageCid && `ipfs://${data.selectedImageCid}`) ||
@@ -231,6 +241,22 @@ const NewRole: FC = () => {
           />
         </ContentContainer>
 
+        <SectionHeading>ロールの上限人数</SectionHeading>
+        <ContentContainer>
+          <Controller
+            control={control}
+            name="maxSupply"
+            render={({ field: { onChange, value } }) => (
+              <InputNumber
+                mt={3}
+                number={value}
+                setNumber={onChange}
+                placeholder="10"
+              />
+            )}
+          />
+        </ContentContainer>
+
         <Box
           mt={10}
           mb="4vh"
@@ -240,7 +266,7 @@ const NewRole: FC = () => {
           alignItems="center"
         >
           <BasicButton
-            disabled={!watch("name")}
+            disabled={!watch("name") || !watch("maxSupply")}
             loading={formState.isSubmitting}
             type="submit"
           >

--- a/pkgs/frontend/app/routes/$treeId_.roles_.new.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.roles_.new.tsx
@@ -45,6 +45,8 @@ const SectionHeading: FC<{ children: React.ReactNode }> = ({ children }) => (
 const NewRole: FC = () => {
   const { treeId } = useParams();
 
+  const defaultMaxSupply = 10;
+
   const { control, watch, handleSubmit, formState, resetField } =
     useForm<FormData>({
       defaultValues: {
@@ -52,7 +54,7 @@ const NewRole: FC = () => {
         description: "",
         responsibilities: [],
         authorities: [],
-        maxSupply: 10,
+        maxSupply: defaultMaxSupply,
       },
     });
 
@@ -251,7 +253,7 @@ const NewRole: FC = () => {
                 mt={3}
                 number={value}
                 setNumber={onChange}
-                placeholder="10"
+                defaultValue={defaultMaxSupply}
               />
             )}
           />

--- a/pkgs/frontend/hooks/useHats.ts
+++ b/pkgs/frontend/hooks/useHats.ts
@@ -521,6 +521,41 @@ export const useHats = () => {
     [wallet],
   );
 
+  const changeHatMaxSupply = useCallback(
+    async (params: { hatId: bigint; newMaxSupply: number }) => {
+      if (!wallet) return;
+
+      setIsLoading(true);
+
+      try {
+        const txHash = await wallet.writeContract({
+          abi: HATS_ABI,
+          address: HATS_ADDRESS,
+          functionName: "changeHatMaxSupply",
+          args: [params.hatId, params.newMaxSupply],
+        });
+
+        const receipt = await publicClient.waitForTransactionReceipt({
+          hash: txHash,
+        });
+
+        const parsedLog = parseEventLogs({
+          abi: HATS_ABI,
+          eventName: "HatMaxSupplyChanged",
+          logs: receipt.logs,
+          strict: false,
+        });
+
+        return parsedLog;
+      } catch (error) {
+        console.error("error occured when changing Hat max supply:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [wallet],
+  );
+
   const renounceHat = useCallback(
     async (hatId: bigint) => {
       if (!wallet) return;
@@ -600,6 +635,7 @@ export const useHats = () => {
     mintHat,
     changeHatDetails,
     changeHatImageURI,
+    changeHatMaxSupply,
     renounceHat,
     transferHat,
   };


### PR DESCRIPTION
# ロールの上限人数を設定可能に変更

## Description

ハードコーディングにより5に固定していたhat maxSupplyをユーザーがインプットで入力できるように変更した。

ロール作成時とロール編集時に、設定・変更できる。

Fixes # (issue)
- #368 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Screenshots

### ロール作成時
Goldskyのリクエストしすぎ429エラーにより、スクショが取れず :pray:
UIと動作は確認済みです

### ロール編集時
![image](https://github.com/user-attachments/assets/c2f75d00-3f25-4f03-be99-c75234970094)
