### PR TITLE
docs: add Claude Design handoff bundle for #418

### DIFF
--- a/docs/design/handoff/README.md
+++ b/docs/design/handoff/README.md
@@ -1,0 +1,68 @@
+# Toban — Design Handoff Bundle
+
+このディレクトリは [claude.ai/design](https://claude.ai/design) で作成したデザインプロトタイプのソースバンドルです。フロントエンドフルリニューアル（親 Issue: [#418](https://github.com/hackdays-io/toban/issues/418)）の **設計参照** として配置しています。
+
+## ⚠️ 重要：これは「参考」であり、忠実に再現すべき仕様書ではありません
+
+- `Toban Prototype.html`（モバイル）と `Toban Desktop.html`（デスクトップ）は **Claude Design による HTML/CSS/JS のプロトタイプ** です。実装の参考にはなりますが、**完全ではありません**。
+- 特に **Desktop はレイアウトが崩れていたり、用途不明な要素が含まれていたり** します。それらは無視して構いません。
+- プロトタイプの内部構造（どのコンポーネントをどう組んでいるか）を真似する必要はありません。**ビジュアル・トーン・UX の方向性** を参考にしつつ、Toban のフロントエンド側の流儀（Vite + React Router v7 + Shadcn + Tailwind + 独自デザインシステム）に落とし込むのが目的です。
+- ロジック・状態管理・データ構造はモックなので、実装ではすべて差し替わります。
+
+## ブラウザでプレビュー
+
+HTML は CDN 経由で React/Babel を読み込むので、ファイルを直接開けば動きます。ビルドは不要です。
+
+```bash
+# シンプル：ファイルを直接開く（OS依存）
+open "docs/design/handoff/project/Toban Prototype.html"
+open "docs/design/handoff/project/Toban Desktop.html"
+
+# またはローカルサーバー経由（推奨：CORS まわりが安定）
+cd docs/design/handoff/project && python3 -m http.server 8080
+# → http://localhost:8080/Toban%20Prototype.html
+# → http://localhost:8080/Toban%20Desktop.html
+```
+
+## ファイル一覧
+
+### `project/` — プロトタイプソース
+
+| ファイル | 内容 |
+| --- | --- |
+| `Toban Prototype.html` | モバイルプロトタイプのエントリ（402px iOS フレーム）— 参考用、完全ではない |
+| `Toban Desktop.html` | デスクトッププロトタイプのエントリ（1280px Sidebar+TopBar）— 参考用、完全ではない |
+| `tokens.js` | **デザイントークン（color / radius / space / shadow / font）** — 実装で正の出典として扱う |
+| `data.js` | モックデータ（`window.TOBAN_DATA`） |
+| `primitives.jsx` | プリミティブ（Button / Card / Avatar / Badge / Input / Sheet / BottomNav 等）— **コンポーネント API の参考** |
+| `screens.jsx` | モバイル各画面：Home / Duties / Splits / Members / Wallet / Thanks 送信フロー / Workspace 一覧 |
+| `edit-screens.jsx` | Duty 作成・編集、Workspace 作成・編集 |
+| `quests.jsx` | クエスト機能（一覧 / 詳細 / 作成 / 承認）+ シェア分布バー |
+| `thanks-insights.jsx` | サンクスのデータ可視化（リスト / Treemap / フレンドシップ） |
+| `desktop.jsx` | デスクトップ用の Sidebar / TopBar / 各画面 — レイアウト崩れあり、参考程度に |
+| `app.jsx` | モバイルアプリのルート（ルーティング・Sheet 制御） |
+| `ios-frame.jsx` | iOS デバイスフレーム表示（実装には不要） |
+
+### `chats/`
+
+| ファイル | 内容 |
+| --- | --- |
+| `chat1.md` | デザイン作成時の対話ログ。**「カードの左縁がカラーになるのが嫌い」「PCレイアウトを作りたい」** など、設計意図・なぜこうしたかが残っている。実装判断に迷ったら参照する価値あり。 |
+
+## 実装で**忠実に**従うべきもの
+
+- **`tokens.js` のカラー・radius・shadow・font** — そのまま Tailwind v4 の `@theme` に展開（[#426](https://github.com/hackdays-io/toban/issues/426) で対応）
+- **コピー方針**：Login → ウォレット接続、Hat/Role → 当番、Splits → 分配、Thanks → サンクス（THX）
+- **ナビゲーション**：モバイル BottomNav（ホーム / 当番 / 分配 / メンバー / ウォレット）、デスクトップ Sidebar+TopBar
+- **`primitives.jsx` の各プリミティブの API・variants**
+
+## 実装で**従わなくて良い**もの
+
+- HTML/JSX の DOM 構造そのまま（実装は Shadcn / Tailwind ベースに置き換わる）
+- インラインスタイル（実装では Tailwind クラスへ）
+- アイコン SVG（lucide-react に置き換え、[#421](https://github.com/hackdays-io/toban/issues/421)）
+- Desktop プロトタイプの不自然なレイアウト崩れ・用途不明な要素
+
+## 各 Issue からの参照
+
+各子 Issue の本文には、対応する設計ソースの該当箇所（例：`screens.jsx:6-85` の `HomeScreen`）を引用しています。実装時はそこから本ディレクトリのファイルを開いてください。

--- a/docs/design/handoff/chats/chat1.md
+++ b/docs/design/handoff/chats/chat1.md
@@ -1,0 +1,414 @@
+# デザインシステム構築
+
+_Started 2026-05-08 12:23 UTC_
+
+---
+
+## User
+
+この画像は参考にしてほしいデザインシステムボードです。カードコンポーネントなどプリミティブコンポーネント以外のマージンなどはあまり参考にしなくていいです。
+
+以下は基本的な画面遷移についての説明です。
+
+## Assistant
+
+_[tool: view_image]_
+
+_[tool: update_todos]_
+
+_[tool: copy_starter_component]_
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: done]_
+
+_[tool: grep]_
+
+_[tool: run_script]_
+
+_[tool: snip]_
+
+_[tool: done]_
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+Tobanのインタラクティブプロトタイプを作成しました。
+
+**実装した主要フロー**
+- ホーム（残高カード・自分の当番・最近のアクティビティ）
+- サンクス送信（宛先選択 → 量とメッセージ → 確認 → 完了）
+- 当番一覧 / 詳細 / 担当割り当て（メンバー選択 → 役割設定 → 確認 → 完了）
+- 分配一覧 / 詳細（ドーナツチャート + 順位 + 折りたたみ式の技術情報）
+- 分配ルール作成（重み調整 → プレビュー → 作成）
+- メンバー一覧 / 詳細
+- ウォレット（プロフィール + 所属ワークスペース）
+- ワークスペース切替メニュー & 一覧
+
+**デザインシステム反映**
+- カラー（Primary #F5B82E, Primary Soft #FFF2CF, Background #FAF7F0, ロール / 分配 / 貢献色など）
+- 角丸トークン（12 / 20 / 28 / Full）、シャドウ、ボーダー
+- ステータスバッジ（Member / 当番リード / サポーター）
+- ボトムナビ（ホーム / 当番 / 分配 / メンバー / ウォレット）
+- やさしい日本語コピー（Login → ウォレット接続、Splits → 分配 など）
+
+ヘッダーのワークスペース名タップで切替メニュー、ホームの「サンクスを送る」、当番タブの「担当を追加」、分配タブの「新規作成」など主要操作はすべて動作します。
+
+## User
+
+- カードの左縁がカラーになるのが嫌い。
+- 当番の作成・編集画面、ワークスペースの作成編集画面をつくって
+
+## Assistant
+
+## Assistant
+
+_[tool: grep]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: grep]_
+
+_[tool: update_todos]_
+
+_[tool: snip]_
+
+_[tool: list_files]_
+
+_[tool: read_file]_
+
+_[tool: grep]_
+
+_[tool: grep]_
+
+_[tool: read_file]_
+
+_[tool: snip]_
+
+_[tool: grep]_
+
+_[tool: snip]_
+
+_[tool: read_file]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: read_file]_
+
+_[tool: snip]_
+
+_[tool: update_todos]_
+
+_[tool: done]_
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+対応した内容：
+
+**カード左縁のカラー帯を削除**
+- `Card` プリミティブの `accent` 装飾（左縁のカラーバー）を完全に取り除きました。
+
+**当番の作成・編集画面**
+- 当番一覧の「当番を作成」、当番詳細ヘッダーの編集アイコンから遷移
+- 名前・アイコン・カラー（6色）・タスク（追加 / 削除可）・頻度・サポーター募集トグル
+- 入力中はカード上部にライブプレビュー
+- 編集時は削除ボタンも表示
+
+**ワークスペース作成・編集画面**
+- 作成：ヘッダー > ワークスペース切替 > 一覧 > 「新規作成」から3ステップフロー（基本情報 → 初期設定 → 確認 → 完了）
+- 編集：ヘッダー > ワークスペース切替メニュー > 「ワークスペース設定」から
+- アイコン9種・カラー8種・公開設定・サンクス単位・機能トグル・アーカイブ等
+
+## User
+
+Thanksトークンの送付データの可視化ページを作りたい。期間を指定して、その期間のデータを使って面積で比較できるビジュアルや、仲の良いメンバーが見える。添付画像は参考程度に今のデザインに合うようにして。
+
+## Assistant
+
+_[tool: read_file]_
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: grep]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: show_html]_
+
+_[tool: done]_
+
+_[tool: snip]_
+
+_[tool: fork_verifier_agent]_
+
+Thanksトークンの可視化ページを実装しました。
+
+**追加した画面**：ホームの「すべて見る」から遷移する `サンクスのデータ` 画面
+
+**3つのビュー**
+- **リスト**：from → THX → to の流れが分かるV字シェイプの送付記録カード（メッセージ + 日時付き）
+- **グラフ**：保有量・送付量を面積で比較できる Squarified Treemap（上段ブルー / 下段イエロー）
+- **フレンドシップ**：メンバーペアを総交換量 or 取引回数でランキング（金 / 銀 / 銅 / 紫の配色 + 双方向アイコン）
+
+**期間フィルタ**：今週 / 30日 / 全期間（カスタム枠は今後）。上部サマリー（送付件数・合計THX・参加者数）が期間に応じて再計算されます。
+
+トランザクションは80件をシード固定で生成し、ひらやま↔homma、前田陽太↔genks など特定ペアに偏りを持たせて、フレンドシップランキングが意味のある順位になるようにしています。
+
+## User
+
+Verifier agent check completed
+
+## Assistant
+
+_[tool: snip]_
+
+検証OKです。ホーム → 最近のアクティビティの「すべて見る」から確認できます。
+
+## User
+
+
+
+## Assistant
+
+_[tool: write_file]_
+
+_[tool: grep]_
+
+_[tool: grep]_
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+_[tool: str_replace_edit]_
+
+_[tool: grep]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: grep]_
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: done]_
+
+_[tool: fork_verifier_agent]_
+
+当番シェア（RoleShare）とクエスト体験を実装しました。
+
+**追加・変更**
+- 当番詳細画面に「当番シェア分布」セクション（配色付き分布バー＋メンバーごとの%表示）
+- クエスト一覧（募集中 / 進行中 / 確認待ち / 完了）を当番詳細内にセクション分けで表示、ステータスバッジ付き
+- 「クエストを作成」CTAを当番詳細に追加
+- クエスト作成画面：紐づく当番表示、自分のシェア → 渡すシェア → 作成後シェアの計算式表示、+/− stepper とプリセット、タイトル・説明入力
+- クエスト詳細画面：状態別CTA（参加する / 完了申請する / 承認画面を開く / キャンセル）、進捗バー、作成者→申請者の流れ表示
+- 完了申請の確認（承認）画面：申請者・付与シェア・承認状況（n/2）
+
+## User
+
+当番の詳細だけでなく、インデックスページにもクエストリストを入れてください。ボタンは参加ではなく、申請にしてください
+
+## Assistant
+
+_[tool: grep]_
+
+_[tool: read_file]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: str_replace_edit]_
+
+_[tool: read_file]_
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: done]_
+
+当番タブに「当番／クエスト」のセグメントを追加し、クエストビューでは募集中・確認待ち・進行中・完了をワークスペース横断で一覧表示します（カード上部に当番名を表示）。クエスト詳細の「参加する」ボタンは「申請する」に変更しました。
+
+## User
+
+今スマホレイアウトでPCも表示されています。Claude Designではレスポンシブデザインにするベストプラクティスはなんですか？
+
+## Assistant
+
+_[tool: snip]_
+
+レスポンシブの考え方をお伝えします。Tobanのようなモバイルアプリ前提のプロトタイプでは、**PCでは「電話のフレームをセンタリングして見せる」、モバイルでは「フレームを外して全画面で動かす」** が定石です。具体的には：
+
+### 1. 単一の幅を作って中身を作る
+モバイルアプリの中身は **`375〜402px` の固定幅** で組む。レスポンシブにしようとすると、中身のレイアウトがブレてiOSらしさが消えます。
+
+### 2. ビューポートで「見せ方」を切り替える
+媒体（フレームのある／なし）だけをCSSメディアクエリで分岐。
+
+```css
+/* PC: フレームに入れて中央に置く */
+.stage { display: flex; align-items: center; justify-content: center;
+         min-height: 100vh; background: #efe9dd; }
+.phone { width: 402px; height: 874px; border-radius: 48px;
+         box-shadow: 0 40px 80px rgba(0,0,0,.18); overflow: hidden; }
+
+/* モバイル実機: フレームを脱がせて全画面 */
+@media (max-width: 480px) {
+  .stage  { background: #fff; min-height: 100dvh; }
+  .phone  { width: 100vw; height: 100dvh; border-radius: 0; box-shadow: none; }
+}
+```
+
+### 3. 中身は `dvh` / `safe-area-inset-*` を使う
+実機ブラウザのアドレスバー / ホームインジケータを避ける。
+
+```css
+.app { height: 100dvh;
+       padding-top: env(safe-area-inset-top);
+       padding-bottom: env(safe-area-inset-bottom); }
+```
+
+### 4. デザイン側で“フレームの脱ぎ着”を意識する
+- ステータスバー（9:41 / バッテリー等）はフレーム所属。実機では非表示にする
+- ボトムナビは中身所属
+- ヘッダーのノッチ余白も「フレーム所属」 → 実機では `safe-area` でやり直す
+
+### 5. PCで複数バリエーションを並べたいときは Design Canvas
+比較フェーズに入ったら `design_canvas` に複数台のフレームを並べるのが便利。実機モードに入る／入らないをトグルできるTweak（`embedded`/`fullbleed`）を1つ用意しておくと使いやすいです。
+
+---
+
+ご希望なら、現在のTobanプロトタイプを上記方針でリファクタしてPC＝フレーム中央／モバイル実機＝全画面、に切り替わるよう適用します。やりますか？
+
+## User
+
+そうではなく、PCレイアウトを作りたい。
+
+## Assistant
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+## Assistant
+
+_[tool: grep]_
+
+_[tool: write_file]_
+
+_[tool: snip]_
+
+_[tool: grep]_
+
+_[tool: grep]_
+
+_[tool: snip]_
+
+_[tool: grep]_
+
+_[tool: grep]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: snip]_
+
+_[tool: read_file]_
+
+_[tool: snip]_
+
+_[tool: write_file]_
+
+_[tool: done]_
+
+_[tool: snip]_
+
+_[tool: str_replace_edit]_
+
+_[tool: done]_
+
+_[tool: get_webview_logs]_
+
+_[tool: eval_js]_
+
+Desktop版が正常に表示されました。 #root に内容がレンダリングされています。
+
+## User
+
+Save this design as a PDF: the current design
+
+## Assistant
+
+_[tool: snip]_
+
+_[tool: read_file]_
+
+_[tool: snip]_
+
+_[tool: write_file]_
+

--- a/docs/design/handoff/project/Toban Desktop.html
+++ b/docs/design/handoff/project/Toban Desktop.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=1280" />
+<title>Toban — Desktop</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Sans+JP:wght@400;500;700;800&display=swap" rel="stylesheet" />
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body, #root { height: 100%; margin: 0; }
+  body {
+    font-family: "Inter", "Noto Sans JP", -apple-system, system-ui, sans-serif;
+    color: #1F1F1F;
+    background: #FAF7F0;
+    -webkit-font-smoothing: antialiased;
+  }
+  button { font-family: inherit; }
+  input { font-family: inherit; }
+  /* scrollbar */
+  ::-webkit-scrollbar { width: 10px; height: 10px; }
+  ::-webkit-scrollbar-thumb { background: #E7E1D7; border-radius: 999px; border: 2px solid #FAF7F0; }
+  ::-webkit-scrollbar-thumb:hover { background: #d4cdbf; }
+</style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+  <!-- Data -->
+  <script src="data.js"></script>
+  <script>
+  window.TOBAN_QUESTS_DATA = {
+    shares: {
+      dishes:    [{name:'ryu',pct:40},{name:'sg',pct:30},{name:'eri',pct:20},{name:'homma',pct:10}],
+      breakfast: [{name:'atsu',pct:50},{name:'eri',pct:30},{name:'koichi',pct:20}],
+      onoono:    [{name:'koichi',pct:60},{name:'sg',pct:25},{name:'shinya',pct:15}],
+      food:      [{name:'eri',pct:45},{name:'shingoohki',pct:35},{name:'homma',pct:20}],
+    },
+    quests: [
+      { id:'q1', dutyId:'dishes', title:'夕食後の食器洗いを手伝う', desc:'食器を洗って、棚に戻してください。', creator:'ryu', share:10, state:'open', count:3, applicant:null },
+      { id:'q2', dutyId:'dishes', title:'洗剤を補充する', desc:'台所の洗剤を新しく買って補充。レシートはあとで共有OK。', creator:'ryu', share:5, state:'inprogress', applicant:'sg' },
+      { id:'q3', dutyId:'dishes', title:'食器棚を整理する', desc:'食器棚の中を片付けて、きれいに並べる。', creator:'sg', share:5, state:'review', applicant:'eri', approvals:1 },
+      { id:'q4', dutyId:'breakfast', title:'朝のコーヒーを淹れる', desc:'朝7時頃にコーヒーを淹れる。', creator:'atsu', share:8, state:'open', count:1, applicant:null },
+      { id:'q5', dutyId:'dishes', title:'ふきんを洗う', desc:'ふきんを洗濯。', creator:'ryu', share:3, state:'done', applicant:'homma' },
+    ],
+  };
+  </script>
+
+  <!-- Desktop app -->
+  <script type="text/babel" src="desktop.jsx"></script>
+</body>
+</html>

--- a/docs/design/handoff/project/Toban Prototype.html
+++ b/docs/design/handoff/project/Toban Prototype.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toban — Interactive Prototype</title>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; height: 100%; }
+    body {
+      font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic UI", -apple-system, system-ui, sans-serif;
+      background: linear-gradient(180deg, #F5EFE0 0%, #EDE3CE 100%);
+      color: #1F1F1F;
+      -webkit-font-smoothing: antialiased;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+    }
+    .stage {
+      display: flex;
+      gap: 32px;
+      align-items: flex-start;
+      flex-wrap: wrap;
+      justify-content: center;
+      max-width: 1400px;
+    }
+    .device {
+      width: 402px;
+      height: 874px;
+      border-radius: 48px;
+      overflow: hidden;
+      position: relative;
+      background: #FAF7F0;
+      box-shadow: 0 40px 80px rgba(31,31,31,0.18), 0 0 0 1px rgba(31,31,31,0.08);
+    }
+    .device::before {
+      content: '';
+      position: absolute;
+      top: 11px; left: 50%;
+      transform: translateX(-50%);
+      width: 126px; height: 37px;
+      border-radius: 24px;
+      background: #000;
+      z-index: 50;
+    }
+    .device::after {
+      content: '';
+      position: absolute;
+      bottom: 8px; left: 50%;
+      transform: translateX(-50%);
+      width: 139px; height: 5px;
+      border-radius: 100px;
+      background: rgba(0,0,0,0.25);
+      z-index: 60;
+      pointer-events: none;
+    }
+    .status-bar {
+      position: absolute; top: 0; left: 0; right: 0;
+      height: 50px; padding: 18px 36px 0;
+      display: flex; justify-content: space-between; align-items: center;
+      z-index: 30;
+      font-weight: 590; font-size: 16px; color: #1F1F1F;
+      pointer-events: none;
+    }
+    .status-bar-icons {
+      display: flex; gap: 6px; align-items: center;
+    }
+    #app {
+      position: absolute; inset: 0;
+      padding-top: 50px;
+      display: flex; flex-direction: column;
+    }
+    .meta {
+      width: 320px;
+      color: #5A4A2C;
+    }
+    .meta h1 {
+      font-size: 32px; margin: 0 0 8px;
+      letter-spacing: -0.5px;
+      color: #1F1F1F;
+      font-weight: 800;
+    }
+    .meta .subtitle {
+      font-size: 13px; color: #A07310; font-weight: 600;
+      letter-spacing: 0.5px; margin-bottom: 16px;
+    }
+    .meta p {
+      font-size: 14px; line-height: 1.6;
+      color: #68645D;
+    }
+    .meta .pills {
+      display: flex; flex-wrap: wrap; gap: 8px; margin: 18px 0 24px;
+    }
+    .meta .pills span {
+      background: rgba(255,255,255,0.6);
+      border: 1px solid #E7E1D7;
+      padding: 6px 12px; border-radius: 999px;
+      font-size: 12px; font-weight: 600; color: #1F1F1F;
+    }
+    .meta .tip {
+      background: #FFF2CF;
+      border-left: 3px solid #F5B82E;
+      padding: 12px 16px;
+      border-radius: 12px;
+      font-size: 13px; color: #5A4A2C; line-height: 1.6;
+      margin-top: 16px;
+    }
+    .logo {
+      display: inline-flex; align-items: center; gap: 10px;
+      margin-bottom: 16px;
+    }
+    .logo-mark {
+      width: 36px; height: 44px;
+      background: radial-gradient(ellipse at 30% 30%, #F0EBE0 0%, #2a2a2a 70%, #0a0a0a 100%);
+      border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
+      box-shadow: inset 2px 2px 4px rgba(255,255,255,0.4), 0 4px 12px rgba(0,0,0,0.2);
+    }
+    .logo span {
+      font-size: 22px; font-weight: 800; letter-spacing: -0.5px;
+    }
+    @keyframes tobanFade { from { opacity: 0 } to { opacity: 1 } }
+    @keyframes tobanSlide { from { transform: translateY(20px); opacity: 0 } to { transform: translateY(0); opacity: 1 } }
+    @keyframes tobanPulse { 0%, 100% { transform: scale(1); opacity: 1 } 50% { transform: scale(1.08); opacity: 0.7 } }
+    button:focus { outline: none; }
+    input:focus, textarea:focus { outline: none; }
+    /* hide scrollbars inside device for cleanliness */
+    #app *::-webkit-scrollbar { width: 0; height: 0; }
+    .stage > .meta { padding-top: 16px; }
+  </style>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body>
+  <div class="stage">
+    <div class="meta">
+      <div class="logo">
+        <div class="logo-mark"></div>
+        <span>Toban</span>
+      </div>
+      <div class="subtitle">あたたかい当番帳</div>
+      <h1>みんなの貢献を、未来の力に。</h1>
+      <p>コミュニティで起きた小さな貢献を、感謝として記録し、納得できる分配につなげるインタラクティブプロトタイプです。</p>
+      <div class="pills">
+        <span>サンクス送信</span>
+        <span>当番割り当て</span>
+        <span>分配作成</span>
+        <span>ワークスペース切替</span>
+      </div>
+      <div class="tip" style="border-width: 0px">
+        💡 ホームの <strong>「サンクスを送る」</strong>、当番タブから <strong>担当を追加</strong>、分配タブで <strong>新規作成</strong> を試してください。ヘッダーの <strong>ワークスペース名</strong> をタップで切替メニューが開きます。
+      </div>
+    </div>
+
+    <div class="device">
+      <div class="status-bar">
+        <span>9:41</span>
+        <span class="status-bar-icons">
+          <svg width="19" height="12" viewBox="0 0 19 12">
+            <rect x="0" y="7.5" width="3.2" height="4.5" rx="0.7" fill="#1F1F1F"/>
+            <rect x="4.8" y="5" width="3.2" height="7" rx="0.7" fill="#1F1F1F"/>
+            <rect x="9.6" y="2.5" width="3.2" height="9.5" rx="0.7" fill="#1F1F1F"/>
+            <rect x="14.4" y="0" width="3.2" height="12" rx="0.7" fill="#1F1F1F"/>
+          </svg>
+          <svg width="17" height="12" viewBox="0 0 17 12">
+            <path d="M8.5 3.2C10.8 3.2 12.9 4.1 14.4 5.6L15.5 4.5C13.7 2.7 11.2 1.5 8.5 1.5C5.8 1.5 3.3 2.7 1.5 4.5L2.6 5.6C4.1 4.1 6.2 3.2 8.5 3.2Z" fill="#1F1F1F"/>
+            <circle cx="8.5" cy="10.5" r="1.5" fill="#1F1F1F"/>
+          </svg>
+          <svg width="27" height="13" viewBox="0 0 27 13">
+            <rect x="0.5" y="0.5" width="23" height="12" rx="3.5" stroke="#1F1F1F" stroke-opacity="0.35" fill="none"/>
+            <rect x="2" y="2" width="20" height="9" rx="2" fill="#1F1F1F"/>
+          </svg>
+        </span>
+      </div>
+      <div id="app"></div>
+    </div>
+  </div>
+
+  <script src="tokens.js"></script>
+  <script src="data.js"></script>
+  <script type="text/babel" src="primitives.jsx"></script>
+  <script type="text/babel" src="screens.jsx"></script>
+  <script type="text/babel" src="edit-screens.jsx"></script>
+  <script type="text/babel" src="thanks-insights.jsx"></script>
+  <script type="text/babel" src="quests.jsx"></script>
+  <script type="text/babel" src="app.jsx"></script>
+</body>
+</html>

--- a/docs/design/handoff/project/app.jsx
+++ b/docs/design/handoff/project/app.jsx
@@ -1,0 +1,108 @@
+// Toban app shell
+const { useState: us, useEffect: ue, Fragment: F } = React;
+const C = window.TOBAN.color;
+const D2 = window.TOBAN_DATA;
+
+function App() {
+  const [ws, setWs] = us(D2.workspaces[0]);
+  const [route, setRoute] = us({ name: 'home' });
+  const [tab, setTab] = us('home');
+  const [thanksOpen, setThanksOpen] = us(null); // null | { preselect }
+  const [wsMenuOpen, setWsMenuOpen] = us(false);
+  const [wsListOpen, setWsListOpen] = us(false);
+  const [toast, setToast] = us(null);
+
+  ue(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 2200);
+    return () => clearTimeout(t);
+  }, [toast]);
+
+  const goto = (r) => {
+    if (r.name === 'thanks-recipient') { setThanksOpen({ preselect: r.preselect }); return; }
+    setRoute(r);
+    if (['home', 'duties', 'splits', 'members', 'wallet'].includes(r.name)) setTab(r.name);
+  };
+
+  const onTab = (t) => {
+    setTab(t); setRoute({ name: t });
+  };
+
+  const showSent = ({ to, amount }) => setToast(`${to} に ${amount} THX を送りました`);
+
+  let screen;
+  switch (route.name) {
+    case 'home': screen = <HomeScreen goto={goto} openThanks={() => setThanksOpen({})} ws={ws} openWsMenu={() => setWsMenuOpen(true)} />; break;
+    case 'duties': screen = <DutiesScreen goto={goto} ws={ws} openWsMenu={() => setWsMenuOpen(true)} />; break;
+    case 'duty-detail': screen = <DutyDetailScreen goto={goto} dutyId={route.dutyId} />; break;
+    case 'assign-duty': screen = <AssignDutyScreen goto={goto} dutyId={route.dutyId} onAssigned={({ member }) => setToast(`${member} を担当に追加しました`)} />; break;
+    case 'duty-edit': screen = <DutyEditScreen goto={goto} dutyId={route.dutyId} onSaved={(r) => setToast(r?.deleted ? '当番を削除しました' : r?.editing ? '当番を保存しました' : '当番を作成しました')} />; break;
+    case 'workspace-create': screen = <WorkspaceCreateScreen goto={goto} onCreated={(w) => setToast(`${w.name} を作成しました`)} />; break;
+    case 'workspace-edit': screen = <WorkspaceEditScreen goto={goto} ws={ws} onSaved={(r) => { if (r?.kind === 'invite') setToast('招待リンクをコピーしました'); else if (r?.kind === 'copy') setToast('IDをコピーしました'); else if (r?.archived) setToast('アーカイブしました'); else setToast('設定を保存しました'); }} />; break;
+    case 'splits': screen = <SplitsScreen goto={goto} ws={ws} openWsMenu={() => setWsMenuOpen(true)} />; break;
+    case 'split-detail': screen = <SplitDetailScreen goto={goto} splitId={route.splitId} />; break;
+    case 'split-create': screen = <SplitCreateScreen goto={goto} />; break;
+    case 'members': screen = <MembersScreen goto={goto} ws={ws} openWsMenu={() => setWsMenuOpen(true)} />; break;
+    case 'member-detail': screen = <MemberDetailScreen goto={goto} memberId={route.memberId} />; break;
+    case 'wallet': screen = <WalletScreen goto={goto} ws={ws} openWsMenu={() => setWsMenuOpen(true)} />; break;
+    case 'thanks-insights': screen = <ThanksInsightsScreen goto={goto} />; break;
+    case 'quest-create': screen = <QuestCreateScreen goto={goto} dutyId={route.dutyId} onCreated={(r) => setToast(`クエスト「${r.title}」を作成しました`)} />; break;
+    case 'quest-detail': screen = <QuestDetailScreen goto={goto} questId={route.questId} onAction={({ kind, q }) => setToast(kind === 'apply' ? `「${q.title}」に申請しました` : kind === 'request' ? '完了申請を送りました' : kind === 'cancel' ? 'クエストをキャンセルしました' : '')} />; break;
+    case 'quest-approve': screen = <QuestApproveScreen goto={goto} questId={route.questId} onApproved={({ q }) => setToast(`${q.applicant} のクエストを承認しました`)} />; break;
+    default: screen = <div style={{ padding: 40 }}>Unknown</div>;
+  }
+
+  const showBottomNav = ['home', 'duties', 'splits', 'members', 'wallet'].includes(route.name);
+
+  return (
+    <div style={{
+      width: '100%', height: '100%', position: 'relative',
+      background: C.bg, fontFamily: window.TOBAN.font, color: C.textPrimary,
+      display: 'flex', flexDirection: 'column', overflow: 'hidden',
+    }}>
+      <div style={{ flex: 1, overflow: 'auto', WebkitOverflowScrolling: 'touch' }}>
+        {screen}
+      </div>
+      {showBottomNav && <BottomNav active={tab} onChange={onTab} />}
+
+      <Sheet open={!!thanksOpen} onClose={() => setThanksOpen(null)}>
+        <ThanksFlow initial={thanksOpen} onClose={() => setThanksOpen(null)} onSent={showSent} />
+      </Sheet>
+
+      <Sheet open={wsMenuOpen} onClose={() => setWsMenuOpen(false)} title={ws.name}>
+        <div style={{ padding: '4px 16px 0' }}>
+          <Card padding={0}>
+            <Row left={<div style={{ width: 36, height: 36, borderRadius: 999, background: '#F0EBE0',
+                display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Icon name="members" size={18} /></div>}
+              title="ワークスペースを切り替え" subtitle={`${D2.workspaces.length}件`}
+              right={<Icon name="chevron-right" size={16} color={C.textSecondary} />}
+              onClick={() => { setWsMenuOpen(false); setWsListOpen(true); }} />
+            <Divider inset={64} />
+            <Row left={<div style={{ width: 36, height: 36, borderRadius: 999, background: '#F0EBE0',
+                display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Icon name="invite" size={18} /></div>}
+              title="メンバーを招待" subtitle="リンクをコピーして共有"
+              right={<Icon name="chevron-right" size={16} color={C.textSecondary} />}
+              onClick={() => { setWsMenuOpen(false); setToast('招待リンクをコピーしました'); }} />
+            <Divider inset={64} />
+            <Row left={<div style={{ width: 36, height: 36, borderRadius: 999, background: '#F0EBE0',
+                display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Icon name="gear" size={18} /></div>}
+              title="ワークスペース設定" subtitle="名前・参加・機能設定"
+              right={<Icon name="chevron-right" size={16} color={C.textSecondary} />}
+              onClick={() => { setWsMenuOpen(false); goto({ name: 'workspace-edit' }); }} />
+          </Card>
+        </div>
+        <div style={{ padding: 16 }}>
+          <Button variant="ghost" full onClick={() => setWsMenuOpen(false)}>閉じる</Button>
+        </div>
+      </Sheet>
+
+      <Sheet open={wsListOpen} onClose={() => setWsListOpen(false)}>
+        <WorkspaceListScreen ws={ws} onPick={(w) => { setWs(w); setWsListOpen(false); setRoute({ name: 'home' }); setTab('home'); setToast(`${w.name} に切り替えました`); }} onCreate={() => { setWsListOpen(false); goto({ name: 'workspace-create' }); }} />
+      </Sheet>
+
+      <Toast show={!!toast}>{toast}</Toast>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')).render(<App />);

--- a/docs/design/handoff/project/data.js
+++ b/docs/design/handoff/project/data.js
@@ -1,0 +1,54 @@
+// Toban data
+window.TOBAN_DATA = {
+  user: {
+    id: 'me', name: 'ryoma', address: '0x1234...abcd',
+    sendable: 120, received: 80,
+  },
+  workspaces: [
+    { id: 'kuu', name: 'kuu village #1', desc: 'オフグリッドポップアップビレッジの貢献を記録する場', members: 24, lastActive: '2時間前', icon: '🌿', color: '#65C98A' },
+    { id: 'cfj', name: 'Code for Japan', desc: 'シビックテックコミュニティ', members: 128, lastActive: '昨日', icon: '🇯🇵', color: '#5DADEC' },
+    { id: 'sen', name: 'Senspace', desc: 'デザインスタジオ', members: 8, lastActive: '3日前', icon: '✦', color: '#D6B995' },
+  ],
+  members: [
+    { id: 'ryu', name: 'ryu', addr: '0x7a5b...F4BF', role: 'lead', received: 80, contribs: 3 },
+    { id: 'homma', name: 'homma', addr: '0x4e3c...a821', role: 'lead', received: 145, contribs: 7 },
+    { id: 'shinya', name: 'shinya', addr: '0x91fa...2b04', role: 'member', received: 60, contribs: 2 },
+    { id: 'sg', name: 'sg', addr: '0x2eb1...c9d3', role: 'supporter', received: 42, contribs: 4 },
+    { id: 'eri', name: 'eri', addr: '0x88aa...6712', role: 'member', received: 55, contribs: 3 },
+    { id: 'shingoohki', name: 'shingoohki', addr: '0x5cdd...0afe', role: 'member', received: 30, contribs: 1 },
+    { id: 'atsu', name: 'atsu', addr: '0x77b9...4422', role: 'member', received: 92, contribs: 5 },
+    { id: 'yumaito', name: 'yumaito', addr: '0xa12c...8809', role: 'member', received: 70, contribs: 4 },
+    { id: 'takerun', name: 'takerun', addr: '0xfbe2...12dd', role: 'member', received: 50, contribs: 2 },
+    { id: 'koichi', name: 'koichi', addr: '0xe411...77a3', role: 'supporter', received: 48, contribs: 3 },
+  ],
+  duties: [
+    { id: 'dishes', name: '食器を洗おう', desc: ['食器を洗う', '食器を拭く', '食器を棚に戻す'], assignee: 'ryu', supporters: ['sg', 'eri', '中田柚葉'], next: '6/08', status: '担当中', accent: '#D6B995' },
+    { id: 'breakfast', name: '美味しい朝食を作る', desc: ['食材を準備', '料理する', '配膳'], assignee: 'atsu', supporters: ['homma'], next: '6/09', status: '担当中', accent: '#65C98A' },
+    { id: 'onoono', name: 'ONOONOを美しく保とう', desc: ['ゴミ拾い', '掃除', '整頓'], assignee: 'koichi', supporters: ['ryu'], next: '6/10', status: '担当中', accent: '#D6B995' },
+    { id: 'food', name: '食材準備', desc: ['買い出し', '仕分け', '保管'], assignee: null, supporters: [], next: null, status: '空き', accent: '#D6B995' },
+  ],
+  splits: [
+    { id: 'd7', name: 'kuu village day 7', count: 7, updated: '2025/10/07', dutyWeight: 82, thanksWeight: 18, thanksRecv: 25, thanksSent: 75, ens: 'kuuvillageday7.split.toban.eth', contract: '0xD8EF...5B18e',
+      shares: [
+        { name: 'atsu', pct: 22.4 }, { name: 'ryoma', pct: 18.1 },
+        { name: 'yumaito', pct: 16.4 }, { name: 'takerun', pct: 13.8 },
+        { name: 'koichi', pct: 12.1 }, { name: 'ryu', pct: 9.4 },
+        { name: 'eri', pct: 7.8 },
+      ] },
+    { id: 'd5', name: 'kuu village day 5', count: 9, updated: '2025/10/05', dutyWeight: 70, thanksWeight: 30, thanksRecv: 40, thanksSent: 60, ens: 'kuuvillageday5.split.toban.eth', contract: '0xA221...90fe',
+      shares: [
+        { name: 'homma', pct: 18.5 }, { name: 'atsu', pct: 16.2 },
+        { name: 'ryoma', pct: 14.8 }, { name: 'sg', pct: 12.1 },
+        { name: 'eri', pct: 10.4 }, { name: 'ryu', pct: 9.3 },
+        { name: 'shinya', pct: 8.0 }, { name: 'koichi', pct: 6.2 },
+        { name: 'yumaito', pct: 4.5 },
+      ] },
+  ],
+  activity: [
+    { id: 'a1', kind: 'thanks-recv', from: 'homma', to: 'me', amount: 100, msg: 'EXPOにお誘いいただきありがとうございます！', time: '2時間前' },
+    { id: 'a2', kind: 'thanks-recv', from: 'shinya', to: 'me', amount: 20, msg: 'Tobanの仕様確認ありがとう！', time: '5時間前' },
+    { id: 'a3', kind: 'duty-assigned', who: 'ryu', duty: '食器を洗おう', time: '昨日' },
+    { id: 'a4', kind: 'split-created', name: 'kuu village day 7', count: 7, time: '昨日' },
+    { id: 'a5', kind: 'thanks-sent', from: 'me', to: 'sg', amount: 30, msg: '準備してくれて助かりました', time: '2日前' },
+  ],
+};

--- a/docs/design/handoff/project/desktop.jsx
+++ b/docs/design/handoff/project/desktop.jsx
@@ -1,0 +1,849 @@
+// Toban — Desktop layout
+const { useState, useMemo, Fragment: F } = React;
+const D = window.TOBAN_DATA;
+const Q = window.TOBAN_QUESTS_DATA;
+const T = {
+  font: '"Inter", "Noto Sans JP", -apple-system, system-ui, sans-serif',
+  fontDisplay: '"Inter", "Noto Sans JP", -apple-system, system-ui, sans-serif',
+  color: {
+    primary: '#F5B82E', primarySoft: '#FFF2CF',
+    background: '#FAF7F0', surface: '#FFFFFF',
+    textPrimary: '#1F1F1F', textSecondary: '#68645D',
+    border: '#E7E1D7',
+    contrib: '#65C98A', split: '#5DADEC', role: '#D6B995', danger: '#E45C4F',
+  },
+};
+const C = T.color;
+
+// ── Avatar (re-implemented locally, simpler) ─────────────────
+const palettes = ['#F5B82E', '#65C98A', '#5DADEC', '#D6B995', '#E48F4F', '#B696E0', '#E48ABF'];
+const avColor = (s = '') => { let h = 0; for (const c of s) h = (h * 31 + c.charCodeAt(0)) >>> 0; return palettes[h % palettes.length]; };
+const Avatar = ({ name = '', size = 32 }) => (
+  <div style={{
+    width: size, height: size, borderRadius: '50%',
+    background: avColor(name) + 'cc', color: '#fff',
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+    fontSize: size * 0.42, fontWeight: 700, fontFamily: T.font, flex: 'none',
+  }}>{name[0]?.toUpperCase() || '?'}</div>
+);
+
+// ── Generic icon (line-based, simple) ────────────────────────
+const Icon = ({ name, size = 18, color = 'currentColor' }) => {
+  const p = { width: size, height: size, viewBox: '0 0 24 24', fill: 'none', stroke: color, strokeWidth: 1.8, strokeLinecap: 'round', strokeLinejoin: 'round' };
+  switch (name) {
+    case 'home': return <svg {...p}><path d="M3 12l9-8 9 8" /><path d="M5 10v10h14V10" /></svg>;
+    case 'duty': return <svg {...p}><path d="M9 11l2 2 4-4" /><circle cx="12" cy="12" r="9" /></svg>;
+    case 'split': return <svg {...p}><circle cx="12" cy="12" r="9" /><path d="M12 3v9l7 4" /></svg>;
+    case 'members': return <svg {...p}><circle cx="9" cy="8" r="3.5" /><circle cx="17" cy="9.5" r="2.5" /><path d="M3 19c0-3 3-5 6-5s6 2 6 5" /><path d="M15 19c0-2 2-3.5 4-3.5s2 1 2 3.5" /></svg>;
+    case 'wallet': return <svg {...p}><rect x="3" y="6" width="18" height="13" rx="2" /><path d="M16 13h2" /></svg>;
+    case 'send': return <svg {...p}><path d="M22 2L11 13" /><path d="M22 2l-7 20-4-9-9-4 20-7z" /></svg>;
+    case 'plus': return <svg {...p}><path d="M12 5v14M5 12h14" /></svg>;
+    case 'search': return <svg {...p}><circle cx="11" cy="11" r="7" /><path d="M21 21l-5-5" /></svg>;
+    case 'bell': return <svg {...p}><path d="M6 8a6 6 0 1112 0c0 7 3 9 3 9H3s3-2 3-9z" /><path d="M10 21a2 2 0 004 0" /></svg>;
+    case 'settings': return <svg {...p}><circle cx="12" cy="12" r="3" /><path d="M19 12a7 7 0 00-.1-1.2l2-1.6-2-3.4-2.4 1a7 7 0 00-2-1.2L14 3h-4l-.5 2.6a7 7 0 00-2 1.2l-2.4-1-2 3.4 2 1.6A7 7 0 005 12a7 7 0 00.1 1.2l-2 1.6 2 3.4 2.4-1a7 7 0 002 1.2L10 21h4l.5-2.6a7 7 0 002-1.2l2.4 1 2-3.4-2-1.6c0-.4.1-.8.1-1.2z" /></svg>;
+    case 'chevron': return <svg {...p}><path d="M9 6l6 6-6 6" /></svg>;
+    case 'chevron-down': return <svg {...p}><path d="M6 9l6 6 6-6" /></svg>;
+    case 'check': return <svg {...p}><path d="M5 12l5 5L20 7" /></svg>;
+    case 'edit': return <svg {...p}><path d="M12 20h9" /><path d="M16.5 3.5a2.1 2.1 0 113 3L7 19l-4 1 1-4z" /></svg>;
+    case 'flame': return <svg {...p}><path d="M12 3s5 5 5 10a5 5 0 11-10 0c0-3 2-4 2-7 2 1 3 4 3 4z" /></svg>;
+    case 'sparkle': return <svg {...p}><path d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6z" /><path d="M19 16l.7 1.8L22 19l-2.3.8L19 22l-.7-2.2L16 19l2.3-1.2z" /></svg>;
+    case 'arrow-right': return <svg {...p}><path d="M5 12h14M13 5l7 7-7 7" /></svg>;
+    default: return null;
+  }
+};
+
+// ── Layout pieces ────────────────────────────────────────────
+const Sidebar = ({ route, setRoute, ws }) => {
+  const items = [
+    { key: 'home', label: 'ホーム', icon: 'home' },
+    { key: 'duties', label: '当番', icon: 'duty' },
+    { key: 'splits', label: '分配', icon: 'split' },
+    { key: 'members', label: 'メンバー', icon: 'members' },
+    { key: 'wallet', label: 'ウォレット', icon: 'wallet' },
+  ];
+  return (
+    <aside style={{
+      width: 260, flex: 'none', borderRight: `1px solid ${C.border}`,
+      background: '#FBF8F1', display: 'flex', flexDirection: 'column',
+    }}>
+      <div style={{ padding: '20px 18px 14px', borderBottom: `1px solid ${C.border}` }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <div style={{ width: 32, height: 32, borderRadius: 10, background: '#1F1F1F', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', color: '#FFD668', fontSize: 16, fontWeight: 800, fontFamily: T.font }}>と</div>
+          <div>
+            <div style={{ fontSize: 15, fontWeight: 700 }}>Toban</div>
+            <div style={{ fontSize: 11, color: C.textSecondary }}>あたたかい当番帳</div>
+          </div>
+        </div>
+      </div>
+
+      <button onClick={() => alert('ワークスペース切替（プロトタイプ）')} style={{
+        margin: '14px 12px 6px', padding: '10px 12px', borderRadius: 12,
+        background: '#fff', border: `1px solid ${C.border}`,
+        display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer',
+        textAlign: 'left',
+      }}>
+        <div style={{ width: 32, height: 32, borderRadius: 8, background: ws.color || C.primary, color: '#fff', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, fontSize: 14, fontFamily: T.font }}>{ws.name[0]}</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 12, color: C.textSecondary }}>WORKSPACE</div>
+          <div style={{ fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{ws.name}</div>
+        </div>
+        <Icon name="chevron-down" size={14} color={C.textSecondary} />
+      </button>
+
+      <nav style={{ padding: '12px 8px', display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {items.map(it => {
+          const active = route.name === it.key || route.name?.startsWith(it.key + '-') || (it.key === 'duties' && route.name === 'quest-detail');
+          return (
+            <button key={it.key} onClick={() => setRoute({ name: it.key })}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 12, padding: '9px 12px',
+                borderRadius: 10, border: 'none', cursor: 'pointer',
+                background: active ? C.primarySoft : 'transparent',
+                color: active ? '#7A5A2E' : C.textPrimary,
+                fontSize: 14, fontWeight: active ? 700 : 500, textAlign: 'left',
+                fontFamily: T.font,
+              }}>
+              <Icon name={it.icon} size={18} color={active ? C.primary : C.textSecondary} />
+              <span>{it.label}</span>
+            </button>
+          );
+        })}
+      </nav>
+
+      <div style={{ marginTop: 'auto', padding: 12, borderTop: `1px solid ${C.border}` }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <Avatar name={D.user.name} size={32} />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 700 }}>{D.user.name}</div>
+            <div style={{ fontSize: 11, color: C.textSecondary, fontFamily: 'ui-monospace, monospace' }}>{D.user.address}</div>
+          </div>
+          <button style={iconBtn}><Icon name="settings" size={16} color={C.textSecondary} /></button>
+        </div>
+      </div>
+    </aside>
+  );
+};
+
+const iconBtn = {
+  width: 32, height: 32, borderRadius: 10,
+  background: 'transparent', border: 'none', cursor: 'pointer',
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+};
+
+// ── Top bar ──────────────────────────────────────────────────
+const TopBar = ({ title, subtitle, right, onSendThanks }) => (
+  <header style={{
+    height: 72, padding: '0 28px', borderBottom: `1px solid ${C.border}`,
+    display: 'flex', alignItems: 'center', gap: 16, background: '#fff',
+  }}>
+    <div style={{ flex: 1 }}>
+      <div style={{ fontSize: 22, fontWeight: 700, letterSpacing: -0.4 }}>{title}</div>
+      {subtitle && <div style={{ fontSize: 12, color: C.textSecondary, marginTop: 2 }}>{subtitle}</div>}
+    </div>
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 8,
+      background: C.background, borderRadius: 999, padding: '8px 14px',
+      width: 280,
+    }}>
+      <Icon name="search" size={16} color={C.textSecondary} />
+      <input placeholder="検索..." style={{ border: 'none', background: 'transparent', outline: 'none', flex: 1, fontSize: 13, fontFamily: T.font }} />
+    </div>
+    <button style={iconBtn}><Icon name="bell" size={18} color={C.textSecondary} /></button>
+    {right}
+    <button onClick={onSendThanks} style={primaryBtn}><Icon name="send" size={14} color="#fff" /> サンクスを送る</button>
+  </header>
+);
+
+const primaryBtn = {
+  display: 'inline-flex', alignItems: 'center', gap: 8,
+  padding: '10px 16px', borderRadius: 999,
+  background: C.primary, color: '#fff', border: 'none',
+  fontSize: 13, fontWeight: 700, fontFamily: T.font, cursor: 'pointer',
+};
+const secondaryBtn = {
+  display: 'inline-flex', alignItems: 'center', gap: 8,
+  padding: '10px 16px', borderRadius: 999,
+  background: '#fff', color: C.textPrimary, border: `1px solid ${C.border}`,
+  fontSize: 13, fontWeight: 600, fontFamily: T.font, cursor: 'pointer',
+};
+
+const Card = ({ children, padding = 20, style }) => (
+  <div style={{
+    background: C.surface, border: `1px solid ${C.border}`,
+    borderRadius: 16, padding, ...style,
+  }}>{children}</div>
+);
+
+const SectionTitle = ({ children, action }) => (
+  <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 12 }}>
+    <div style={{ fontSize: 14, fontWeight: 700, letterSpacing: 0.2 }}>{children}</div>
+    {action}
+  </div>
+);
+
+const StateBadge = ({ state }) => {
+  const map = {
+    open: { label: '募集中', bg: '#FFF2CF', fg: '#7A5A2E' },
+    inprogress: { label: '進行中', bg: '#E5F1FB', fg: '#2D6FA8' },
+    review: { label: '確認待ち', bg: '#F2EBF8', fg: '#6E4DAA' },
+    done: { label: '完了', bg: '#E5F5EC', fg: '#2F8B58' },
+  };
+  const s = map[state] || map.open;
+  return <span style={{ display: 'inline-flex', alignItems: 'center', padding: '2px 9px', borderRadius: 999, background: s.bg, color: s.fg, fontSize: 11, fontWeight: 700 }}>{s.label}</span>;
+};
+
+const Pill = ({ children, kind }) => {
+  const colors = {
+    Member: { bg: '#E5F5EC', fg: '#2F8B58' },
+    lead: { bg: '#FFF2CF', fg: '#7A5A2E' },
+    supporter: { bg: '#F2EBF8', fg: '#6E4DAA' },
+  };
+  const c = colors[kind] || colors.Member;
+  return <span style={{ padding: '2px 9px', borderRadius: 999, background: c.bg, color: c.fg, fontSize: 11, fontWeight: 700 }}>{children}</span>;
+};
+
+// ── HOME ─────────────────────────────────────────────────────
+const HomeView = ({ setRoute }) => {
+  const recent = [
+    { from: 'homma', to: 'me', amount: 100, msg: 'EXPOにお誘いいただきありがとうございました！', time: '12時間前' },
+    { from: 'shinya', to: 'me', amount: 20, msg: 'Tobanの仕様補足ありがとうございます！', time: '1日前' },
+    { from: 'me', to: 'sg', amount: 50, msg: '準備手伝ってくれて助かりました', time: '2日前' },
+  ];
+  return (
+    <div style={{ padding: 28, display: 'grid', gridTemplateColumns: '2fr 1fr', gap: 20 }}>
+      {/* Left column */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12 }}>
+          <StatCard label="送れるサンクス" value="120" unit="THX" accent={C.primary} delta="+15%" />
+          <StatCard label="受け取ったサンクス" value="80" unit="THX" accent="#65C98A" />
+          <StatCard label="今週の貢献" value="3" unit="件" accent="#5DADEC" />
+        </div>
+
+        <Card>
+          <SectionTitle action={<button style={linkBtn} onClick={() => setRoute({ name: 'duties' })}>すべて見る →</button>}>あなたの当番</SectionTitle>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 10 }}>
+            {D.duties.slice(0, 4).map(d => (
+              <button key={d.id} onClick={() => setRoute({ name: 'duty-detail', dutyId: d.id })} style={{
+                background: '#FBF8F1', border: `1px solid ${C.border}`, borderRadius: 12,
+                padding: '14px 16px', textAlign: 'left', cursor: 'pointer',
+                display: 'flex', alignItems: 'center', gap: 12, fontFamily: T.font,
+              }}>
+                <div style={{ width: 36, height: 36, borderRadius: 10, background: (d.accent || '#D6B995') + '33', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <Icon name="duty" size={18} color="#7A5A2E" />
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 2 }}>{d.name}</div>
+                  <div style={{ fontSize: 11, color: C.textSecondary }}>担当: {d.assignee || '未設定'} ・ 次回 {d.next}</div>
+                </div>
+                <Icon name="chevron" size={14} color={C.textSecondary} />
+              </button>
+            ))}
+          </div>
+        </Card>
+
+        <Card>
+          <SectionTitle action={<button style={linkBtn}>すべて見る →</button>}>最近のアクティビティ</SectionTitle>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            {recent.map((r, i) => (
+              <div key={i} style={{
+                display: 'flex', alignItems: 'center', gap: 12, padding: '12px 0',
+                borderTop: i === 0 ? 'none' : `1px solid ${C.border}`,
+              }}>
+                <Avatar name={r.from === 'me' ? 'ryoma' : r.from} size={36} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13, marginBottom: 2 }}>
+                    <strong>{r.from === 'me' ? 'あなた' : r.from}</strong>
+                    <span style={{ color: C.textSecondary }}> から </span>
+                    <strong>{r.to === 'me' ? 'あなた' : r.to}</strong>
+                    <span style={{ color: C.textSecondary }}> へ</span>
+                  </div>
+                  <div style={{ fontSize: 12, color: C.textSecondary, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.msg}</div>
+                </div>
+                <div style={{ textAlign: 'right', flex: 'none' }}>
+                  <div style={{ fontSize: 14, fontWeight: 700, color: C.primary }}>{r.amount} <span style={{ fontSize: 10, color: C.textSecondary }}>THX</span></div>
+                  <div style={{ fontSize: 10, color: C.textSecondary }}>{r.time}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+      </div>
+
+      {/* Right column */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+        <Card style={{ background: 'linear-gradient(160deg, #FFD668, #F5B82E)', border: 'none', color: '#3D2D14' }}>
+          <div style={{ fontSize: 12, fontWeight: 700, opacity: 0.7 }}>今週の残高</div>
+          <div style={{ fontSize: 56, fontWeight: 700, fontFamily: T.fontDisplay || T.font, letterSpacing: -2, lineHeight: 1, margin: '10px 0 4px' }}>120<span style={{ fontSize: 18, marginLeft: 6, opacity: 0.8 }}>THX</span></div>
+          <div style={{ fontSize: 12, opacity: 0.8, marginBottom: 16 }}>送付可能量 ・ 先週 +15%</div>
+          <button style={{ ...secondaryBtn, background: '#3D2D14', color: '#FFD668', border: 'none', width: '100%', justifyContent: 'center' }}>
+            <Icon name="send" size={14} color="#FFD668" /> サンクスを送る
+          </button>
+        </Card>
+
+        <Card>
+          <SectionTitle>進行中のクエスト</SectionTitle>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {Q.quests.filter(q => q.state === 'review' || q.state === 'inprogress').slice(0, 3).map(q => (
+              <button key={q.id} onClick={() => setRoute({ name: 'quest-detail', questId: q.id })} style={{
+                background: '#FBF8F1', border: `1px solid ${C.border}`, borderRadius: 12,
+                padding: '12px 14px', textAlign: 'left', cursor: 'pointer', fontFamily: T.font,
+                display: 'flex', flexDirection: 'column', gap: 4,
+              }}>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+                  <div style={{ fontSize: 13, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{q.title}</div>
+                  <div style={{ fontSize: 12, fontWeight: 700, color: C.primary }}>+{q.share}%</div>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <StateBadge state={q.state} />
+                  <span style={{ fontSize: 11, color: C.textSecondary }}>{q.applicant}</span>
+                </div>
+              </button>
+            ))}
+          </div>
+        </Card>
+
+        <Card>
+          <SectionTitle>原則</SectionTitle>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {[
+              { icon: '♡', label: 'Warm', desc: 'やさしい人のつながり' },
+              { icon: '✺', label: 'Clear', desc: '迷わないシンプルさ' },
+              { icon: '◍', label: 'Community', desc: 'みんなで育てる仕組み' },
+            ].map(p => (
+              <div key={p.label} style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                <div style={{ width: 32, height: 32, borderRadius: 8, background: C.primarySoft, color: '#7A5A2E', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 14 }}>{p.icon}</div>
+                <div>
+                  <div style={{ fontSize: 13, fontWeight: 700 }}>{p.label}</div>
+                  <div style={{ fontSize: 11, color: C.textSecondary }}>{p.desc}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+const StatCard = ({ label, value, unit, accent, delta }) => (
+  <Card padding={18}>
+    <div style={{ fontSize: 12, color: C.textSecondary, fontWeight: 600 }}>{label}</div>
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, marginTop: 8 }}>
+      <div style={{ fontSize: 32, fontWeight: 700, fontFamily: T.fontDisplay || T.font, letterSpacing: -1, color: accent }}>{value}</div>
+      <div style={{ fontSize: 12, color: C.textSecondary }}>{unit}</div>
+      {delta && <div style={{ marginLeft: 'auto', fontSize: 11, color: '#2F8B58', fontWeight: 700, background: '#E5F5EC', padding: '2px 8px', borderRadius: 999 }}>{delta}</div>}
+    </div>
+  </Card>
+);
+
+const linkBtn = {
+  background: 'transparent', border: 'none', color: C.textSecondary,
+  fontSize: 12, cursor: 'pointer', fontFamily: T.font, fontWeight: 600,
+};
+
+// ── DUTIES (master-detail) ───────────────────────────────────
+const DutiesView = ({ route, setRoute }) => {
+  const [view, setView] = useState('duties'); // duties | quests
+  const [selected, setSelected] = useState(route.dutyId || D.duties[0].id);
+  const duty = D.duties.find(d => d.id === selected) || D.duties[0];
+  const palette = ['#D6B995', '#65C98A', '#5DADEC', '#F5B82E', '#B696E0'];
+  const shares = Q.shares[selected] || [];
+  const dutyQuests = Q.quests.filter(q => q.dutyId === selected);
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '320px 1fr', height: 'calc(100vh - 72px)' }}>
+      {/* List */}
+      <aside style={{ borderRight: `1px solid ${C.border}`, background: '#FBF8F1', overflow: 'auto' }}>
+        <div style={{ padding: '16px 16px 8px', display: 'flex', gap: 6 }}>
+          {[{ k: 'duties', l: '当番' }, { k: 'quests', l: 'クエスト' }].map(t => (
+            <button key={t.k} onClick={() => setView(t.k)} style={{
+              flex: 1, padding: '8px 0', borderRadius: 10,
+              background: view === t.k ? '#fff' : 'transparent',
+              border: view === t.k ? `1px solid ${C.border}` : '1px solid transparent',
+              fontSize: 12, fontWeight: 700, fontFamily: T.font, cursor: 'pointer',
+              color: view === t.k ? C.textPrimary : C.textSecondary,
+            }}>{t.l}</button>
+          ))}
+        </div>
+
+        {view === 'duties' && (
+          <div style={{ padding: '4px 8px 16px' }}>
+            {D.duties.map(d => {
+              const active = d.id === selected;
+              return (
+                <button key={d.id} onClick={() => setSelected(d.id)} style={{
+                  width: '100%', textAlign: 'left', padding: '12px 12px', borderRadius: 12,
+                  border: 'none', background: active ? '#fff' : 'transparent',
+                  boxShadow: active ? '0 1px 0 rgba(0,0,0,0.04)' : 'none',
+                  cursor: 'pointer', fontFamily: T.font,
+                  display: 'flex', alignItems: 'center', gap: 10,
+                  marginBottom: 2,
+                }}>
+                  <div style={{ width: 36, height: 36, borderRadius: 10, background: (d.accent || '#D6B995') + '33', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <Icon name="duty" size={18} color="#7A5A2E" />
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 13, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{d.name}</div>
+                    <div style={{ fontSize: 11, color: C.textSecondary }}>{d.assignee || '担当者を募集中'}</div>
+                  </div>
+                </button>
+              );
+            })}
+            <button style={{ ...secondaryBtn, width: '100%', justifyContent: 'center', marginTop: 8 }}>
+              <Icon name="plus" size={14} color={C.textPrimary} /> 当番を作成
+            </button>
+          </div>
+        )}
+
+        {view === 'quests' && (
+          <div style={{ padding: '4px 12px 16px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {Q.quests.map(q => (
+              <button key={q.id} onClick={() => setRoute({ name: 'quest-detail', questId: q.id })} style={{
+                background: '#fff', border: `1px solid ${C.border}`, borderRadius: 10,
+                padding: '10px 12px', textAlign: 'left', cursor: 'pointer', fontFamily: T.font,
+              }}>
+                <div style={{ fontSize: 10, color: C.textSecondary, fontWeight: 700, marginBottom: 2 }}>{D.duties.find(d => d.id === q.dutyId)?.name}</div>
+                <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 6 }}>{q.title}</div>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <StateBadge state={q.state} />
+                  <span style={{ fontSize: 12, fontWeight: 700, color: C.primary }}>+{q.share}%</span>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </aside>
+
+      {/* Detail */}
+      <div style={{ overflow: 'auto', padding: 28 }}>
+        {view === 'duties' && (
+          <DutyDetail duty={duty} shares={shares} dutyQuests={dutyQuests} palette={palette} setRoute={setRoute} />
+        )}
+        {view === 'quests' && <QuestsBoard setRoute={setRoute} />}
+      </div>
+    </div>
+  );
+};
+
+const DutyDetail = ({ duty, shares, dutyQuests, palette, setRoute }) => (
+  <div style={{ display: 'grid', gridTemplateColumns: '1fr 320px', gap: 24 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 10 }}>
+          <div style={{ width: 64, height: 64, borderRadius: 16, background: (duty.accent || '#D6B995') + '33', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Icon name="duty" size={32} color="#7A5A2E" />
+          </div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 26, fontWeight: 700, letterSpacing: -0.5 }}>{duty.name}</div>
+            <div style={{ fontSize: 13, color: C.textSecondary, marginTop: 4 }}>担当: <strong style={{ color: C.textPrimary }}>{duty.assignee || '—'}</strong> ・ 次回 {duty.next}</div>
+          </div>
+          <button style={secondaryBtn}><Icon name="edit" size={14} color={C.textPrimary} /> 編集</button>
+          <button style={primaryBtn}><Icon name="plus" size={14} color="#fff" /> クエストを作成</button>
+        </div>
+      </div>
+
+      <Card>
+        <SectionTitle>説明</SectionTitle>
+        <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {duty.desc.map((line, i) => (
+            <li key={i} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, fontSize: 14, lineHeight: 1.5 }}>
+              <div style={{ width: 6, height: 6, borderRadius: 999, background: C.primary, marginTop: 8, flex: 'none' }} />{line}
+            </li>
+          ))}
+        </ul>
+      </Card>
+
+      <Card>
+        <SectionTitle action={<button style={linkBtn}>すべて見る →</button>}>クエスト</SectionTitle>
+        {dutyQuests.length === 0 && <div style={{ padding: 20, color: C.textSecondary, fontSize: 13, textAlign: 'center' }}>このダッジにはまだクエストがありません</div>}
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 10 }}>
+          {dutyQuests.map(q => (
+            <button key={q.id} onClick={() => setRoute({ name: 'quest-detail', questId: q.id })} style={{
+              background: '#FBF8F1', border: `1px solid ${C.border}`, borderRadius: 12,
+              padding: 14, textAlign: 'left', cursor: 'pointer', fontFamily: T.font,
+              display: 'flex', flexDirection: 'column', gap: 8,
+            }}>
+              <StateBadge state={q.state} />
+              <div style={{ fontSize: 14, fontWeight: 700 }}>{q.title}</div>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <div style={{ fontSize: 11, color: C.textSecondary }}>
+                  {q.state === 'open' && `作成者 ${q.creator}・残り${q.count}件`}
+                  {q.state === 'inprogress' && `参加 ${q.applicant}`}
+                  {q.state === 'review' && `${q.applicant}・承認 ${q.approvals || 0}/2`}
+                  {q.state === 'done' && `${q.applicant} 完了`}
+                </div>
+                <div style={{ fontSize: 14, fontWeight: 700, color: C.primary }}>+{q.share}%</div>
+              </div>
+            </button>
+          ))}
+        </div>
+      </Card>
+    </div>
+
+    {/* Side */}
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <Card>
+        <SectionTitle>当番シェア分布</SectionTitle>
+        <div style={{ display: 'flex', borderRadius: 6, overflow: 'hidden', height: 12, marginBottom: 14 }}>
+          {shares.map((s, i) => <div key={s.name} style={{ width: `${s.pct}%`, background: palette[i % palette.length] }} />)}
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {shares.map((s, i) => (
+            <div key={s.name} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <div style={{ width: 8, height: 8, borderRadius: 999, background: palette[i % palette.length] }} />
+              <Avatar name={s.name} size={24} />
+              <div style={{ flex: 1, fontSize: 13, fontWeight: 600 }}>{s.name}</div>
+              <div style={{ fontSize: 14, fontWeight: 700 }}>{s.pct}<span style={{ fontSize: 10, color: C.textSecondary, marginLeft: 2 }}>%</span></div>
+            </div>
+          ))}
+        </div>
+      </Card>
+
+      <Card>
+        <SectionTitle>サポーター（{duty.supporters.length}）</SectionTitle>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {duty.supporters.map(s => (
+            <div key={s} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <Avatar name={s} size={32} />
+              <div style={{ flex: 1, fontSize: 13, fontWeight: 600 }}>{s}</div>
+              <Pill kind="supporter">サポーター</Pill>
+            </div>
+          ))}
+        </div>
+      </Card>
+    </div>
+  </div>
+);
+
+const QuestsBoard = ({ setRoute }) => {
+  const groups = [
+    { state: 'open', title: '募集中' },
+    { state: 'inprogress', title: '進行中' },
+    { state: 'review', title: '確認待ち' },
+    { state: 'done', title: '完了' },
+  ];
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 14 }}>
+      {groups.map(g => {
+        const items = Q.quests.filter(q => q.state === g.state);
+        return (
+          <div key={g.state} style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <StateBadge state={g.state} />
+              <div style={{ fontSize: 12, color: C.textSecondary, fontWeight: 700 }}>{items.length}</div>
+            </div>
+            {items.map(q => (
+              <button key={q.id} onClick={() => setRoute({ name: 'quest-detail', questId: q.id })} style={{
+                background: '#fff', border: `1px solid ${C.border}`, borderRadius: 12,
+                padding: 14, textAlign: 'left', cursor: 'pointer', fontFamily: T.font,
+              }}>
+                <div style={{ fontSize: 10, color: C.textSecondary, fontWeight: 700, marginBottom: 4 }}>{D.duties.find(d => d.id === q.dutyId)?.name}</div>
+                <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 10, lineHeight: 1.4 }}>{q.title}</div>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <Avatar name={q.applicant || q.creator} size={22} />
+                  <div style={{ fontSize: 14, fontWeight: 700, color: C.primary }}>+{q.share}%</div>
+                </div>
+              </button>
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+// ── QUEST DETAIL ─────────────────────────────────────────────
+const QuestDetailView = ({ route, setRoute }) => {
+  const q = Q.quests.find(x => x.id === route.questId);
+  if (!q) return null;
+  const duty = D.duties.find(d => d.id === q.dutyId);
+  const isMine = q.creator === D.user.name;
+  return (
+    <div style={{ padding: 28, display: 'grid', gridTemplateColumns: '1fr 360px', gap: 24, alignItems: 'flex-start' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+        <button onClick={() => setRoute({ name: 'duties', dutyId: q.dutyId })} style={{ ...linkBtn, padding: 0, alignSelf: 'flex-start' }}>← {duty?.name}</button>
+        <Card padding={28}>
+          <StateBadge state={q.state} />
+          <div style={{ fontSize: 32, fontWeight: 700, letterSpacing: -0.6, margin: '14px 0 10px', lineHeight: 1.3 }}>{q.title}</div>
+          <div style={{ fontSize: 14, color: C.textSecondary, lineHeight: 1.7 }}>{q.desc}</div>
+
+          <div style={{ display: 'flex', gap: 16, margin: '24px 0', padding: '16px 0', borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}` }}>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 11, color: C.textSecondary, fontWeight: 700 }}>紐づく当番</div>
+              <div style={{ fontSize: 14, fontWeight: 700, marginTop: 4 }}>{duty?.name}</div>
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 11, color: C.textSecondary, fontWeight: 700 }}>もらえる当番シェア</div>
+              <div style={{ fontSize: 22, fontWeight: 700, color: C.primary, fontFamily: T.fontDisplay || T.font, letterSpacing: -0.5, marginTop: 2 }}>+{q.share}%</div>
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 11, color: C.textSecondary, fontWeight: 700 }}>状態</div>
+              <div style={{ fontSize: 14, fontWeight: 700, marginTop: 4 }}>
+                {q.state === 'open' && `募集中（残り ${q.count}件）`}
+                {q.state === 'inprogress' && `${q.applicant} が進行中`}
+                {q.state === 'review' && `承認 ${q.approvals || 0}/2`}
+                {q.state === 'done' && `${q.applicant} が完了`}
+              </div>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+            <Avatar name={q.creator} size={44} />
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 11, color: C.textSecondary }}>作成者</div>
+              <div style={{ fontSize: 14, fontWeight: 700 }}>{q.creator}</div>
+            </div>
+            {q.applicant && <>
+              <Icon name="arrow-right" size={18} color={C.textSecondary} />
+              <Avatar name={q.applicant} size={44} />
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 11, color: C.textSecondary }}>{q.state === 'review' ? '申請者' : '参加者'}</div>
+                <div style={{ fontSize: 14, fontWeight: 700 }}>{q.applicant}</div>
+              </div>
+            </>}
+          </div>
+
+          <div style={{ display: 'flex', gap: 10, marginTop: 24 }}>
+            {q.state === 'open' && !isMine && <button style={{ ...primaryBtn, flex: 1, justifyContent: 'center', padding: '12px 20px' }}><Icon name="check" size={14} color="#fff" /> 申請する</button>}
+            {q.state === 'open' && isMine && <button style={{ ...secondaryBtn, flex: 1, justifyContent: 'center', padding: '12px 20px' }}>キャンセル</button>}
+            {q.state === 'inprogress' && <button style={{ ...primaryBtn, flex: 1, justifyContent: 'center', padding: '12px 20px' }}><Icon name="send" size={14} color="#fff" /> 完了申請する</button>}
+            {q.state === 'review' && <button style={{ ...primaryBtn, flex: 1, justifyContent: 'center', padding: '12px 20px' }}><Icon name="check" size={14} color="#fff" /> 承認する</button>}
+          </div>
+        </Card>
+      </div>
+
+      <Card>
+        <SectionTitle>シェアの動き</SectionTitle>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div>
+            <div style={{ fontSize: 11, color: C.textSecondary, fontWeight: 600 }}>作成前のシェア</div>
+            <div style={{ fontSize: 24, fontWeight: 700, fontFamily: T.fontDisplay || T.font }}>40%</div>
+          </div>
+          <div style={{ borderTop: `1px dashed ${C.border}` }} />
+          <div>
+            <div style={{ fontSize: 11, color: C.textSecondary, fontWeight: 600 }}>このクエストで動くシェア</div>
+            <div style={{ fontSize: 32, fontWeight: 700, color: C.primary, fontFamily: T.fontDisplay || T.font, letterSpacing: -0.5 }}>{q.share}%</div>
+          </div>
+          <div style={{ borderTop: `1px dashed ${C.border}` }} />
+          <div>
+            <div style={{ fontSize: 11, color: C.textSecondary, fontWeight: 600 }}>完了後のシェア（参加者へ）</div>
+            <div style={{ fontSize: 24, fontWeight: 700, color: '#2F8B58', fontFamily: T.fontDisplay || T.font }}>+{q.share}%</div>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+// ── SPLITS ───────────────────────────────────────────────────
+const SplitsView = ({ setRoute }) => {
+  const splits = [
+    { id: 's1', name: 'kuu village day 7', count: 7, top: [{ n: 'atsu', p: 2.34 }, { n: 'ryoma', p: 2.21 }, { n: 'yumaito', p: 1.64 }, { n: 'takerun', p: 1.18 }, { n: 'koichi', p: 1.21 }], date: '2025/10/07' },
+    { id: 's2', name: 'kuu village day 5', count: 9, top: [{ n: 'eri', p: 1.92 }, { n: 'sg', p: 1.71 }, { n: 'homma', p: 1.5 }], date: '2025/10/05' },
+  ];
+  const [sel, setSel] = useState('s1');
+  const split = splits.find(s => s.id === sel);
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '320px 1fr', height: 'calc(100vh - 72px)' }}>
+      <aside style={{ borderRight: `1px solid ${C.border}`, background: '#FBF8F1', overflow: 'auto', padding: 12 }}>
+        <button style={{ ...primaryBtn, width: '100%', justifyContent: 'center', marginBottom: 12 }}><Icon name="plus" size={14} color="#fff" /> 新規作成</button>
+        {splits.map(s => (
+          <button key={s.id} onClick={() => setSel(s.id)} style={{
+            width: '100%', textAlign: 'left', padding: 14, borderRadius: 12,
+            border: 'none', background: sel === s.id ? '#fff' : 'transparent',
+            cursor: 'pointer', fontFamily: T.font, marginBottom: 4,
+            display: 'flex', alignItems: 'center', gap: 12,
+          }}>
+            <div style={{ width: 36, height: 36, borderRadius: 10, background: '#E5F1FB', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <Icon name="split" size={18} color={C.split} />
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.name}</div>
+              <div style={{ fontSize: 11, color: C.textSecondary }}>{s.count}人に分配 ・ {s.date}</div>
+            </div>
+          </button>
+        ))}
+      </aside>
+      <div style={{ overflow: 'auto', padding: 28, display: 'grid', gridTemplateColumns: '1fr 360px', gap: 24, alignItems: 'flex-start' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+          <div>
+            <div style={{ fontSize: 26, fontWeight: 700, letterSpacing: -0.5 }}>{split.name}</div>
+            <div style={{ fontSize: 13, color: C.textSecondary, marginTop: 4 }}>合計 100% ・ 対象 {split.count}人 ・ 作成日 {split.date}</div>
+          </div>
+          <Card>
+            <SectionTitle>分配結果</SectionTitle>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              {split.top.map((t, i) => (
+                <div key={t.n} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 0', borderTop: i === 0 ? 'none' : `1px solid ${C.border}` }}>
+                  <div style={{ width: 24, fontSize: 12, color: C.textSecondary, fontWeight: 700 }}>{i + 1}.</div>
+                  <Avatar name={t.n} size={32} />
+                  <div style={{ flex: 1, fontSize: 14, fontWeight: 600 }}>{t.n}</div>
+                  <div style={{ width: 200, height: 6, background: C.border, borderRadius: 999, overflow: 'hidden' }}>
+                    <div style={{ width: `${(t.p / 2.5) * 100}%`, height: '100%', background: C.split }} />
+                  </div>
+                  <div style={{ width: 60, textAlign: 'right', fontSize: 14, fontWeight: 700, fontFamily: T.fontDisplay || T.font }}>{t.p.toFixed(2)}%</div>
+                </div>
+              ))}
+            </div>
+          </Card>
+          <Card>
+            <SectionTitle>技術情報</SectionTitle>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10, fontFamily: 'ui-monospace, monospace', fontSize: 12 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}><span style={{ color: C.textSecondary }}>ENS</span><span>kuuvillageday7.split.toban.eth</span></div>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}><span style={{ color: C.textSecondary }}>Contract</span><span>0xD8EF...5B18e</span></div>
+            </div>
+          </Card>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <Card>
+            <SectionTitle>分配ルール</SectionTitle>
+            <RuleBar label="当番ベース" pct={82} color={C.role} />
+            <RuleBar label="サンクスベース" pct={18} color={C.split} />
+            <div style={{ height: 12 }} />
+            <div style={{ fontSize: 11, color: C.textSecondary, fontWeight: 700, marginBottom: 6 }}>サンクスの内訳</div>
+            <RuleBar label="送付" pct={75} color={C.primary} />
+            <RuleBar label="受け取り" pct={25} color="#65C98A" />
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const RuleBar = ({ label, pct, color }) => (
+  <div style={{ marginBottom: 10 }}>
+    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, fontWeight: 600, marginBottom: 4 }}>
+      <span>{label}</span><span>{pct}%</span>
+    </div>
+    <div style={{ height: 6, background: C.border, borderRadius: 999, overflow: 'hidden' }}>
+      <div style={{ width: `${pct}%`, height: '100%', background: color }} />
+    </div>
+  </div>
+);
+
+// ── MEMBERS ─────────────────────────────────────────────────
+const MembersView = () => {
+  const [sel, setSel] = useState(D.members[0].id);
+  const m = D.members.find(x => x.id === sel) || D.members[0];
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '320px 1fr', height: 'calc(100vh - 72px)' }}>
+      <aside style={{ borderRight: `1px solid ${C.border}`, background: '#FBF8F1', overflow: 'auto', padding: 12 }}>
+        {D.members.map(mem => (
+          <button key={mem.id} onClick={() => setSel(mem.id)} style={{
+            width: '100%', textAlign: 'left', padding: 12, borderRadius: 12,
+            border: 'none', background: sel === mem.id ? '#fff' : 'transparent',
+            cursor: 'pointer', fontFamily: T.font, marginBottom: 2,
+            display: 'flex', alignItems: 'center', gap: 12,
+          }}>
+            <Avatar name={mem.name} size={36} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 700 }}>{mem.name}</div>
+              <div style={{ fontSize: 11, color: C.textSecondary, fontFamily: 'ui-monospace, monospace' }}>{mem.addr}</div>
+            </div>
+            <Pill kind={mem.role === 'lead' ? 'lead' : mem.role === 'supporter' ? 'supporter' : 'Member'}>{mem.role === 'lead' ? '当番リード' : mem.role === 'supporter' ? 'サポーター' : 'Member'}</Pill>
+          </button>
+        ))}
+      </aside>
+      <div style={{ overflow: 'auto', padding: 32 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 20, marginBottom: 24 }}>
+          <Avatar name={m.name} size={88} />
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 32, fontWeight: 700, letterSpacing: -0.5 }}>{m.name}</div>
+            <div style={{ fontSize: 13, color: C.textSecondary, fontFamily: 'ui-monospace, monospace', marginTop: 4 }}>{m.addr}</div>
+            <div style={{ marginTop: 10 }}><Pill kind={m.role === 'lead' ? 'lead' : m.role === 'supporter' ? 'supporter' : 'Member'}>{m.role === 'lead' ? '当番リード' : m.role === 'supporter' ? 'サポーター' : 'Member'}</Pill></div>
+          </div>
+          <button style={primaryBtn}><Icon name="send" size={14} color="#fff" /> サンクスを送る</button>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16, marginBottom: 20 }}>
+          <StatCard label="今週の貢献" value={m.contribs} unit="件" accent={C.contrib} />
+          <StatCard label="受け取ったサンクス" value={m.received} unit="THX" accent={C.primary} />
+          <StatCard label="当番シェア合計" value="35" unit="%" accent={C.split} />
+        </div>
+
+        <Card>
+          <SectionTitle>関わっている当番</SectionTitle>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 10 }}>
+            {D.duties.filter(d => d.assignee === m.id || d.supporters.includes(m.name)).map(d => (
+              <div key={d.id} style={{ background: '#FBF8F1', border: `1px solid ${C.border}`, borderRadius: 12, padding: 14, display: 'flex', alignItems: 'center', gap: 10 }}>
+                <div style={{ width: 32, height: 32, borderRadius: 8, background: (d.accent || '#D6B995') + '33', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <Icon name="duty" size={16} color="#7A5A2E" />
+                </div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 13, fontWeight: 700 }}>{d.name}</div>
+                  <div style={{ fontSize: 11, color: C.textSecondary }}>{d.assignee === m.id ? '担当' : 'サポーター'}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+// ── WALLET ──────────────────────────────────────────────────
+const WalletView = () => (
+  <div style={{ padding: 32, maxWidth: 720 }}>
+    <Card padding={28}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 20, marginBottom: 28 }}>
+        <Avatar name={D.user.name} size={88} />
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 28, fontWeight: 700, letterSpacing: -0.5 }}>{D.user.name}</div>
+          <div style={{ fontSize: 13, color: C.textSecondary, fontFamily: 'ui-monospace, monospace', marginTop: 4 }}>{D.user.address}</div>
+        </div>
+        <button style={secondaryBtn}><Icon name="edit" size={14} color={C.textPrimary} /> プロフィール編集</button>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 16, marginBottom: 24 }}>
+        <StatCard label="送れるサンクス" value="120" unit="THX" accent={C.primary} />
+        <StatCard label="受け取ったサンクス" value="80" unit="THX" accent={C.contrib} />
+      </div>
+      <div style={{ borderTop: `1px solid ${C.border}`, paddingTop: 20 }}>
+        <SectionTitle>所属ワークスペース</SectionTitle>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '14px 0' }}>
+          <div style={{ width: 40, height: 40, borderRadius: 10, background: C.primary, color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700 }}>k</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 14, fontWeight: 700 }}>kuu village #1</div>
+            <div style={{ fontSize: 11, color: C.textSecondary }}>24 members ・ 2時間前</div>
+          </div>
+        </div>
+      </div>
+    </Card>
+  </div>
+);
+
+// ── App root ─────────────────────────────────────────────────
+const App = () => {
+  const [route, setRoute] = useState({ name: 'home' });
+  const ws = { name: 'kuu village #1', color: '#F5B82E' };
+
+  const titles = {
+    home: { title: 'ホーム', subtitle: '今日もおつかれさまです！' },
+    duties: { title: '当番', subtitle: 'コミュニティの役割と関わり' },
+    splits: { title: '分配', subtitle: '貢献記録から作る分配ルール' },
+    members: { title: 'メンバー', subtitle: 'ワークスペース参加者' },
+    wallet: { title: 'ウォレット', subtitle: 'プロフィールと残高' },
+    'duty-detail': { title: '当番', subtitle: 'コミュニティの役割と関わり' },
+    'quest-detail': { title: 'クエスト', subtitle: '当番シェアの動き' },
+  };
+  const tt = titles[route.name] || titles.home;
+
+  return (
+    <div style={{ height: '100vh', display: 'flex', background: C.background, fontFamily: T.font, color: C.textPrimary }}>
+      <Sidebar route={route} setRoute={setRoute} ws={ws} />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+        <TopBar title={tt.title} subtitle={tt.subtitle} onSendThanks={() => alert('サンクス送信モーダル（プロトタイプ）')} />
+        <main style={{ flex: 1, overflow: 'auto' }}>
+          {route.name === 'home' && <HomeView setRoute={setRoute} />}
+          {(route.name === 'duties' || route.name === 'duty-detail') && <DutiesView route={route} setRoute={setRoute} />}
+          {route.name === 'splits' && <SplitsView setRoute={setRoute} />}
+          {route.name === 'members' && <MembersView />}
+          {route.name === 'wallet' && <WalletView />}
+          {route.name === 'quest-detail' && <QuestDetailView route={route} setRoute={setRoute} />}
+        </main>
+      </div>
+    </div>
+  );
+};
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/docs/design/handoff/project/edit-screens.jsx
+++ b/docs/design/handoff/project/edit-screens.jsx
@@ -1,0 +1,578 @@
+// Toban — duty + workspace create/edit screens
+
+// ─── DUTY CREATE / EDIT ─────────────────────────────────────
+function DutyEditScreen({ goto, dutyId, onSaved }) {
+  const editing = !!dutyId;
+  const existing = editing ? D.duties.find(d => d.id === dutyId) : null;
+  const [name, setName] = useState(existing?.name || '');
+  const [tasks, setTasks] = useState(existing?.desc?.length ? existing.desc : ['']);
+  const [accent, setAccent] = useState(existing?.accent || '#D6B995');
+  const [frequency, setFrequency] = useState('weekly');
+  const [icon, setIcon] = useState('duty');
+  const [needSupporter, setNeedSupporter] = useState(true);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const accentOptions = [
+    { c: '#D6B995', label: 'Beige' },
+    { c: '#65C98A', label: 'Green' },
+    { c: '#F5B82E', label: 'Yellow' },
+    { c: '#5DADEC', label: 'Blue' },
+    { c: '#E48F4F', label: 'Orange' },
+    { c: '#B696E0', label: 'Purple' },
+  ];
+  const iconOptions = ['duty', 'sparkle', 'heart', 'shield', 'pie', 'user'];
+
+  const updateTask = (i, v) => {
+    const next = [...tasks]; next[i] = v; setTasks(next);
+  };
+  const addTask = () => setTasks([...tasks, '']);
+  const removeTask = (i) => setTasks(tasks.filter((_, idx) => idx !== i));
+
+  const valid = name.trim() && tasks.some(t => t.trim());
+
+  const back = () => editing ? goto({ name: 'duty-detail', dutyId }) : goto({ name: 'duties' });
+
+  return (
+    <div style={{ paddingBottom: 32 }}>
+      <ScreenHeader
+        title={editing ? '当番を編集' : '当番を作成'}
+        onBack={back}
+        right={editing ? (
+          <button onClick={() => setConfirmOpen(true)} style={{ ...iconBtn, color: T.color.danger, border: 'none', background: 'transparent' }}>
+            <Icon name="close" size={20} color={T.color.danger} />
+          </button>
+        ) : null}
+      />
+
+      {/* live preview card */}
+      <div style={{ padding: '8px 16px 12px' }}>
+        <Card padding={16} style={{ background: T.color.primarySoft, borderColor: T.color.primary + '55' }}>
+          <div style={{ fontSize: 11, color: '#7A5A2E', fontWeight: 700, marginBottom: 10, letterSpacing: 0.4 }}>プレビュー</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div style={{ width: 48, height: 48, borderRadius: T.radius.md,
+              background: accent + '33', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <Icon name={icon} size={24} color="#7A5A2E" />
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 15, fontWeight: 700, color: T.color.textPrimary,
+                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {name || '当番名を入力'}
+              </div>
+              <div style={{ fontSize: 12, color: T.color.textSecondary, marginTop: 2 }}>
+                {tasks.filter(t => t.trim()).length}件のタスク ・ {frequency === 'daily' ? '毎日' : frequency === 'weekly' ? '毎週' : 'スポット'}
+              </div>
+            </div>
+          </div>
+        </Card>
+      </div>
+
+      <div style={{ padding: '8px 20px 0' }}>
+        <FieldLabel>当番名 <span style={{ color: T.color.danger }}>*</span></FieldLabel>
+        <Input value={name} onChange={setName} placeholder="例：食器を洗おう" />
+      </div>
+
+      <div style={{ padding: '20px 20px 0' }}>
+        <FieldLabel>アイコン</FieldLabel>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          {iconOptions.map(ic => {
+            const active = icon === ic;
+            return (
+              <button key={ic} onClick={() => setIcon(ic)} style={{
+                width: 48, height: 48, borderRadius: T.radius.sm,
+                background: active ? accent + '33' : T.color.surface,
+                border: `1.5px solid ${active ? accent : T.color.border}`,
+                cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
+              }}>
+                <Icon name={ic} size={22} color={active ? '#7A5A2E' : T.color.textSecondary} />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div style={{ padding: '20px 20px 0' }}>
+        <FieldLabel>カラー</FieldLabel>
+        <div style={{ display: 'flex', gap: 10 }}>
+          {accentOptions.map(o => {
+            const active = accent === o.c;
+            return (
+              <button key={o.c} onClick={() => setAccent(o.c)} style={{
+                width: 36, height: 36, borderRadius: T.radius.full,
+                background: o.c, border: `3px solid ${active ? '#fff' : 'transparent'}`,
+                boxShadow: active ? `0 0 0 2px ${o.c}` : 'none',
+                cursor: 'pointer',
+              }} aria-label={o.label} />
+            );
+          })}
+        </div>
+      </div>
+
+      <div style={{ padding: '20px 20px 0' }}>
+        <FieldLabel>タスク（説明）<span style={{ color: T.color.danger }}>*</span></FieldLabel>
+        <Card padding={0}>
+          {tasks.map((t, i) => (
+            <div key={i} style={{
+              display: 'flex', alignItems: 'center', gap: 8,
+              padding: '4px 8px 4px 12px',
+              borderBottom: i < tasks.length - 1 ? `1px solid ${T.color.border}` : 'none',
+            }}>
+              <div style={{ width: 6, height: 6, borderRadius: 999, background: accent, flex: 'none' }} />
+              <input value={t} onChange={e => updateTask(i, e.target.value)} placeholder="タスクを入力"
+                style={{ flex: 1, border: 'none', outline: 'none', fontFamily: T.font, fontSize: 14, padding: '12px 0', background: 'transparent', color: T.color.textPrimary }} />
+              {tasks.length > 1 && (
+                <button onClick={() => removeTask(i)} style={{
+                  width: 32, height: 32, borderRadius: 999, background: 'transparent',
+                  border: 'none', cursor: 'pointer', color: T.color.textSecondary,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                }}><Icon name="close" size={16} /></button>
+              )}
+            </div>
+          ))}
+        </Card>
+        <button onClick={addTask} style={{
+          marginTop: 10, display: 'inline-flex', alignItems: 'center', gap: 6,
+          padding: '6px 12px', borderRadius: T.radius.full,
+          background: 'transparent', border: `1px dashed ${T.color.border}`,
+          color: T.color.textSecondary, fontSize: 12, fontWeight: 600,
+          cursor: 'pointer', fontFamily: T.font,
+        }}><Icon name="plus" size={14} />タスクを追加</button>
+      </div>
+
+      <div style={{ padding: '20px 20px 0' }}>
+        <FieldLabel>頻度</FieldLabel>
+        <Segmented value={frequency} onChange={setFrequency} options={[
+          { value: 'daily', label: '毎日' },
+          { value: 'weekly', label: '毎週' },
+          { value: 'spot', label: 'スポット' },
+        ]} />
+      </div>
+
+      <div style={{ padding: '20px 20px 0' }}>
+        <Card padding={0}>
+          <ToggleRow label="サポーターを募集" sub="担当者以外も関わることができます"
+            value={needSupporter} onChange={setNeedSupporter} />
+        </Card>
+      </div>
+
+      <div style={{ padding: '24px 16px 0', display: 'flex', gap: 10 }}>
+        <Button variant="secondary" onClick={back}>キャンセル</Button>
+        <Button variant="primary" full disabled={!valid} icon={editing ? 'check' : 'plus'}
+          onClick={() => { onSaved?.({ name, editing }); back(); }}>
+          {editing ? '保存' : '作成する'}
+        </Button>
+      </div>
+
+      <Sheet open={confirmOpen} onClose={() => setConfirmOpen(false)} title="当番を削除しますか？">
+        <div style={{ padding: '0 20px 8px', fontSize: 13, color: T.color.textSecondary, lineHeight: 1.6 }}>
+          この当番を削除すると、関連する履歴は残りますが新しい担当の追加はできなくなります。
+        </div>
+        <div style={{ padding: '20px 16px 0', display: 'flex', gap: 10 }}>
+          <Button variant="secondary" full onClick={() => setConfirmOpen(false)}>キャンセル</Button>
+          <Button variant="dark" full style={{ background: T.color.danger }}
+            onClick={() => { setConfirmOpen(false); onSaved?.({ deleted: true }); goto({ name: 'duties' }); }}>削除する</Button>
+        </div>
+      </Sheet>
+    </div>
+  );
+}
+
+const ToggleRow = ({ label, sub, value, onChange }) => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '14px 16px' }}>
+    <div style={{ flex: 1 }}>
+      <div style={{ fontSize: 14, fontWeight: 600 }}>{label}</div>
+      {sub && <div style={{ fontSize: 11, color: T.color.textSecondary, marginTop: 2 }}>{sub}</div>}
+    </div>
+    <button onClick={() => onChange(!value)} style={{
+      width: 48, height: 28, borderRadius: 999,
+      background: value ? T.color.primary : '#E0DACC',
+      border: 'none', cursor: 'pointer', position: 'relative',
+      transition: 'background .15s',
+    }}>
+      <span style={{
+        position: 'absolute', top: 2, left: value ? 22 : 2,
+        width: 24, height: 24, borderRadius: 999, background: '#fff',
+        transition: 'left .15s', boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
+      }} />
+    </button>
+  </div>
+);
+
+// ─── WORKSPACE CREATE FLOW ──────────────────────────────────
+function WorkspaceCreateScreen({ goto, onCreated }) {
+  const [step, setStep] = useState('basic'); // basic | initial | confirm | done
+  const [name, setName] = useState('');
+  const [desc, setDesc] = useState('');
+  const [icon, setIcon] = useState('🌿');
+  const [color, setColor] = useState('#65C98A');
+  const [openness, setOpenness] = useState('invite');
+  const [unitName, setUnitName] = useState('サンクス');
+  const [unitSym, setUnitSym] = useState('THX');
+  const [defaultRole, setDefaultRole] = useState('Member');
+  const [enableSplit, setEnableSplit] = useState(true);
+  const [enableDuty, setEnableDuty] = useState(true);
+
+  const iconChoices = ['🌿', '🇯🇵', '✦', '🏠', '🌊', '🔥', '🌸', '⚡', '🛠'];
+  const colorChoices = ['#65C98A', '#5DADEC', '#F5B82E', '#D6B995', '#E48F4F', '#B696E0', '#E48ABF', '#7AC2D9'];
+
+  const stepIdx = { basic: 0, initial: 1, confirm: 2, done: 3 }[step];
+
+  const StepBar = () => (
+    <div style={{ display: 'flex', gap: 6, padding: '0 20px 12px' }}>
+      {[0, 1, 2].map(i => (
+        <div key={i} style={{
+          flex: 1, height: 4, borderRadius: 2,
+          background: i <= stepIdx ? T.color.primary : T.color.border,
+          transition: 'background .2s',
+        }} />
+      ))}
+    </div>
+  );
+
+  if (step === 'done') {
+    return (
+      <div style={{ padding: '40px 24px 24px', textAlign: 'center' }}>
+        <div style={{ width: 96, height: 96, borderRadius: T.radius.full, background: color,
+          margin: '0 auto 20px', display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: 44, color: '#fff', fontWeight: 700,
+          boxShadow: `0 0 0 12px ${color}22` }}>{icon}</div>
+        <div style={{ fontSize: 22, fontWeight: 700, marginBottom: 8 }}>ワークスペースを作成しました</div>
+        <div style={{ fontSize: 13, color: T.color.textSecondary, marginBottom: 28, lineHeight: 1.6 }}>
+          <strong style={{ color: T.color.textPrimary }}>{name}</strong> をはじめましょう。
+        </div>
+        <Card padding={16} style={{ textAlign: 'left', marginBottom: 20 }}>
+          <div style={{ fontSize: 12, color: T.color.textSecondary, fontWeight: 700, marginBottom: 10, letterSpacing: 0.3 }}>次にできること</div>
+          <NextStep icon="invite" label="メンバーを招待する" />
+          <Divider />
+          <NextStep icon="duty" label="当番を作成する" />
+          <Divider />
+          <NextStep icon="send" label="サンクスを送る" />
+        </Card>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <Button variant="primary" full icon="invite" onClick={() => { onCreated?.({ name, icon, color, desc }); goto({ name: 'home' }); }}>メンバーを招待</Button>
+          <Button variant="ghost" full onClick={() => { onCreated?.({ name, icon, color, desc }); goto({ name: 'home' }); }}>ホームへ</Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (step === 'confirm') {
+    return (
+      <div style={{ paddingBottom: 24 }}>
+        <ScreenHeader title="作成内容を確認" subtitle="3 / 3" onBack={() => setStep('initial')} />
+        <StepBar />
+        <div style={{ padding: '0 16px 8px' }}>
+          <Card padding={20} style={{ textAlign: 'center' }}>
+            <div style={{ width: 72, height: 72, borderRadius: T.radius.lg, background: color,
+              margin: '0 auto 12px', display: 'flex', alignItems: 'center', justifyContent: 'center',
+              fontSize: 32, color: '#fff' }}>{icon}</div>
+            <div style={{ fontSize: 18, fontWeight: 700 }}>{name}</div>
+            {desc && <div style={{ fontSize: 12, color: T.color.textSecondary, marginTop: 4, lineHeight: 1.5 }}>{desc}</div>}
+          </Card>
+        </div>
+        <div style={{ padding: '12px 16px' }}>
+          <Card padding={0}>
+            <SummaryRow label="公開設定" value={openness === 'invite' ? '招待制' : 'リンク参加可'} />
+            <Divider />
+            <SummaryRow label="サンクス単位" value={`${unitName}（${unitSym}）`} />
+            <Divider />
+            <SummaryRow label="初期ロール" value={defaultRole} />
+            <Divider />
+            <SummaryRow label="有効な機能" value={
+              <span style={{ display: 'inline-flex', gap: 6, flexWrap: 'wrap' }}>
+                <Badge kind="member">サンクス</Badge>
+                {enableDuty && <Badge kind="role">当番</Badge>}
+                {enableSplit && <Badge kind="info">分配</Badge>}
+              </span>
+            } />
+          </Card>
+        </div>
+        <div style={{ padding: '16px 16px 0', display: 'flex', gap: 10 }}>
+          <Button variant="secondary" onClick={() => setStep('initial')}>戻って修正</Button>
+          <Button variant="primary" full icon="check" onClick={() => setStep('done')}>作成する</Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (step === 'initial') {
+    return (
+      <div style={{ paddingBottom: 24 }}>
+        <ScreenHeader title="初期設定" subtitle="2 / 3" onBack={() => setStep('basic')} />
+        <StepBar />
+        <div style={{ padding: '0 20px 8px', fontSize: 13, color: T.color.textSecondary, lineHeight: 1.5 }}>
+          あとから変更できます。
+        </div>
+
+        <div style={{ padding: '12px 20px 0' }}>
+          <FieldLabel>サンクスの表示名と単位</FieldLabel>
+          <div style={{ display: 'flex', gap: 10 }}>
+            <div style={{ flex: 2 }}>
+              <Input value={unitName} onChange={setUnitName} placeholder="サンクス" />
+            </div>
+            <div style={{ flex: 1 }}>
+              <Input value={unitSym} onChange={setUnitSym} placeholder="THX" />
+            </div>
+          </div>
+        </div>
+
+        <div style={{ padding: '20px 20px 0' }}>
+          <FieldLabel>メンバーの初期ロール</FieldLabel>
+          <Segmented value={defaultRole} onChange={setDefaultRole} options={[
+            { value: 'Member', label: 'Member' },
+            { value: 'Guest', label: 'Guest' },
+          ]} />
+        </div>
+
+        <div style={{ padding: '20px 20px 0' }}>
+          <FieldLabel>機能</FieldLabel>
+          <Card padding={0}>
+            <ToggleRow label="当番" sub="役割と担当を見える化" value={enableDuty} onChange={setEnableDuty} />
+            <Divider />
+            <ToggleRow label="分配" sub="貢献記録から報酬を分ける" value={enableSplit} onChange={setEnableSplit} />
+          </Card>
+        </div>
+
+        <div style={{ padding: '24px 16px 0', display: 'flex', gap: 10 }}>
+          <Button variant="ghost" onClick={() => setStep('confirm')}>スキップ</Button>
+          <Button variant="primary" full onClick={() => setStep('confirm')}>確認へ</Button>
+        </div>
+      </div>
+    );
+  }
+
+  // basic
+  const valid = name.trim().length > 0;
+  return (
+    <div style={{ paddingBottom: 24 }}>
+      <ScreenHeader title="ワークスペースを作成" subtitle="1 / 3" onBack={() => goto({ name: 'home' })} />
+      <StepBar />
+
+      <div style={{ padding: '0 20px 0' }}>
+        <FieldLabel>アイコン & カラー</FieldLabel>
+        <Card padding={16}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 14 }}>
+            <div style={{ width: 64, height: 64, borderRadius: T.radius.md, background: color,
+              display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 32, color: '#fff' }}>{icon}</div>
+            <div style={{ flex: 1, fontSize: 12, color: T.color.textSecondary, lineHeight: 1.5 }}>
+              プレビューはここに表示されます。アイコンとカラーは下から選択できます。
+            </div>
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 12 }}>
+            {iconChoices.map(ic => (
+              <button key={ic} onClick={() => setIcon(ic)} style={{
+                width: 36, height: 36, borderRadius: T.radius.sm,
+                background: icon === ic ? T.color.primarySoft : T.color.bg,
+                border: `1.5px solid ${icon === ic ? T.color.primary : T.color.border}`,
+                cursor: 'pointer', fontSize: 18, fontFamily: T.font,
+              }}>{ic}</button>
+            ))}
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            {colorChoices.map(c => (
+              <button key={c} onClick={() => setColor(c)} style={{
+                width: 28, height: 28, borderRadius: T.radius.full,
+                background: c, border: `3px solid ${color === c ? '#fff' : 'transparent'}`,
+                boxShadow: color === c ? `0 0 0 2px ${c}` : 'none',
+                cursor: 'pointer',
+              }} />
+            ))}
+          </div>
+        </Card>
+      </div>
+
+      <div style={{ padding: '20px 20px 0' }}>
+        <FieldLabel>ワークスペース名 <span style={{ color: T.color.danger }}>*</span></FieldLabel>
+        <Input value={name} onChange={setName} placeholder="例：kuu village #1" />
+      </div>
+
+      <div style={{ padding: '20px 20px 0' }}>
+        <FieldLabel>説明</FieldLabel>
+        <Input value={desc} onChange={setDesc} multiline rows={3} placeholder="どんなコミュニティかを入力" />
+      </div>
+
+      <div style={{ padding: '20px 20px 0' }}>
+        <FieldLabel>公開設定</FieldLabel>
+        <Segmented value={openness} onChange={setOpenness} options={[
+          { value: 'invite', label: '招待制' },
+          { value: 'link', label: 'リンク参加可' },
+        ]} />
+        <div style={{ fontSize: 11, color: T.color.textSecondary, marginTop: 6, lineHeight: 1.4 }}>
+          {openness === 'invite' ? '招待されたメンバーのみ参加できます。' : '招待リンクを知っている人なら誰でも参加できます。'}
+        </div>
+      </div>
+
+      <div style={{ padding: '24px 16px 0' }}>
+        <Button variant="primary" full disabled={!valid} onClick={() => setStep('initial')}>次へ</Button>
+      </div>
+    </div>
+  );
+}
+
+const NextStep = ({ icon, label }) => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 0' }}>
+    <div style={{ width: 32, height: 32, borderRadius: T.radius.full, background: T.color.primarySoft,
+      display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 'none' }}>
+      <Icon name={icon} size={16} color="#7A5A2E" />
+    </div>
+    <span style={{ flex: 1, fontSize: 14, fontWeight: 600 }}>{label}</span>
+    <Icon name="chevron-right" size={16} color={T.color.textSecondary} />
+  </div>
+);
+
+// ─── WORKSPACE EDIT ─────────────────────────────────────────
+function WorkspaceEditScreen({ goto, ws, onSaved }) {
+  const [name, setName] = useState(ws.name);
+  const [desc, setDesc] = useState(ws.desc);
+  const [icon, setIcon] = useState(ws.icon);
+  const [color, setColor] = useState(ws.color);
+  const [openness, setOpenness] = useState('invite');
+  const [unitName, setUnitName] = useState('サンクス');
+  const [unitSym, setUnitSym] = useState('THX');
+  const [enableSplit, setEnableSplit] = useState(true);
+  const [enableDuty, setEnableDuty] = useState(true);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [archiveOpen, setArchiveOpen] = useState(false);
+
+  const iconChoices = ['🌿', '🇯🇵', '✦', '🏠', '🌊', '🔥', '🌸', '⚡', '🛠'];
+  const colorChoices = ['#65C98A', '#5DADEC', '#F5B82E', '#D6B995', '#E48F4F', '#B696E0', '#E48ABF', '#7AC2D9'];
+
+  return (
+    <div style={{ paddingBottom: 32 }}>
+      <ScreenHeader title="ワークスペース設定" onBack={() => goto({ name: 'home' })} />
+
+      <div style={{ padding: '8px 16px 12px' }}>
+        <Card padding={20} style={{ textAlign: 'center', background: T.color.primarySoft, borderColor: T.color.primary + '55' }}>
+          <div style={{ width: 72, height: 72, borderRadius: T.radius.lg, background: color,
+            margin: '0 auto 10px', display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: 32, color: '#fff' }}>{icon}</div>
+          <div style={{ fontSize: 16, fontWeight: 700 }}>{name || '（名称未設定）'}</div>
+          <div style={{ fontSize: 11, color: '#7A5A2E', fontWeight: 600, marginTop: 4 }}>プレビュー</div>
+        </Card>
+      </div>
+
+      <SectionLabel>基本情報</SectionLabel>
+      <div style={{ padding: '0 20px' }}>
+        <Card padding={16}>
+          <FieldLabel>アイコン</FieldLabel>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 14 }}>
+            {iconChoices.map(ic => (
+              <button key={ic} onClick={() => setIcon(ic)} style={{
+                width: 36, height: 36, borderRadius: T.radius.sm,
+                background: icon === ic ? T.color.primarySoft : T.color.bg,
+                border: `1.5px solid ${icon === ic ? T.color.primary : T.color.border}`,
+                cursor: 'pointer', fontSize: 18, fontFamily: T.font,
+              }}>{ic}</button>
+            ))}
+          </div>
+          <FieldLabel>カラー</FieldLabel>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            {colorChoices.map(c => (
+              <button key={c} onClick={() => setColor(c)} style={{
+                width: 28, height: 28, borderRadius: T.radius.full,
+                background: c, border: `3px solid ${color === c ? '#fff' : 'transparent'}`,
+                boxShadow: color === c ? `0 0 0 2px ${c}` : 'none',
+                cursor: 'pointer',
+              }} />
+            ))}
+          </div>
+        </Card>
+      </div>
+
+      <div style={{ padding: '16px 20px 0' }}>
+        <FieldLabel>ワークスペース名</FieldLabel>
+        <Input value={name} onChange={setName} />
+      </div>
+
+      <div style={{ padding: '16px 20px 0' }}>
+        <FieldLabel>説明</FieldLabel>
+        <Input value={desc} onChange={setDesc} multiline rows={3} />
+      </div>
+
+      <SectionLabel>参加設定</SectionLabel>
+      <div style={{ padding: '0 20px 0' }}>
+        <Segmented value={openness} onChange={setOpenness} options={[
+          { value: 'invite', label: '招待制' },
+          { value: 'link', label: 'リンク参加可' },
+        ]} />
+      </div>
+
+      <SectionLabel>機能</SectionLabel>
+      <div style={{ padding: '0 16px' }}>
+        <Card padding={0}>
+          <ToggleRow label="当番" sub="役割と担当を見える化" value={enableDuty} onChange={setEnableDuty} />
+          <Divider />
+          <ToggleRow label="分配" sub="貢献記録から報酬を分ける" value={enableSplit} onChange={setEnableSplit} />
+        </Card>
+      </div>
+
+      <SectionLabel>表示設定</SectionLabel>
+      <div style={{ padding: '0 20px 0' }}>
+        <Card padding={16}>
+          <FieldLabel>サンクスの表示名 / 単位</FieldLabel>
+          <div style={{ display: 'flex', gap: 10 }}>
+            <div style={{ flex: 2 }}><Input value={unitName} onChange={setUnitName} /></div>
+            <div style={{ flex: 1 }}><Input value={unitSym} onChange={setUnitSym} /></div>
+          </div>
+        </Card>
+      </div>
+
+      <SectionLabel>その他</SectionLabel>
+      <div style={{ padding: '0 16px 16px' }}>
+        <Card padding={0}>
+          <Row left={<div style={{ width: 36, height: 36, borderRadius: 999, background: '#F0EBE0',
+              display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Icon name="invite" size={18} /></div>}
+            title="メンバーを招待" subtitle="招待リンクを共有"
+            right={<Icon name="chevron-right" size={16} color={T.color.textSecondary} />}
+            onClick={() => onSaved?.({ kind: 'invite' })} />
+          <Divider inset={64} />
+          <Row left={<div style={{ width: 36, height: 36, borderRadius: 999, background: '#F0EBE0',
+              display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Icon name="copy" size={18} /></div>}
+            title="ワークスペースID をコピー"
+            subtitle="ws_kuu_001"
+            right={<Icon name="chevron-right" size={16} color={T.color.textSecondary} />}
+            onClick={() => onSaved?.({ kind: 'copy' })} />
+        </Card>
+      </div>
+
+      <div style={{ padding: '0 16px 16px' }}>
+        <Card padding={0}>
+          <Row left={<div style={{ width: 36, height: 36, borderRadius: 999, background: '#FBE5E2',
+              display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Icon name="logout" size={18} color={T.color.danger} /></div>}
+            title={<span style={{ color: T.color.danger }}>ワークスペースをアーカイブ</span>}
+            subtitle="閲覧専用にする"
+            onClick={() => setArchiveOpen(true)} />
+        </Card>
+      </div>
+
+      <div style={{ padding: '8px 16px 0', display: 'flex', gap: 10 }}>
+        <Button variant="secondary" onClick={() => goto({ name: 'home' })}>キャンセル</Button>
+        <Button variant="primary" full icon="check" onClick={() => setConfirmOpen(true)}>保存</Button>
+      </div>
+
+      <Sheet open={confirmOpen} onClose={() => setConfirmOpen(false)} title="設定を変更しますか？">
+        <div style={{ padding: '0 20px 8px', fontSize: 13, color: T.color.textSecondary, lineHeight: 1.6 }}>
+          この変更は、ワークスペース内のメンバーに影響します。
+        </div>
+        <div style={{ padding: '20px 16px 0', display: 'flex', gap: 10 }}>
+          <Button variant="secondary" full onClick={() => setConfirmOpen(false)}>キャンセル</Button>
+          <Button variant="primary" full onClick={() => { setConfirmOpen(false); onSaved?.({ name, icon, color, desc }); goto({ name: 'home' }); }}>変更する</Button>
+        </div>
+      </Sheet>
+
+      <Sheet open={archiveOpen} onClose={() => setArchiveOpen(false)} title="アーカイブしますか？">
+        <div style={{ padding: '0 20px 8px', fontSize: 13, color: T.color.textSecondary, lineHeight: 1.6 }}>
+          アーカイブ後はメンバーが閲覧のみ可能になります。あとで戻すこともできます。
+        </div>
+        <div style={{ padding: '20px 16px 0', display: 'flex', gap: 10 }}>
+          <Button variant="secondary" full onClick={() => setArchiveOpen(false)}>キャンセル</Button>
+          <Button variant="dark" full style={{ background: T.color.danger }}
+            onClick={() => { setArchiveOpen(false); onSaved?.({ archived: true }); goto({ name: 'home' }); }}>アーカイブ</Button>
+        </div>
+      </Sheet>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  DutyEditScreen, WorkspaceCreateScreen, WorkspaceEditScreen, ToggleRow,
+});

--- a/docs/design/handoff/project/ios-frame.jsx
+++ b/docs/design/handoff/project/ios-frame.jsx
@@ -1,0 +1,338 @@
+
+// iOS.jsx — Simplified iOS 26 (Liquid Glass) device frame
+// Based on the iOS 26 UI Kit + Figma status bar spec. No assets, no deps.
+// Exports: IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard
+
+// ─────────────────────────────────────────────────────────────
+// Status bar
+// ─────────────────────────────────────────────────────────────
+function IOSStatusBar({ dark = false, time = '9:41' }) {
+  const c = dark ? '#fff' : '#000';
+  return (
+    <div style={{
+      display: 'flex', gap: 154, alignItems: 'center', justifyContent: 'center',
+      padding: '21px 24px 19px', boxSizing: 'border-box',
+      position: 'relative', zIndex: 20, width: '100%',
+    }}>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', paddingTop: 1.5 }}>
+        <span style={{
+          fontFamily: '-apple-system, "SF Pro", system-ui', fontWeight: 590,
+          fontSize: 17, lineHeight: '22px', color: c,
+        }}>{time}</span>
+      </div>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7, paddingTop: 1, paddingRight: 1 }}>
+        <svg width="19" height="12" viewBox="0 0 19 12">
+          <rect x="0" y="7.5" width="3.2" height="4.5" rx="0.7" fill={c}/>
+          <rect x="4.8" y="5" width="3.2" height="7" rx="0.7" fill={c}/>
+          <rect x="9.6" y="2.5" width="3.2" height="9.5" rx="0.7" fill={c}/>
+          <rect x="14.4" y="0" width="3.2" height="12" rx="0.7" fill={c}/>
+        </svg>
+        <svg width="17" height="12" viewBox="0 0 17 12">
+          <path d="M8.5 3.2C10.8 3.2 12.9 4.1 14.4 5.6L15.5 4.5C13.7 2.7 11.2 1.5 8.5 1.5C5.8 1.5 3.3 2.7 1.5 4.5L2.6 5.6C4.1 4.1 6.2 3.2 8.5 3.2Z" fill={c}/>
+          <path d="M8.5 6.8C9.9 6.8 11.1 7.3 12 8.2L13.1 7.1C11.8 5.9 10.2 5.1 8.5 5.1C6.8 5.1 5.2 5.9 3.9 7.1L5 8.2C5.9 7.3 7.1 6.8 8.5 6.8Z" fill={c}/>
+          <circle cx="8.5" cy="10.5" r="1.5" fill={c}/>
+        </svg>
+        <svg width="27" height="13" viewBox="0 0 27 13">
+          <rect x="0.5" y="0.5" width="23" height="12" rx="3.5" stroke={c} strokeOpacity="0.35" fill="none"/>
+          <rect x="2" y="2" width="20" height="9" rx="2" fill={c}/>
+          <path d="M25 4.5V8.5C25.8 8.2 26.5 7.2 26.5 6.5C26.5 5.8 25.8 4.8 25 4.5Z" fill={c} fillOpacity="0.4"/>
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Liquid glass pill — blur + tint + shine
+// ─────────────────────────────────────────────────────────────
+function IOSGlassPill({ children, dark = false, style = {} }) {
+  return (
+    <div style={{
+      height: 44, minWidth: 44, borderRadius: 9999,
+      position: 'relative', overflow: 'hidden',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      boxShadow: dark
+        ? '0 2px 6px rgba(0,0,0,0.35), 0 6px 16px rgba(0,0,0,0.2)'
+        : '0 1px 3px rgba(0,0,0,0.07), 0 3px 10px rgba(0,0,0,0.06)',
+      ...style,
+    }}>
+      {/* blur + tint */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.28)' : 'rgba(255,255,255,0.5)',
+      }} />
+      {/* shine */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15), inset -1px -1px 1px rgba(255,255,255,0.08)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+      }} />
+      <div style={{ position: 'relative', zIndex: 1, display: 'flex', alignItems: 'center', padding: '0 4px' }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Navigation bar — glass pills + large title
+// ─────────────────────────────────────────────────────────────
+function IOSNavBar({ title = 'Title', dark = false, trailingIcon = true }) {
+  const muted = dark ? 'rgba(255,255,255,0.6)' : '#404040';
+  const text = dark ? '#fff' : '#000';
+  const pillIcon = (content) => (
+    <IOSGlassPill dark={dark}>
+      <div style={{ width: 36, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        {content}
+      </div>
+    </IOSGlassPill>
+  );
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', gap: 10,
+      paddingTop: 62, paddingBottom: 10, position: 'relative', zIndex: 5,
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '0 16px',
+      }}>
+        {/* back chevron */}
+        {pillIcon(
+          <svg width="12" height="20" viewBox="0 0 12 20" fill="none" style={{ marginLeft: -1 }}>
+            <path d="M10 2L2 10l8 8" stroke={muted} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        )}
+        {/* trailing ellipsis */}
+        {trailingIcon && pillIcon(
+          <svg width="22" height="6" viewBox="0 0 22 6">
+            <circle cx="3" cy="3" r="2.5" fill={muted}/>
+            <circle cx="11" cy="3" r="2.5" fill={muted}/>
+            <circle cx="19" cy="3" r="2.5" fill={muted}/>
+          </svg>
+        )}
+      </div>
+      {/* large title */}
+      <div style={{
+        padding: '0 16px',
+        fontFamily: '-apple-system, system-ui',
+        fontSize: 34, fontWeight: 700, lineHeight: '41px',
+        color: text, letterSpacing: 0.4,
+      }}>{title}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Grouped list (inset card, r:26) + row (52px)
+// ─────────────────────────────────────────────────────────────
+function IOSListRow({ title, detail, icon, chevron = true, isLast = false, dark = false }) {
+  const text = dark ? '#fff' : '#000';
+  const sec = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const ter = dark ? 'rgba(235,235,245,0.3)' : 'rgba(60,60,67,0.3)';
+  const sep = dark ? 'rgba(84,84,88,0.65)' : 'rgba(60,60,67,0.12)';
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', minHeight: 52,
+      padding: '0 16px', position: 'relative',
+      fontFamily: '-apple-system, system-ui', fontSize: 17,
+      letterSpacing: -0.43,
+    }}>
+      {icon && (
+        <div style={{
+          width: 30, height: 30, borderRadius: 7, background: icon,
+          marginRight: 12, flexShrink: 0,
+        }} />
+      )}
+      <div style={{ flex: 1, color: text }}>{title}</div>
+      {detail && <span style={{ color: sec, marginRight: 6 }}>{detail}</span>}
+      {chevron && (
+        <svg width="8" height="14" viewBox="0 0 8 14" style={{ flexShrink: 0 }}>
+          <path d="M1 1l6 6-6 6" stroke={ter} strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      )}
+      {!isLast && (
+        <div style={{
+          position: 'absolute', bottom: 0, right: 0,
+          left: icon ? 58 : 16, height: 0.5, background: sep,
+        }} />
+      )}
+    </div>
+  );
+}
+
+function IOSList({ header, children, dark = false }) {
+  const hc = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const bg = dark ? '#1C1C1E' : '#fff';
+  return (
+    <div>
+      {header && (
+        <div style={{
+          fontFamily: '-apple-system, system-ui', fontSize: 13,
+          color: hc, textTransform: 'uppercase',
+          padding: '8px 36px 6px', letterSpacing: -0.08,
+        }}>{header}</div>
+      )}
+      <div style={{
+        background: bg, borderRadius: 26,
+        margin: '0 16px', overflow: 'hidden',
+      }}>{children}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Device frame
+// ─────────────────────────────────────────────────────────────
+function IOSDevice({
+  children, width = 402, height = 874, dark = false,
+  title, keyboard = false,
+}) {
+  return (
+    <div style={{
+      width, height, borderRadius: 48, overflow: 'hidden',
+      position: 'relative', background: dark ? '#000' : '#F2F2F7',
+      boxShadow: '0 40px 80px rgba(0,0,0,0.18), 0 0 0 1px rgba(0,0,0,0.12)',
+      fontFamily: '-apple-system, system-ui, sans-serif',
+      WebkitFontSmoothing: 'antialiased',
+    }}>
+      {/* dynamic island */}
+      <div style={{
+        position: 'absolute', top: 11, left: '50%', transform: 'translateX(-50%)',
+        width: 126, height: 37, borderRadius: 24, background: '#000', zIndex: 50,
+      }} />
+      {/* status bar (absolute) */}
+      <div style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 10 }}>
+        <IOSStatusBar dark={dark} />
+      </div>
+      {/* nav + content */}
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        {title !== undefined && <IOSNavBar title={title} dark={dark} />}
+        <div style={{ flex: 1, overflow: 'auto' }}>{children}</div>
+        {keyboard && <IOSKeyboard dark={dark} />}
+      </div>
+      {/* home indicator — always on top */}
+      <div style={{
+        position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 60,
+        height: 34, display: 'flex', justifyContent: 'center', alignItems: 'flex-end',
+        paddingBottom: 8, pointerEvents: 'none',
+      }}>
+        <div style={{
+          width: 139, height: 5, borderRadius: 100,
+          background: dark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.25)',
+        }} />
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Keyboard — iOS 26 liquid glass
+// ─────────────────────────────────────────────────────────────
+function IOSKeyboard({ dark = false }) {
+  const glyph = dark ? 'rgba(255,255,255,0.7)' : '#595959';
+  const sugg = dark ? 'rgba(255,255,255,0.6)' : '#333';
+  const keyBg = dark ? 'rgba(255,255,255,0.22)' : 'rgba(255,255,255,0.85)';
+
+  // special-key icons
+  const icons = {
+    shift: <svg width="19" height="17" viewBox="0 0 19 17"><path d="M9.5 1L1 9.5h4.5V16h8V9.5H18L9.5 1z" fill={glyph}/></svg>,
+    del: <svg width="23" height="17" viewBox="0 0 23 17"><path d="M7 1h13a2 2 0 012 2v11a2 2 0 01-2 2H7l-6-7.5L7 1z" fill="none" stroke={glyph} strokeWidth="1.6" strokeLinejoin="round"/><path d="M10 5l7 7M17 5l-7 7" stroke={glyph} strokeWidth="1.6" strokeLinecap="round"/></svg>,
+    ret: <svg width="20" height="14" viewBox="0 0 20 14"><path d="M18 1v6H4m0 0l4-4M4 7l4 4" fill="none" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/></svg>,
+  };
+
+  const key = (content, { w, flex, ret, fs = 25, k } = {}) => (
+    <div key={k} style={{
+      height: 42, borderRadius: 8.5,
+      flex: flex ? 1 : undefined, width: w, minWidth: 0,
+      background: ret ? '#08f' : keyBg,
+      boxShadow: '0 1px 0 rgba(0,0,0,0.075)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontFamily: '-apple-system, "SF Compact", system-ui',
+      fontSize: fs, fontWeight: 458, color: ret ? '#fff' : glyph,
+    }}>{content}</div>
+  );
+
+  const row = (keys, pad = 0) => (
+    <div style={{ display: 'flex', gap: 6.5, justifyContent: 'center', padding: `0 ${pad}px` }}>
+      {keys.map(l => key(l, { flex: true, k: l }))}
+    </div>
+  );
+
+  return (
+    <div style={{
+      position: 'relative', zIndex: 15, borderRadius: 27, overflow: 'hidden',
+      padding: '11px 0 2px',
+      display: 'flex', flexDirection: 'column', alignItems: 'center',
+      boxShadow: dark
+        ? '0 -2px 20px rgba(0,0,0,0.09)'
+        : '0 -1px 6px rgba(0,0,0,0.018), 0 -3px 20px rgba(0,0,0,0.012)',
+    }}>
+      {/* liquid glass bg — same recipe as nav pills */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.14)' : 'rgba(255,255,255,0.25)',
+      }} />
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+        pointerEvents: 'none',
+      }} />
+
+      {/* autocorrect bar */}
+      <div style={{
+        display: 'flex', gap: 20, alignItems: 'center',
+        padding: '8px 22px 13px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {['"The"', 'the', 'to'].map((w, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && <div style={{ width: 1, height: 25, background: '#ccc', opacity: 0.3 }} />}
+            <div style={{
+              flex: 1, textAlign: 'center',
+              fontFamily: '-apple-system, system-ui', fontSize: 17,
+              color: sugg, letterSpacing: -0.43, lineHeight: '22px',
+            }}>{w}</div>
+          </React.Fragment>
+        ))}
+      </div>
+
+      {/* key layout */}
+      <div style={{
+        display: 'flex', flexDirection: 'column', gap: 13,
+        padding: '0 6.5px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {row(['q','w','e','r','t','y','u','i','o','p'])}
+        {row(['a','s','d','f','g','h','j','k','l'], 20)}
+        <div style={{ display: 'flex', gap: 14.25, alignItems: 'center' }}>
+          {key(icons.shift, { w: 45, k: 'shift' })}
+          <div style={{ display: 'flex', gap: 6.5, flex: 1 }}>
+            {['z','x','c','v','b','n','m'].map(l => key(l, { flex: true, k: l }))}
+          </div>
+          {key(icons.del, { w: 45, k: 'del' })}
+        </div>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          {key('ABC', { w: 92.25, fs: 18, k: 'abc' })}
+          {key('', { flex: true, k: 'space' })}
+          {key(icons.ret, { w: 92.25, ret: true, k: 'ret' })}
+        </div>
+      </div>
+
+      {/* bottom spacer (emoji+mic area, icons omitted) */}
+      <div style={{ height: 56, width: '100%', position: 'relative' }} />
+    </div>
+  );
+}
+
+Object.assign(window, {
+  IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard,
+});

--- a/docs/design/handoff/project/primitives.jsx
+++ b/docs/design/handoff/project/primitives.jsx
@@ -1,0 +1,335 @@
+// Toban primitives
+const { useState, useEffect, useRef, useMemo, createContext, useContext, Fragment } = React;
+const T = window.TOBAN;
+
+// ─── icons ─────────────────────────────────────────────────────
+const Icon = ({ name, size = 22, color = 'currentColor', stroke = 1.7 }) => {
+  const p = { width: size, height: size, viewBox: '0 0 24 24', fill: 'none',
+    stroke: color, strokeWidth: stroke, strokeLinecap: 'round', strokeLinejoin: 'round' };
+  switch (name) {
+    case 'home': return <svg {...p}><path d="M3.5 11L12 4l8.5 7v9a1.5 1.5 0 0 1-1.5 1.5h-3v-6h-8v6H5A1.5 1.5 0 0 1 3.5 20z"/></svg>;
+    case 'duty': return <svg {...p}><circle cx="12" cy="8" r="3.5"/><path d="M5 20c0-3.5 3-6 7-6s7 2.5 7 6"/><circle cx="18" cy="6" r="2.5"/></svg>;
+    case 'split': return <svg {...p}><circle cx="12" cy="12" r="8.5"/><path d="M12 3.5v8.5l6 6"/></svg>;
+    case 'members': return <svg {...p}><circle cx="9" cy="8" r="3.5"/><circle cx="17" cy="9.5" r="2.8"/><path d="M3 19c0-3 2.5-5.5 6-5.5s6 2.5 6 5.5"/><path d="M15 17c.6-2 2-3 3.5-3 2 0 3.5 1.5 3.5 3.5"/></svg>;
+    case 'wallet': return <svg {...p}><rect x="3" y="6" width="18" height="13" rx="2.5"/><path d="M3 9h18"/><circle cx="17" cy="14" r="1.3" fill={color}/></svg>;
+    case 'bell': return <svg {...p}><path d="M6 17V11a6 6 0 0 1 12 0v6l1.5 2H4.5z"/><path d="M10 21h4"/></svg>;
+    case 'search': return <svg {...p}><circle cx="11" cy="11" r="6.5"/><path d="M16 16l4 4"/></svg>;
+    case 'plus': return <svg {...p}><path d="M12 5v14M5 12h14"/></svg>;
+    case 'edit': return <svg {...p}><path d="M4 20h4l10-10-4-4L4 16z"/><path d="M14 6l4 4"/></svg>;
+    case 'gear': return <svg {...p}><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 0 0-.1-1.2l2-1.5-2-3.4-2.3.9a7 7 0 0 0-2-1.2L14 3h-4l-.6 2.6a7 7 0 0 0-2 1.2l-2.3-.9-2 3.4 2 1.5A7 7 0 0 0 5 12c0 .4 0 .8.1 1.2l-2 1.5 2 3.4 2.3-.9a7 7 0 0 0 2 1.2L10 21h4l.6-2.6a7 7 0 0 0 2-1.2l2.3.9 2-3.4-2-1.5c.1-.4.1-.8.1-1.2z"/></svg>;
+    case 'send': return <svg {...p}><path d="M21 3L3 11l7 2 2 7z"/><path d="M21 3l-11 11"/></svg>;
+    case 'check': return <svg {...p}><path d="M5 12.5l4.5 4.5L19 7.5"/></svg>;
+    case 'chevron-right': return <svg {...p}><path d="M9 5l7 7-7 7"/></svg>;
+    case 'chevron-left': return <svg {...p}><path d="M15 5l-7 7 7 7"/></svg>;
+    case 'chevron-down': return <svg {...p}><path d="M5 9l7 7 7-7"/></svg>;
+    case 'close': return <svg {...p}><path d="M6 6l12 12M18 6L6 18"/></svg>;
+    case 'arrow-right': return <svg {...p}><path d="M5 12h14M13 6l6 6-6 6"/></svg>;
+    case 'sparkle': return <svg {...p}><path d="M12 3l2 6 6 2-6 2-2 6-2-6-6-2 6-2z"/></svg>;
+    case 'heart': return <svg {...p}><path d="M12 20s-7-4.5-7-10a4 4 0 0 1 7-2.5A4 4 0 0 1 19 10c0 5.5-7 10-7 10z"/></svg>;
+    case 'shield': return <svg {...p}><path d="M12 3l8 3v6c0 5-3.5 8.5-8 9-4.5-.5-8-4-8-9V6z"/></svg>;
+    case 'user': return <svg {...p}><circle cx="12" cy="8.5" r="3.8"/><path d="M5 20c0-3.5 3-6 7-6s7 2.5 7 6"/></svg>;
+    case 'invite': return <svg {...p}><circle cx="9" cy="9" r="3.5"/><path d="M3 19c0-3 2.5-5.5 6-5.5s6 2.5 6 5.5"/><path d="M18 8v6M15 11h6"/></svg>;
+    case 'copy': return <svg {...p}><rect x="8" y="8" width="12" height="12" rx="2"/><path d="M16 8V5a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h3"/></svg>;
+    case 'logout': return <svg {...p}><path d="M14 3h5a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1h-5"/><path d="M10 16l-4-4 4-4"/><path d="M16 12H6"/></svg>;
+    case 'qr': return <svg {...p}><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 14h3v3M21 14v7M14 21h3"/></svg>;
+    case 'pie': return <svg {...p}><path d="M12 3v9l8 4a9 9 0 1 1-8-13z"/></svg>;
+    default: return null;
+  }
+};
+
+// ─── status badge ─────────────────────────────────────────────
+const Badge = ({ kind = 'member', children, style = {} }) => {
+  const palette = {
+    member: { bg: '#E5F5EC', fg: '#2F8B58' },
+    lead: { bg: T.color.primarySoft, fg: '#A07310' },
+    supporter: { bg: '#E8E2D4', fg: '#7A5A2E' },
+    role: { bg: '#F2EAD9', fg: '#7A5A2E' },
+    danger: { bg: '#FBE5E2', fg: '#B5382C' },
+    info: { bg: '#E2F0FB', fg: '#2870A8' },
+  };
+  const p = palette[kind] || palette.member;
+  return <span style={{
+    display: 'inline-flex', alignItems: 'center', gap: 4,
+    padding: '3px 10px', borderRadius: T.radius.full,
+    background: p.bg, color: p.fg, fontSize: 12, fontWeight: 600,
+    ...style,
+  }}>{children}</span>;
+};
+
+// ─── button ───────────────────────────────────────────────────
+const Button = ({ children, variant = 'primary', size = 'md', onClick, disabled, full, icon, style = {} }) => {
+  const sizes = { sm: { h: 36, fs: 14, px: 14 }, md: { h: 48, fs: 15, px: 20 }, lg: { h: 56, fs: 16, px: 24 } };
+  const s = sizes[size];
+  const base = {
+    height: s.h, padding: `0 ${s.px}px`, borderRadius: T.radius.full,
+    fontSize: s.fs, fontWeight: 600, fontFamily: T.font,
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+    border: 'none', cursor: disabled ? 'not-allowed' : 'pointer',
+    width: full ? '100%' : undefined,
+    transition: 'all .15s ease', userSelect: 'none',
+  };
+  const variants = {
+    primary: { background: disabled ? '#F0E7CB' : T.color.primary, color: disabled ? '#B0A179' : T.color.textPrimary, boxShadow: disabled ? 'none' : '0 1px 0 rgba(0,0,0,0.04)' },
+    soft: { background: T.color.primarySoft, color: '#7A5A2E' },
+    secondary: { background: T.color.surface, color: T.color.textPrimary, border: `1px solid ${T.color.border}` },
+    ghost: { background: 'transparent', color: T.color.textSecondary },
+    danger: { background: T.color.surface, color: T.color.danger, border: `1px solid ${T.color.border}` },
+    dark: { background: T.color.textPrimary, color: '#fff' },
+  };
+  return (
+    <button disabled={disabled} onClick={onClick} style={{ ...base, ...variants[variant], ...style }}
+      onMouseDown={e => { if (!disabled) e.currentTarget.style.transform = 'scale(0.98)'; }}
+      onMouseUp={e => e.currentTarget.style.transform = 'scale(1)'}
+      onMouseLeave={e => e.currentTarget.style.transform = 'scale(1)'}>
+      {icon && <Icon name={icon} size={16} />}
+      {children}
+    </button>
+  );
+};
+
+// ─── card ─────────────────────────────────────────────────────
+const Card = ({ children, style = {}, padding = 16, onClick, accent }) => (
+  <div onClick={onClick} style={{
+    background: T.color.surface,
+    borderRadius: T.radius.md,
+    border: `1px solid ${T.color.border}`,
+    boxShadow: T.shadow[1],
+    padding,
+    cursor: onClick ? 'pointer' : 'default',
+    transition: 'transform .15s ease',
+    position: 'relative', overflow: 'hidden',
+    ...style,
+  }}>
+    {children}
+  </div>
+);
+
+// ─── avatar ──────────────────────────────────────────────────
+const palettes = ['#F5B82E', '#65C98A', '#5DADEC', '#D6B995', '#E48F4F', '#B696E0', '#E48ABF'];
+function avatarColor(seed = '') {
+  let h = 0; for (const c of seed) h = (h * 31 + c.charCodeAt(0)) >>> 0;
+  return palettes[h % palettes.length];
+}
+const Avatar = ({ name = '?', size = 36, src }) => {
+  const initials = name.replace(/[^a-zA-Z\u3040-\u30ff\u4e00-\u9fff]/g, '').slice(0, 2).toUpperCase() || '?';
+  return (
+    <div style={{
+      width: size, height: size, borderRadius: T.radius.full,
+      background: avatarColor(name), color: '#fff',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontWeight: 700, fontSize: size * 0.42, flex: 'none',
+      backgroundImage: src ? `url(${src})` : undefined,
+      backgroundSize: 'cover', backgroundPosition: 'center',
+      letterSpacing: -0.5,
+    }}>{!src && initials}</div>
+  );
+};
+
+// ─── input ────────────────────────────────────────────────────
+const Input = ({ icon, value, onChange, placeholder, type = 'text', style = {}, multiline, rows = 3 }) => {
+  const wrap = {
+    display: 'flex', alignItems: multiline ? 'flex-start' : 'center', gap: 8,
+    padding: multiline ? '12px 14px' : '0 14px',
+    height: multiline ? undefined : 48,
+    background: T.color.surface,
+    border: `1px solid ${T.color.border}`,
+    borderRadius: T.radius.sm,
+    fontFamily: T.font,
+    ...style,
+  };
+  const inputStyle = {
+    flex: 1, border: 'none', outline: 'none', background: 'transparent',
+    fontSize: 15, fontFamily: T.font, color: T.color.textPrimary,
+    width: '100%', padding: 0, resize: 'none',
+  };
+  return (
+    <div style={wrap}>
+      {icon && <Icon name={icon} size={18} color={T.color.textSecondary} />}
+      {multiline
+        ? <textarea value={value} onChange={e => onChange?.(e.target.value)} placeholder={placeholder} rows={rows} style={inputStyle} />
+        : <input type={type} value={value} onChange={e => onChange?.(e.target.value)} placeholder={placeholder} style={inputStyle} />}
+    </div>
+  );
+};
+
+// ─── chip / segmented ────────────────────────────────────────
+const Chip = ({ children, active, onClick, icon }) => (
+  <button onClick={onClick} style={{
+    display: 'inline-flex', alignItems: 'center', gap: 6,
+    height: 34, padding: '0 14px', borderRadius: T.radius.full,
+    background: active ? T.color.textPrimary : T.color.surface,
+    color: active ? '#fff' : T.color.textPrimary,
+    border: `1px solid ${active ? T.color.textPrimary : T.color.border}`,
+    fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: T.font,
+    whiteSpace: 'nowrap',
+  }}>
+    {icon && <Icon name={icon} size={14} />}
+    {children}
+  </button>
+);
+
+const Segmented = ({ options, value, onChange }) => (
+  <div style={{
+    display: 'flex', padding: 4, background: '#F0EBE0',
+    borderRadius: T.radius.full, gap: 2,
+  }}>
+    {options.map(opt => (
+      <button key={opt.value} onClick={() => onChange(opt.value)} style={{
+        flex: 1, height: 36, border: 'none',
+        background: value === opt.value ? T.color.surface : 'transparent',
+        borderRadius: T.radius.full,
+        fontSize: 13, fontWeight: 600, cursor: 'pointer',
+        color: value === opt.value ? T.color.textPrimary : T.color.textSecondary,
+        boxShadow: value === opt.value ? '0 1px 3px rgba(0,0,0,0.06)' : 'none',
+        fontFamily: T.font,
+      }}>{opt.label}</button>
+    ))}
+  </div>
+);
+
+// ─── list row ────────────────────────────────────────────────
+const Row = ({ left, title, subtitle, right, onClick, style = {} }) => (
+  <div onClick={onClick} style={{
+    display: 'flex', alignItems: 'center', gap: 12,
+    padding: '12px 16px', cursor: onClick ? 'pointer' : 'default',
+    ...style,
+  }}>
+    {left}
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{ fontSize: 15, fontWeight: 600, color: T.color.textPrimary, lineHeight: 1.3 }}>{title}</div>
+      {subtitle && <div style={{ fontSize: 12, color: T.color.textSecondary, marginTop: 2, lineHeight: 1.4, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{subtitle}</div>}
+    </div>
+    {right}
+  </div>
+);
+
+// ─── divider ─────────────────────────────────────────────────
+const Divider = ({ inset = 0 }) => (
+  <div style={{ height: 1, background: T.color.border, marginLeft: inset }} />
+);
+
+// ─── header ──────────────────────────────────────────────────
+const ScreenHeader = ({ title, onBack, right, subtitle }) => (
+  <div style={{
+    display: 'flex', alignItems: 'center', gap: 8,
+    padding: '8px 16px 12px',
+    background: T.color.bg, borderBottom: `1px solid transparent`,
+  }}>
+    {onBack && (
+      <button onClick={onBack} style={{
+        width: 36, height: 36, borderRadius: T.radius.full,
+        background: 'transparent', border: 'none', cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}><Icon name="chevron-left" size={22} /></button>
+    )}
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{ fontSize: 17, fontWeight: 700, color: T.color.textPrimary }}>{title}</div>
+      {subtitle && <div style={{ fontSize: 12, color: T.color.textSecondary, marginTop: 2 }}>{subtitle}</div>}
+    </div>
+    {right}
+  </div>
+);
+
+// ─── bottom nav ──────────────────────────────────────────────
+const BottomNav = ({ active, onChange }) => {
+  const items = [
+    { key: 'home', label: 'ホーム', icon: 'home' },
+    { key: 'duties', label: '当番', icon: 'duty' },
+    { key: 'splits', label: '分配', icon: 'split' },
+    { key: 'members', label: 'メンバー', icon: 'members' },
+    { key: 'wallet', label: 'ウォレット', icon: 'wallet' },
+  ];
+  return (
+    <div style={{
+      display: 'flex', justifyContent: 'space-around',
+      padding: '8px 8px 22px',
+      background: T.color.surface,
+      borderTop: `1px solid ${T.color.border}`,
+    }}>
+      {items.map(it => {
+        const isActive = active === it.key;
+        return (
+          <button key={it.key} onClick={() => onChange(it.key)} style={{
+            background: 'transparent', border: 'none', cursor: 'pointer',
+            display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3,
+            padding: '6px 8px', flex: 1,
+            color: isActive ? T.color.primary : T.color.textSecondary,
+            fontFamily: T.font,
+          }}>
+            <div style={{
+              width: 44, height: 28, borderRadius: T.radius.full,
+              background: isActive ? T.color.primarySoft : 'transparent',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              transition: 'background .15s',
+            }}>
+              <Icon name={it.icon} size={20} color={isActive ? '#A07310' : T.color.textSecondary} stroke={isActive ? 2 : 1.7} />
+            </div>
+            <span style={{ fontSize: 10, fontWeight: isActive ? 700 : 500 }}>{it.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+// ─── modal / sheet ──────────────────────────────────────────
+const Sheet = ({ open, onClose, children, title }) => {
+  if (!open) return null;
+  return (
+    <div style={{
+      position: 'absolute', inset: 0, zIndex: 100,
+      display: 'flex', flexDirection: 'column', justifyContent: 'flex-end',
+      background: T.color.overlay,
+      animation: 'tobanFade .18s ease',
+    }} onClick={onClose}>
+      <div onClick={e => e.stopPropagation()} style={{
+        background: T.color.surface,
+        borderTopLeftRadius: T.radius.lg, borderTopRightRadius: T.radius.lg,
+        padding: '8px 0 28px',
+        animation: 'tobanSlide .22s ease',
+        maxHeight: '88%', overflow: 'auto',
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '6px 0 4px' }}>
+          <div style={{ width: 36, height: 4, background: T.color.border, borderRadius: 2 }} />
+        </div>
+        {title && <div style={{ padding: '8px 20px 12px', fontSize: 17, fontWeight: 700 }}>{title}</div>}
+        {children}
+      </div>
+    </div>
+  );
+};
+
+// ─── toast ──────────────────────────────────────────────────
+const Toast = ({ children, show }) => (
+  <div style={{
+    position: 'absolute', left: 16, right: 16, bottom: 96, zIndex: 200,
+    background: T.color.textPrimary, color: '#fff',
+    borderRadius: T.radius.full, padding: '12px 18px',
+    fontSize: 13, fontWeight: 600, textAlign: 'center',
+    transform: show ? 'translateY(0)' : 'translateY(20px)',
+    opacity: show ? 1 : 0,
+    transition: 'all .25s ease',
+    pointerEvents: 'none',
+    boxShadow: T.shadow[3],
+  }}>{children}</div>
+);
+
+// ─── empty state ─────────────────────────────────────────────
+const EmptyState = ({ icon, title, body, action }) => (
+  <div style={{ padding: '48px 24px', textAlign: 'center' }}>
+    <div style={{
+      width: 56, height: 56, borderRadius: T.radius.full,
+      background: T.color.primarySoft, margin: '0 auto 16px',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+    }}><Icon name={icon} size={26} color="#A07310" /></div>
+    <div style={{ fontSize: 15, fontWeight: 700, color: T.color.textPrimary, marginBottom: 6 }}>{title}</div>
+    {body && <div style={{ fontSize: 13, color: T.color.textSecondary, marginBottom: 20, lineHeight: 1.5 }}>{body}</div>}
+    {action}
+  </div>
+);
+
+// expose
+Object.assign(window, {
+  Icon, Badge, Button, Card, Avatar, Input, Chip, Segmented, Row, Divider,
+  ScreenHeader, BottomNav, Sheet, Toast, EmptyState,
+});

--- a/docs/design/handoff/project/quests.jsx
+++ b/docs/design/handoff/project/quests.jsx
@@ -1,0 +1,410 @@
+// Quest / 当番シェア (RoleShare) screens
+
+window.TOBAN_QUESTS_DATA = {
+  // shares per duty: array of { name, pct } summing to 100
+  shares: {
+    dishes: [
+      { name: 'ryu', pct: 40 }, { name: 'sg', pct: 30 },
+      { name: 'eri', pct: 20 }, { name: 'homma', pct: 10 },
+    ],
+    breakfast: [
+      { name: 'atsu', pct: 50 }, { name: 'homma', pct: 30 }, { name: 'ryoma', pct: 20 },
+    ],
+    onoono: [
+      { name: 'koichi', pct: 45 }, { name: 'ryu', pct: 25 },
+      { name: 'sg', pct: 20 }, { name: 'eri', pct: 10 },
+    ],
+    food: [
+      { name: 'ryoma', pct: 100 },
+    ],
+  },
+  // quests
+  quests: [
+    { id: 'q1', dutyId: 'dishes', title: '夕食後の食器洗いを手伝う',
+      desc: '食器を洗って、棚に戻してください。', creator: 'ryu', share: 10,
+      state: 'open', count: 3, applicant: null },
+    { id: 'q2', dutyId: 'dishes', title: '洗剤を補充する',
+      desc: '台所の洗剤を新しく買って補充。レシートはあとで共有OK。',
+      creator: 'ryu', share: 5, state: 'inprogress', applicant: 'sg' },
+    { id: 'q3', dutyId: 'dishes', title: '食器棚を整理する',
+      desc: '食器棚の中を片付けて、きれいに並べる。',
+      creator: 'sg', share: 5, state: 'review', applicant: 'eri', approvals: 1 },
+    { id: 'q4', dutyId: 'breakfast', title: '朝のコーヒーを淹れる',
+      desc: '朝7時頃にコーヒーを淹れる。', creator: 'atsu', share: 8,
+      state: 'open', count: 1, applicant: null },
+    { id: 'q5', dutyId: 'dishes', title: 'ふきんを洗う', desc: 'ふきんを洗濯。',
+      creator: 'ryu', share: 3, state: 'done', applicant: 'homma' },
+  ],
+};
+
+const STATE_LABELS = {
+  open: { label: '募集中', bg: '#FFF2CF', fg: '#7A5A2E' },
+  inprogress: { label: '進行中', bg: '#E5F1FB', fg: '#2D6FA8' },
+  review: { label: '確認待ち', bg: '#F2EBF8', fg: '#6E4DAA' },
+  done: { label: '完了', bg: '#E5F5EC', fg: '#2F8B58' },
+  cancelled: { label: 'キャンセル', bg: '#F0EBE0', fg: T.color.textSecondary },
+};
+
+const QStateBadge = ({ state }) => {
+  const s = STATE_LABELS[state] || STATE_LABELS.open;
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center',
+      padding: '3px 10px', borderRadius: 999,
+      background: s.bg, color: s.fg,
+      fontSize: 11, fontWeight: 700, letterSpacing: 0.2,
+    }}>{s.label}</span>
+  );
+};
+
+function userShareInDuty(dutyId, userName = 'ryoma') {
+  const arr = (window.TOBAN_QUESTS_DATA.shares[dutyId] || []);
+  return arr.find(x => x.name === userName)?.pct || 0;
+}
+
+// ─── Share distribution bar ─────────────────────────────────
+function ShareDistribution({ dutyId, accent = '#D6B995' }) {
+  const shares = window.TOBAN_QUESTS_DATA.shares[dutyId] || [];
+  const palette = ['#D6B995', '#65C98A', '#5DADEC', '#F5B82E', '#B696E0', '#E48F4F', '#E48ABF'];
+  return (
+    <Card padding={16}>
+      <div style={{ display: 'flex', borderRadius: 6, overflow: 'hidden', height: 12, marginBottom: 12 }}>
+        {shares.map((s, i) => (
+          <div key={s.name} style={{ width: `${s.pct}%`, background: palette[i % palette.length] }} title={`${s.name}: ${s.pct}%`} />
+        ))}
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {shares.map((s, i) => (
+          <div key={s.name} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <div style={{ width: 8, height: 8, borderRadius: 999, background: palette[i % palette.length] }} />
+            <Avatar name={s.name} size={24} />
+            <div style={{ flex: 1, fontSize: 13, fontWeight: 600 }}>{s.name}</div>
+            <div style={{ fontSize: 14, fontWeight: 700, fontFamily: T.fontDisplay || T.font, letterSpacing: -0.3 }}>{s.pct}<span style={{ fontSize: 10, color: T.color.textSecondary, marginLeft: 2 }}>%</span></div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+// ─── Quest list section (in duty detail) ────────────────────
+function QuestSections({ dutyId, goto }) {
+  const all = window.TOBAN_QUESTS_DATA.quests.filter(q => q.dutyId === dutyId);
+  const groups = [
+    { state: 'open', title: '募集中のクエスト' },
+    { state: 'inprogress', title: '進行中' },
+    { state: 'review', title: '確認待ち' },
+    { state: 'done', title: '完了' },
+  ];
+  return (
+    <>
+      {groups.map(g => {
+        const items = all.filter(q => q.state === g.state);
+        if (items.length === 0) return null;
+        return (
+          <F key={g.state}>
+            <SectionLabel>{g.title}（{items.length}）</SectionLabel>
+            <div style={{ padding: '0 16px 16px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {items.map(q => <QuestCard key={q.id} q={q} onClick={() => goto({ name: 'quest-detail', questId: q.id })} />)}
+            </div>
+          </F>
+        );
+      })}
+    </>
+  );
+}
+
+function AllQuestSections({ goto }) {
+  const all = window.TOBAN_QUESTS_DATA.quests;
+  const groups = [
+    { state: 'open', title: '募集中のクエスト' },
+    { state: 'review', title: '確認待ち' },
+    { state: 'inprogress', title: '進行中' },
+    { state: 'done', title: '完了' },
+  ];
+  return (
+    <>
+      {groups.map(g => {
+        const items = all.filter(q => q.state === g.state);
+        if (items.length === 0) return null;
+        return (
+          <F key={g.state}>
+            <SectionLabel>{g.title}（{items.length}）</SectionLabel>
+            <div style={{ padding: '0 16px 14px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {items.map(q => <QuestCard key={q.id} q={q} showDuty onClick={() => goto({ name: 'quest-detail', questId: q.id })} />)}
+            </div>
+          </F>
+        );
+      })}
+    </>
+  );
+}
+
+function QuestCard({ q, onClick, showDuty }) {
+  const duty = showDuty ? window.TOBAN_DATA.duties.find(d => d.id === q.dutyId) : null;
+  return (
+    <Card padding={14} onClick={onClick} style={{ cursor: 'pointer' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10, marginBottom: 8 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {duty && <div style={{ fontSize: 10, fontWeight: 700, color: T.color.textSecondary, marginBottom: 3, letterSpacing: 0.3 }}>{duty.name}</div>}
+          <div style={{ fontSize: 14, fontWeight: 700, marginBottom: 4 }}>{q.title}</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+            <QStateBadge state={q.state} />
+            <span style={{ fontSize: 11, color: T.color.textSecondary }}>
+              {q.state === 'open' && `作成者: ${q.creator}・残り${q.count}件`}
+              {q.state === 'inprogress' && `参加者: ${q.applicant}`}
+              {q.state === 'review' && `申請者: ${q.applicant}・承認 ${q.approvals || 0}/2`}
+              {q.state === 'done' && `${q.applicant} が完了`}
+            </span>
+          </div>
+        </div>
+        <div style={{ textAlign: 'right', flex: 'none' }}>
+          <div style={{ fontSize: 11, color: T.color.textSecondary }}>当番シェア</div>
+          <div style={{ fontSize: 18, fontWeight: 700, color: T.color.primary, fontFamily: T.fontDisplay || T.font, letterSpacing: -0.5 }}>+{q.share}<span style={{ fontSize: 10, color: T.color.textSecondary, marginLeft: 1 }}>%</span></div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// ─── Quest create ────────────────────────────────────────────
+function QuestCreateScreen({ goto, dutyId, onCreated }) {
+  const duty = window.TOBAN_DATA.duties.find(d => d.id === dutyId);
+  const myShare = userShareInDuty(dutyId);
+  const [title, setTitle] = useState('');
+  const [desc, setDesc] = useState('');
+  const [share, setShare] = useState(Math.min(10, myShare));
+
+  const after = myShare - share;
+  const valid = title.trim() && share > 0 && share <= myShare;
+
+  return (
+    <div style={{ paddingBottom: 32 }}>
+      <ScreenHeader title="クエストを作成" onBack={() => goto({ name: 'duty-detail', dutyId })} />
+
+      <div style={{ padding: '0 16px 12px' }}>
+        <Card padding={16} style={{ background: T.color.primarySoft, borderColor: T.color.primary + '55' }}>
+          <div style={{ fontSize: 11, color: '#7A5A2E', fontWeight: 700, marginBottom: 8 }}>紐づく当番</div>
+          <div style={{ fontSize: 16, fontWeight: 700, marginBottom: 14 }}>{duty?.name || '—'}</div>
+          <div style={{ display: 'flex', alignItems: 'flex-end', gap: 18 }}>
+            <ShareNumber label="あなたのシェア" value={myShare} />
+            <span style={{ fontSize: 18, color: '#7A5A2E', paddingBottom: 4 }}>−</span>
+            <ShareNumber label="渡すシェア" value={share} highlight />
+            <span style={{ fontSize: 18, color: '#7A5A2E', paddingBottom: 4 }}>=</span>
+            <ShareNumber label="作成後" value={after} dim />
+          </div>
+        </Card>
+      </div>
+
+      <div style={{ padding: '8px 20px 0' }}>
+        <FieldLabel>渡す当番シェア <span style={{ color: T.color.danger }}>*</span></FieldLabel>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <button onClick={() => setShare(Math.max(1, share - 1))} style={stepBtn}>−</button>
+          <div style={{ flex: 1, textAlign: 'center', fontSize: 28, fontWeight: 700, fontFamily: T.fontDisplay || T.font, letterSpacing: -0.5 }}>
+            {share}<span style={{ fontSize: 14, color: T.color.textSecondary, marginLeft: 3 }}>%</span>
+          </div>
+          <button onClick={() => setShare(Math.min(myShare, share + 1))} style={stepBtn}>+</button>
+        </div>
+        <div style={{ display: 'flex', gap: 6, marginTop: 10 }}>
+          {[5, 10, 15, 20].filter(n => n <= myShare).map(n => (
+            <button key={n} onClick={() => setShare(n)} style={{
+              flex: 1, padding: '8px 0', borderRadius: T.radius.full,
+              background: share === n ? T.color.primary : T.color.surface,
+              color: share === n ? '#fff' : T.color.textPrimary,
+              border: `1px solid ${share === n ? T.color.primary : T.color.border}`,
+              fontFamily: T.font, fontSize: 12, fontWeight: 700, cursor: 'pointer',
+            }}>{n}%</button>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ padding: '20px 20px 0' }}>
+        <FieldLabel>クエスト名 <span style={{ color: T.color.danger }}>*</span></FieldLabel>
+        <Input value={title} onChange={setTitle} placeholder="例：夕食後の食器洗いを手伝う" />
+      </div>
+
+      <div style={{ padding: '20px 20px 0' }}>
+        <FieldLabel>説明</FieldLabel>
+        <Input value={desc} onChange={setDesc} multiline rows={4} placeholder="どんなお願いか、自由に書いてください" />
+      </div>
+
+      <div style={{ padding: '24px 16px 0', display: 'flex', gap: 10 }}>
+        <Button variant="secondary" onClick={() => goto({ name: 'duty-detail', dutyId })}>キャンセル</Button>
+        <Button variant="primary" full disabled={!valid} icon="plus"
+          onClick={() => { onCreated?.({ title, share }); goto({ name: 'duty-detail', dutyId }); }}>
+          作成する
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+const stepBtn = {
+  width: 48, height: 48, borderRadius: 999,
+  background: T.color.surface, border: `1px solid ${T.color.border}`,
+  fontSize: 20, fontWeight: 700, fontFamily: T.font, cursor: 'pointer',
+  color: T.color.textPrimary,
+};
+
+const ShareNumber = ({ label, value, highlight, dim }) => (
+  <div style={{ flex: 1, textAlign: 'center', opacity: dim ? 0.7 : 1 }}>
+    <div style={{ fontSize: 10, color: '#7A5A2E', fontWeight: 600, marginBottom: 2 }}>{label}</div>
+    <div style={{ fontSize: highlight ? 30 : 24, fontWeight: 700,
+      color: highlight ? T.color.primary : '#3D2D14',
+      fontFamily: T.fontDisplay || T.font, letterSpacing: -0.5,
+      lineHeight: 1,
+    }}>{value}<span style={{ fontSize: 11, color: '#7A5A2E', marginLeft: 2 }}>%</span></div>
+  </div>
+);
+
+// ─── Quest detail ────────────────────────────────────────────
+function QuestDetailScreen({ goto, questId, onAction }) {
+  const q = window.TOBAN_QUESTS_DATA.quests.find(x => x.id === questId);
+  if (!q) return <div style={{ padding: 40 }}>クエストが見つかりません</div>;
+  const duty = window.TOBAN_DATA.duties.find(d => d.id === q.dutyId);
+  const isMine = q.creator === 'ryoma';
+
+  return (
+    <div style={{ paddingBottom: 32 }}>
+      <ScreenHeader title="クエスト" onBack={() => goto({ name: 'duty-detail', dutyId: q.dutyId })} />
+
+      <div style={{ padding: '0 16px 12px' }}>
+        <Card padding={20}>
+          <QStateBadge state={q.state} />
+          <div style={{ fontSize: 22, fontWeight: 700, margin: '12px 0 8px', lineHeight: 1.3 }}>{q.title}</div>
+          <div style={{ fontSize: 13, color: T.color.textSecondary, lineHeight: 1.6, marginBottom: 16 }}>{q.desc}</div>
+
+          <div style={{ display: 'flex', gap: 12, padding: '12px 0', borderTop: `1px solid ${T.color.border}`, borderBottom: `1px solid ${T.color.border}` }}>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 11, color: T.color.textSecondary, fontWeight: 600 }}>紐づく当番</div>
+              <div style={{ fontSize: 14, fontWeight: 700, marginTop: 2 }}>{duty?.name || '—'}</div>
+            </div>
+            <div style={{ width: 1, background: T.color.border }} />
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 11, color: T.color.textSecondary, fontWeight: 600 }}>もらえるシェア</div>
+              <div style={{ fontSize: 18, fontWeight: 700, color: T.color.primary, fontFamily: T.fontDisplay || T.font, letterSpacing: -0.3, marginTop: 2 }}>+{q.share}%</div>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 14 }}>
+            <Avatar name={q.creator} size={32} />
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 11, color: T.color.textSecondary }}>作成者</div>
+              <div style={{ fontSize: 13, fontWeight: 700 }}>{q.creator}</div>
+            </div>
+            {q.applicant && (
+              <>
+                <Icon name="arrow-right" size={16} color={T.color.textSecondary} />
+                <Avatar name={q.applicant} size={32} />
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 11, color: T.color.textSecondary }}>{q.state === 'review' ? '申請者' : '参加者'}</div>
+                  <div style={{ fontSize: 13, fontWeight: 700 }}>{q.applicant}</div>
+                </div>
+              </>
+            )}
+          </div>
+
+          {q.state === 'review' && (
+            <Card padding={12} style={{ marginTop: 14, background: T.color.primarySoft, borderColor: T.color.primary + '55' }}>
+              <div style={{ fontSize: 12, fontWeight: 700, color: '#7A5A2E', marginBottom: 6 }}>承認状況</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <div style={{ flex: 1, height: 6, background: '#fff', borderRadius: 999, overflow: 'hidden' }}>
+                  <div style={{ width: `${(q.approvals || 0) / 2 * 100}%`, height: '100%', background: T.color.primary }} />
+                </div>
+                <div style={{ fontSize: 13, fontWeight: 700, color: '#7A5A2E' }}>{q.approvals || 0} / 2</div>
+              </div>
+              <div style={{ fontSize: 11, color: '#7A5A2E', marginTop: 8, lineHeight: 1.5 }}>
+                作成者の承認、または当番シェア保有者2人の承認で完了します。
+              </div>
+            </Card>
+          )}
+        </Card>
+      </div>
+
+      {/* CTAs by state */}
+      <div style={{ padding: '8px 16px 0' }}>
+        {q.state === 'open' && !isMine && (
+          <Button variant="primary" full icon="check" onClick={() => { onAction?.({ kind: 'apply', q }); goto({ name: 'duty-detail', dutyId: q.dutyId }); }}>申請する</Button>
+        )}
+        {q.state === 'open' && isMine && (
+          <Button variant="secondary" full onClick={() => { onAction?.({ kind: 'cancel', q }); goto({ name: 'duty-detail', dutyId: q.dutyId }); }}>キャンセル</Button>
+        )}
+        {q.state === 'inprogress' && q.applicant === 'me-or-not' && (
+          <Button variant="primary" full icon="send" onClick={() => onAction?.({ kind: 'request', q })}>完了申請する</Button>
+        )}
+        {q.state === 'inprogress' && (
+          <Button variant="primary" full icon="send" onClick={() => { onAction?.({ kind: 'request', q }); goto({ name: 'duty-detail', dutyId: q.dutyId }); }}>完了申請する</Button>
+        )}
+        {q.state === 'review' && (
+          <Button variant="primary" full icon="check" onClick={() => goto({ name: 'quest-approve', questId: q.id })}>承認画面を開く</Button>
+        )}
+        {q.state === 'done' && (
+          <Card padding={14} style={{ background: '#E5F5EC', borderColor: T.color.contrib + '55' }}>
+            <div style={{ fontSize: 13, fontWeight: 700, color: '#2F8B58', marginBottom: 4 }}>
+              {q.applicant} が完了しました
+            </div>
+            <div style={{ fontSize: 12, color: '#2F8B58' }}>
+              {duty?.name} の当番シェア +{q.share}%
+            </div>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Quest approve ───────────────────────────────────────────
+function QuestApproveScreen({ goto, questId, onApproved }) {
+  const q = window.TOBAN_QUESTS_DATA.quests.find(x => x.id === questId);
+  if (!q) return <div style={{ padding: 40 }}>—</div>;
+  const duty = window.TOBAN_DATA.duties.find(d => d.id === q.dutyId);
+
+  return (
+    <div style={{ paddingBottom: 32 }}>
+      <ScreenHeader title="完了申請の確認" onBack={() => goto({ name: 'quest-detail', questId })} />
+
+      <div style={{ padding: '0 16px 12px' }}>
+        <Card padding={20}>
+          <div style={{ fontSize: 11, color: T.color.textSecondary, fontWeight: 600, marginBottom: 4 }}>クエスト</div>
+          <div style={{ fontSize: 17, fontWeight: 700, marginBottom: 16 }}>{q.title}</div>
+
+          <Row left={<Avatar name={q.applicant} size={40} />}
+            title={q.applicant} subtitle="完了申請" />
+          <Divider />
+
+          <div style={{ padding: '14px 0 4px', textAlign: 'center' }}>
+            <div style={{ fontSize: 11, color: T.color.textSecondary, fontWeight: 600 }}>付与される当番シェア</div>
+            <div style={{ fontSize: 36, fontWeight: 700, color: T.color.primary, fontFamily: T.fontDisplay || T.font, letterSpacing: -1, lineHeight: 1, margin: '8px 0' }}>+{q.share}<span style={{ fontSize: 16, color: '#7A5A2E', marginLeft: 2 }}>%</span></div>
+            <div style={{ fontSize: 13, color: T.color.textSecondary }}>{duty?.name}</div>
+          </div>
+
+          <Divider />
+          <div style={{ padding: '14px 0 0' }}>
+            <div style={{ fontSize: 11, color: T.color.textSecondary, fontWeight: 600, marginBottom: 6 }}>承認状況</div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <div style={{ flex: 1, height: 6, background: T.color.border, borderRadius: 999, overflow: 'hidden' }}>
+                <div style={{ width: `${(q.approvals || 0) / 2 * 100}%`, height: '100%', background: T.color.primary }} />
+              </div>
+              <div style={{ fontSize: 13, fontWeight: 700 }}>{q.approvals || 0} / 2</div>
+            </div>
+          </div>
+        </Card>
+      </div>
+
+      <div style={{ padding: '8px 20px 16px', fontSize: 12, color: T.color.textSecondary, lineHeight: 1.6 }}>
+        作成者の承認、または当番シェア保有者2人の承認で完了します。
+      </div>
+
+      <div style={{ padding: '0 16px', display: 'flex', gap: 10 }}>
+        <Button variant="secondary" onClick={() => goto({ name: 'quest-detail', questId })}>戻る</Button>
+        <Button variant="primary" full icon="check" onClick={() => { onApproved?.({ q }); goto({ name: 'duty-detail', dutyId: q.dutyId }); }}>承認する</Button>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  ShareDistribution, QuestSections, AllQuestSections, QuestCard, QStateBadge,
+  QuestCreateScreen, QuestDetailScreen, QuestApproveScreen,
+  userShareInDuty,
+});

--- a/docs/design/handoff/project/screens.jsx
+++ b/docs/design/handoff/project/screens.jsx
@@ -1,0 +1,1190 @@
+// Toban screens — home, thanks, duties, splits, members, wallet
+const D = window.TOBAN_DATA;
+const memberById = (id) => D.members.find(m => m.id === id) || { name: id, addr: '' };
+
+// ─── HOME ─────────────────────────────────────────────────────
+function HomeScreen({ goto, openThanks, ws, openWsMenu }) {
+  const myDuty = D.duties.find(d => d.assignee === 'ryu'); // pretend ryu is "me" sometimes
+  return (
+    <div style={{ paddingBottom: 24 }}>
+      <AppHeader ws={ws} openWsMenu={openWsMenu} />
+
+      {/* greeting */}
+      <div style={{ padding: '4px 20px 16px' }}>
+        <div style={{ fontSize: 13, color: T.color.textSecondary }}>こんにちは、ryoma さん</div>
+        <div style={{ fontSize: 22, fontWeight: 700, marginTop: 2, letterSpacing: -0.3 }}>今日もおつかれさまです！</div>
+      </div>
+
+      {/* sendable balance card */}
+      <div style={{ padding: '0 16px 12px' }}>
+        <Card padding={0} style={{ overflow: 'hidden' }}>
+          <div style={{ background: T.color.primarySoft, padding: 18, position: 'relative' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+              <div>
+                <div style={{ fontSize: 12, color: '#7A5A2E', fontWeight: 600 }}>送れるサンクス</div>
+                <div style={{ marginTop: 6, display: 'flex', alignItems: 'baseline', gap: 6 }}>
+                  <span style={{ fontSize: 40, fontWeight: 800, letterSpacing: -1, color: T.color.textPrimary, lineHeight: 1 }}>120</span>
+                  <span style={{ fontSize: 14, fontWeight: 700, color: '#7A5A2E' }}>THX</span>
+                </div>
+              </div>
+              <div style={{ width: 44, height: 44, borderRadius: T.radius.full, background: T.color.primary,
+                display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Icon name="sparkle" size={22} color="#fff" />
+              </div>
+            </div>
+            <div style={{ marginTop: 12, fontSize: 12, color: '#7A5A2E', display: 'flex', justifyContent: 'space-between' }}>
+              <span>受け取った: <strong style={{ color: T.color.textPrimary }}>80 THX</strong></span>
+              <span>+15% 今週</span>
+            </div>
+          </div>
+          <div style={{ padding: 14 }}>
+            <Button variant="primary" full icon="send" onClick={openThanks}>サンクスを送る</Button>
+          </div>
+        </Card>
+      </div>
+
+      {/* my duty */}
+      <SectionLabel>あなたの当番</SectionLabel>
+      <div style={{ padding: '0 16px 16px' }}>
+        {myDuty ? (
+          <Card onClick={() => goto({ name: 'duty-detail', dutyId: myDuty.id })} padding={14}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+              <div style={{ width: 44, height: 44, borderRadius: T.radius.sm,
+                background: '#F2EAD9', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Icon name="duty" size={22} color="#7A5A2E" />
+              </div>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 15, fontWeight: 700 }}>{myDuty.name}</div>
+                <div style={{ fontSize: 12, color: T.color.textSecondary, marginTop: 3 }}>
+                  次回: {myDuty.next} ・ サポーター {myDuty.supporters.length}人
+                </div>
+              </div>
+              <Badge kind="lead">担当中</Badge>
+            </div>
+          </Card>
+        ) : null}
+      </div>
+
+      {/* recent activity */}
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', padding: '0 20px 8px' }}>
+        <div style={{ fontSize: 12, color: T.color.textSecondary, fontWeight: 700, letterSpacing: 0.4 }}>最近のアクティビティ</div>
+        <button onClick={() => goto({ name: 'thanks-insights' })} style={{ background: 'none', border: 'none', fontSize: 12, color: T.color.textSecondary, fontFamily: T.font, cursor: 'pointer', display: 'inline-flex', alignItems: 'center', gap: 2 }}>すべて見る<Icon name="chevron-right" size={12} color={T.color.textSecondary} /></button>
+      </div>
+      <div style={{ padding: '0 16px' }}>
+        <Card padding={0}>
+          {D.activity.slice(0, 4).map((a, i) => (
+            <div key={a.id} style={{display:"contents"}}>
+              <ActivityRow a={a} />
+              {i < 3 && <Divider inset={64} />}
+            </div>
+          ))}
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+const SectionLabel = ({ children }) => (
+  <div style={{ padding: '4px 20px 8px', fontSize: 12, color: T.color.textSecondary, fontWeight: 700, letterSpacing: 0.4 }}>{children}</div>
+);
+
+const AppHeader = ({ ws, openWsMenu }) => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px 8px' }}>
+    <button onClick={openWsMenu} style={{
+      display: 'flex', alignItems: 'center', gap: 8,
+      background: T.color.surface, border: `1px solid ${T.color.border}`,
+      borderRadius: T.radius.full, padding: '6px 10px 6px 6px',
+      cursor: 'pointer', fontFamily: T.font, flex: 1, minWidth: 0,
+    }}>
+      <div style={{ width: 28, height: 28, borderRadius: T.radius.full, background: ws.color, color: '#fff',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 14, fontWeight: 700, flex: 'none' }}>
+        {ws.icon}
+      </div>
+      <span style={{ fontSize: 14, fontWeight: 700, color: T.color.textPrimary, flex: 1, textAlign: 'left',
+        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{ws.name}</span>
+      <Icon name="chevron-down" size={16} color={T.color.textSecondary} />
+    </button>
+    <button style={iconBtn}><Icon name="bell" size={20} /><span style={{ position: 'absolute', top: 8, right: 8, width: 8, height: 8, borderRadius: 999, background: T.color.danger, border: '2px solid #fff' }} /></button>
+  </div>
+);
+
+const iconBtn = {
+  position: 'relative',
+  width: 40, height: 40, borderRadius: T.radius.full,
+  background: T.color.surface, border: `1px solid ${T.color.border}`,
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+  cursor: 'pointer', flex: 'none',
+};
+
+const ActivityRow = ({ a }) => {
+  let icon, label, color = T.color.contrib, suffix;
+  if (a.kind === 'thanks-recv') {
+    icon = 'heart'; color = T.color.contrib;
+    label = <><strong>{a.from}</strong> さんから</>;
+    suffix = <span style={{ color: T.color.contrib, fontWeight: 700, fontSize: 13 }}>+{a.amount} THX</span>;
+  } else if (a.kind === 'thanks-sent') {
+    icon = 'send'; color = T.color.primary;
+    label = <><strong>{a.to}</strong> さんへ</>;
+    suffix = <span style={{ color: T.color.textSecondary, fontWeight: 700, fontSize: 13 }}>−{a.amount} THX</span>;
+  } else if (a.kind === 'duty-assigned') {
+    icon = 'duty'; color = T.color.role;
+    label = <><strong>{a.who}</strong> さんが担当に</>;
+    suffix = <span style={{ fontSize: 11, color: T.color.textSecondary }}>{a.duty}</span>;
+  } else if (a.kind === 'split-created') {
+    icon = 'pie'; color = T.color.split;
+    label = <>分配「<strong>{a.name}</strong>」作成</>;
+    suffix = <span style={{ fontSize: 11, color: T.color.textSecondary }}>{a.count}人</span>;
+  }
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 16px' }}>
+      <div style={{ width: 36, height: 36, borderRadius: T.radius.full,
+        background: '#fff', border: `1.5px solid ${color}33`, color,
+        display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 'none' }}>
+        <Icon name={icon} size={18} color={color} />
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13, color: T.color.textPrimary }}>{label}</div>
+        {a.msg && <div style={{ fontSize: 12, color: T.color.textSecondary, marginTop: 2,
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{a.msg}</div>}
+        <div style={{ fontSize: 11, color: T.color.textSecondary, marginTop: 2 }}>{a.time}</div>
+      </div>
+      {suffix}
+    </div>
+  );
+};
+
+// ─── DUTIES ──────────────────────────────────────────────────
+function DutiesScreen({ goto, ws, openWsMenu }) {
+  const [tab, setTab] = useState('all');
+  const [view, setView] = useState('duties');
+  return (
+    <div style={{ paddingBottom: 24 }}>
+      <AppHeader ws={ws} openWsMenu={openWsMenu} />
+      <div style={{ padding: '4px 20px 12px' }}>
+        <div style={{ fontSize: 22, fontWeight: 700, letterSpacing: -0.3 }}>当番</div>
+        <div style={{ fontSize: 13, color: T.color.textSecondary, marginTop: 2 }}>コミュニティの役割と関わり</div>
+      </div>
+      <div style={{ padding: '0 16px 12px' }}>
+        <Segmented value={view} onChange={setView} options={[
+          { value: 'duties', label: '当番' },
+          { value: 'quests', label: 'クエスト' },
+        ]} />
+      </div>
+      {view === 'duties' && <>
+        <div style={{ padding: '0 16px 10px' }}>
+          <Segmented value={tab} onChange={setTab} options={[
+            { value: 'mine', label: 'あなたの当番' },
+            { value: 'all', label: 'すべて' },
+            { value: 'open', label: '空き' },
+          ]} />
+        </div>
+        <div style={{ padding: '0 16px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {D.duties
+            .filter(d => tab === 'all' ? true : tab === 'mine' ? d.assignee === 'ryu' : !d.assignee)
+            .map(d => <DutyCard key={d.id} duty={d} onClick={() => goto({ name: 'duty-detail', dutyId: d.id })} />)
+          }
+        </div>
+        <div style={{ padding: 16 }}>
+          <Button variant="secondary" full icon="plus" onClick={() => goto({ name: 'duty-edit' })}>当番を作成</Button>
+        </div>
+      </>}
+      {view === 'quests' && <AllQuestSections goto={goto} />}
+    </div>
+  );
+}
+
+const DutyCard = ({ duty, onClick }) => (
+  <Card onClick={onClick} padding={14}>
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+        <div style={{ fontSize: 15, fontWeight: 700 }}>{duty.name}</div>
+        {duty.assignee
+          ? <Badge kind="lead">担当中</Badge>
+          : <Badge kind="role">空き</Badge>}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12, color: T.color.textSecondary }}>
+        {duty.assignee ? (
+          <>
+            <Avatar name={duty.assignee} size={22} />
+            <span>担当: <strong style={{ color: T.color.textPrimary }}>{duty.assignee}</strong></span>
+            {duty.next && <><span>・</span><span>次回 {duty.next}</span></>}
+            {duty.supporters.length > 0 && <><span>・</span><span>サポーター {duty.supporters.length}人</span></>}
+          </>
+        ) : (
+          <span>担当者を募集中</span>
+        )}
+      </div>
+    </div>
+  </Card>
+);
+
+// ─── DUTY DETAIL ─────────────────────────────────────────────
+function DutyDetailScreen({ goto, dutyId }) {
+  const duty = D.duties.find(d => d.id === dutyId);
+  const assignee = duty.assignee ? memberById(duty.assignee) : null;
+  return (
+    <div style={{ paddingBottom: 24 }}>
+      <ScreenHeader title="当番" onBack={() => goto({ name: 'duties' })} right={<button style={iconBtn} onClick={() => goto({ name: 'duty-edit', dutyId })}><Icon name="edit" size={18} /></button>} />
+      <div style={{ padding: '0 20px 20px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 8 }}>
+          <div style={{ width: 56, height: 56, borderRadius: T.radius.md,
+            background: duty.accent + '33', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Icon name="duty" size={28} color="#7A5A2E" />
+          </div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 20, fontWeight: 700 }}>{duty.name}</div>
+            <div style={{ fontSize: 12, color: T.color.textSecondary, marginTop: 4 }}>
+              次回: {duty.next || '未定'}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <SectionLabel>説明</SectionLabel>
+      <div style={{ padding: '0 16px 16px' }}>
+        <Card padding={16}>
+          {duty.desc.map((line, i) => (
+            <div key={i} style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginBottom: i === duty.desc.length - 1 ? 0 : 8 }}>
+              <div style={{ width: 6, height: 6, borderRadius: 999, background: T.color.primary, marginTop: 8, flex: 'none' }} />
+              <div style={{ fontSize: 14, lineHeight: 1.5 }}>{line}</div>
+            </div>
+          ))}
+        </Card>
+      </div>
+
+      <SectionLabel>現在の担当</SectionLabel>
+      <div style={{ padding: '0 16px 16px' }}>
+        <Card padding={0}>
+          {assignee ? (
+            <Row
+              left={<Avatar name={assignee.name} size={40} />}
+              title={assignee.name}
+              subtitle={`${assignee.addr} ・ 担当者`}
+              right={<Badge kind="lead">当番リード</Badge>}
+              onClick={() => goto({ name: 'member-detail', memberId: assignee.id })}
+            />
+          ) : (
+            <div style={{ padding: 20, textAlign: 'center', color: T.color.textSecondary, fontSize: 13 }}>
+              まだ担当者はいません
+            </div>
+          )}
+        </Card>
+      </div>
+
+      <SectionLabel>当番シェア分布</SectionLabel>
+      <div style={{ padding: '0 16px 16px' }}>
+        <ShareDistribution dutyId={dutyId} />
+      </div>
+
+      <QuestSections dutyId={dutyId} goto={goto} />
+
+      <div style={{ padding: '0 16px 20px' }}>
+        <Button variant="secondary" full icon="plus" onClick={() => goto({ name: 'quest-create', dutyId })}>クエストを作成</Button>
+      </div>
+
+      <SectionLabel>サポーター（{duty.supporters.length}人）</SectionLabel>
+      <div style={{ padding: '0 16px 16px' }}>
+        <Card padding={0}>
+          {duty.supporters.length === 0 ? (
+            <div style={{ padding: 20, textAlign: 'center', color: T.color.textSecondary, fontSize: 13 }}>
+              サポーターはいません
+            </div>
+          ) : duty.supporters.map((s, i) => (
+            <div key={s} style={{display:"contents"}}>
+              <Row
+                left={<Avatar name={s} size={36} />}
+                title={s}
+                subtitle="サポーター"
+                right={<Icon name="chevron-right" size={16} color={T.color.textSecondary} />}
+              />
+              {i < duty.supporters.length - 1 && <Divider inset={64} />}
+            </div>
+          ))}
+        </Card>
+      </div>
+
+      <div style={{ padding: '8px 16px 0', display: 'flex', gap: 10 }}>
+        <Button variant="primary" full icon="plus" onClick={() => goto({ name: 'assign-duty', dutyId })}>担当を追加</Button>
+        <Button variant="secondary" icon="send" style={{ flex: 'none', width: 48, padding: 0 }} onClick={() => goto({ name: 'thanks-recipient', preselect: assignee?.id })}> </Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── ASSIGN DUTY ─────────────────────────────────────────────
+function AssignDutyScreen({ goto, dutyId, onAssigned }) {
+  const duty = D.duties.find(d => d.id === dutyId);
+  const [step, setStep] = useState('select'); // select | settings | confirm | done
+  const [picked, setPicked] = useState(null);
+  const [role, setRole] = useState('lead');
+  const [q, setQ] = useState('');
+  const filtered = D.members.filter(m => !q || m.name.toLowerCase().includes(q.toLowerCase()) || m.addr.includes(q));
+
+  if (step === 'done') {
+    return (
+      <div>
+        <ScreenHeader title="完了" onBack={() => goto({ name: 'duty-detail', dutyId })} />
+        <div style={{ padding: '40px 24px', textAlign: 'center' }}>
+          <div style={{ width: 80, height: 80, borderRadius: T.radius.full, background: '#E5F5EC',
+            margin: '0 auto 20px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Icon name="check" size={36} color={T.color.contrib} />
+          </div>
+          <div style={{ fontSize: 20, fontWeight: 700, marginBottom: 8 }}>担当を追加しました</div>
+          <div style={{ fontSize: 13, color: T.color.textSecondary, marginBottom: 28 }}>
+            <strong style={{ color: T.color.textPrimary }}>{picked.name}</strong> が「{duty.name}」の{role === 'lead' ? '担当者' : 'サポーター'}になりました。
+          </div>
+          <Button variant="primary" full onClick={() => goto({ name: 'duty-detail', dutyId })}>当番詳細へ戻る</Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (step === 'confirm') {
+    return (
+      <div>
+        <ScreenHeader title="確認" onBack={() => setStep('settings')} />
+        <div style={{ padding: '8px 16px' }}>
+          <Card padding={0}>
+            <SummaryRow label="当番" value={duty.name} />
+            <Divider />
+            <SummaryRow label="メンバー" value={<><Avatar name={picked.name} size={24} style={{ marginRight: 8 }} />{picked.name}</>} />
+            <Divider />
+            <SummaryRow label="役割" value={role === 'lead' ? '担当者' : 'サポーター'} />
+            <Divider />
+            <SummaryRow label="開始日" value="2026/05/08 12:30" />
+          </Card>
+        </div>
+        <div style={{ padding: 16, display: 'flex', gap: 10 }}>
+          <Button variant="secondary" onClick={() => setStep('settings')}>戻って修正</Button>
+          <Button variant="primary" full onClick={() => { onAssigned?.({ dutyId, member: picked.name, role }); setStep('done'); }}>追加する</Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (step === 'settings') {
+    return (
+      <div>
+        <ScreenHeader title="開始日と役割" subtitle={duty.name} onBack={() => setStep('select')} />
+        <div style={{ padding: '8px 20px 0' }}>
+          <FieldLabel>担当者</FieldLabel>
+          <Card padding={12}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <Avatar name={picked.name} size={36} />
+              <div>
+                <div style={{ fontSize: 15, fontWeight: 700 }}>{picked.name}</div>
+                <div style={{ fontSize: 11, color: T.color.textSecondary }}>{picked.addr}</div>
+              </div>
+            </div>
+          </Card>
+        </div>
+        <div style={{ padding: '16px 20px 0' }}>
+          <FieldLabel>役割</FieldLabel>
+          <Segmented value={role} onChange={setRole} options={[
+            { value: 'lead', label: '担当者' }, { value: 'supporter', label: 'サポーター' },
+          ]} />
+        </div>
+        <div style={{ padding: '16px 20px 0' }}>
+          <FieldLabel>開始日</FieldLabel>
+          <Card padding={14}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <span style={{ fontSize: 15, fontWeight: 600 }}>2026/05/08</span>
+              <span style={{ fontSize: 13, color: T.color.textSecondary }}>12:30</span>
+            </div>
+          </Card>
+        </div>
+        <div style={{ padding: '16px 20px 0' }}>
+          <FieldLabel>メモ（任意）</FieldLabel>
+          <Input placeholder="引き継ぎ事項など" multiline rows={2} value="" onChange={() => {}} />
+        </div>
+        <div style={{ padding: 16, marginTop: 12 }}>
+          <Button variant="primary" full onClick={() => setStep('confirm')}>確認へ</Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <ScreenHeader title="担当を追加" subtitle={duty.name} onBack={() => goto({ name: 'duty-detail', dutyId })} />
+      <div style={{ padding: '4px 16px 12px' }}>
+        <Input icon="search" placeholder="ユーザー名 or ウォレットアドレス" value={q} onChange={setQ} />
+      </div>
+      <SectionLabel>メンバー</SectionLabel>
+      <div style={{ padding: '0 16px' }}>
+        <Card padding={0}>
+          {filtered.map((m, i) => (
+            <div key={m.id} style={{display:"contents"}}>
+              <Row
+                left={<Avatar name={m.name} size={36} />}
+                title={m.name}
+                subtitle={m.addr}
+                right={<Icon name="chevron-right" size={16} color={T.color.textSecondary} />}
+                onClick={() => { setPicked(m); setStep('settings'); }}
+              />
+              {i < filtered.length - 1 && <Divider inset={64} />}
+            </div>
+          ))}
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+const FieldLabel = ({ children }) => <div style={{ fontSize: 12, fontWeight: 700, color: T.color.textSecondary, marginBottom: 8, letterSpacing: 0.3 }}>{children}</div>;
+const SummaryRow = ({ label, value }) => (
+  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '14px 16px', gap: 12 }}>
+    <span style={{ fontSize: 12, color: T.color.textSecondary, fontWeight: 600 }}>{label}</span>
+    <span style={{ fontSize: 14, fontWeight: 600, textAlign: 'right', display: 'inline-flex', alignItems: 'center' }}>{value}</span>
+  </div>
+);
+
+// ─── SPLITS ─────────────────────────────────────────────────
+function SplitsScreen({ goto, ws, openWsMenu }) {
+  return (
+    <div style={{ paddingBottom: 24 }}>
+      <AppHeader ws={ws} openWsMenu={openWsMenu} />
+      <div style={{ padding: '4px 20px 16px', display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between' }}>
+        <div>
+          <div style={{ fontSize: 22, fontWeight: 700, letterSpacing: -0.3 }}>分配</div>
+          <div style={{ fontSize: 13, color: T.color.textSecondary, marginTop: 2 }}>貢献記録から、納得できる分配へ</div>
+        </div>
+        <Button size="sm" variant="primary" icon="plus" onClick={() => goto({ name: 'split-create' })}>新規作成</Button>
+      </div>
+      <SectionLabel>分配ルール</SectionLabel>
+      <div style={{ padding: '0 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {D.splits.map(s => <SplitCard key={s.id} split={s} onClick={() => goto({ name: 'split-detail', splitId: s.id })} />)}
+      </div>
+    </div>
+  );
+}
+
+const SplitCard = ({ split, onClick }) => (
+  <Card onClick={onClick} padding={16}>
+    <div style={{ display: 'flex', gap: 14, alignItems: 'center' }}>
+      <DonutChart shares={split.shares} size={72} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 15, fontWeight: 700 }}>{split.name}</div>
+        <div style={{ fontSize: 12, color: T.color.textSecondary, marginTop: 2 }}>
+          {split.count}人に分配 ・ 最終更新: {split.updated}
+        </div>
+        <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap' }}>
+          {split.shares.slice(0, 3).map(sh => (
+            <span key={sh.name} style={{ fontSize: 11, fontWeight: 600, padding: '3px 8px',
+              borderRadius: T.radius.full, background: '#F0EBE0', color: T.color.textPrimary }}>
+              {sh.name} {sh.pct.toFixed(1)}%
+            </span>
+          ))}
+          {split.shares.length > 3 && <span style={{ fontSize: 11, color: T.color.textSecondary, alignSelf: 'center' }}>+{split.shares.length - 3}</span>}
+        </div>
+      </div>
+      <Icon name="chevron-right" size={18} color={T.color.textSecondary} />
+    </div>
+  </Card>
+);
+
+// donut chart with split-blue palette family
+const donutColors = ['#5DADEC', '#F5B82E', '#65C98A', '#D6B995', '#E48F4F', '#B696E0', '#E48ABF', '#7AC2D9', '#F2A6A0'];
+function DonutChart({ shares, size = 80, total }) {
+  const sum = shares.reduce((a, b) => a + b.pct, 0);
+  const remainder = Math.max(0, 100 - sum);
+  const all = remainder > 0.5 ? [...shares, { name: 'その他', pct: remainder, _other: true }] : shares;
+  const r = size / 2 - 8;
+  const cx = size / 2, cy = size / 2;
+  const circ = 2 * Math.PI * r;
+  let offset = 0;
+  return (
+    <div style={{ position: 'relative', width: size, height: size, flex: 'none' }}>
+      <svg width={size} height={size} style={{ transform: 'rotate(-90deg)' }}>
+        <circle cx={cx} cy={cy} r={r} fill="none" stroke="#F0EBE0" strokeWidth={10} />
+        {all.map((s, i) => {
+          const len = (s.pct / 100) * circ;
+          const seg = (
+            <circle key={i} cx={cx} cy={cy} r={r} fill="none"
+              stroke={s._other ? T.color.border : donutColors[i % donutColors.length]}
+              strokeWidth={10}
+              strokeDasharray={`${len} ${circ - len}`}
+              strokeDashoffset={-offset} />
+          );
+          offset += len;
+          return seg;
+        })}
+      </svg>
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column',
+        alignItems: 'center', justifyContent: 'center', textAlign: 'center' }}>
+        {total != null
+          ? <><span style={{ fontSize: size * 0.22, fontWeight: 800, lineHeight: 1 }}>{total}</span>
+              <span style={{ fontSize: size * 0.11, color: T.color.textSecondary, fontWeight: 700 }}>THX</span></>
+          : <span style={{ fontSize: size * 0.16, fontWeight: 700, color: T.color.textSecondary }}>{shares.length}人</span>}
+      </div>
+    </div>
+  );
+}
+
+// ─── SPLIT DETAIL ─────────────────────────────────────────────
+function SplitDetailScreen({ goto, splitId }) {
+  const split = D.splits.find(s => s.id === splitId);
+  const [showTech, setShowTech] = useState(false);
+  return (
+    <div style={{ paddingBottom: 24 }}>
+      <ScreenHeader title="分配詳細" onBack={() => goto({ name: 'splits' })} />
+      <div style={{ padding: '0 20px 8px' }}>
+        <div style={{ fontSize: 20, fontWeight: 700, letterSpacing: -0.3 }}>{split.name}</div>
+        <div style={{ fontSize: 12, color: T.color.textSecondary, marginTop: 4 }}>
+          作成日: {split.updated} ・ 対象 {split.count}人
+        </div>
+      </div>
+
+      <div style={{ padding: '12px 16px' }}>
+        <Card padding={20}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 18, justifyContent: 'center' }}>
+            <DonutChart shares={split.shares} size={130} total={100} />
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {split.shares.slice(0, 4).map((s, i) => (
+                <div key={s.name} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12 }}>
+                  <span style={{ width: 10, height: 10, borderRadius: 999,
+                    background: donutColors[i % donutColors.length], flex: 'none' }} />
+                  <span style={{ flex: 1, color: T.color.textPrimary }}>{s.name}</span>
+                  <span style={{ fontWeight: 700 }}>{s.pct.toFixed(1)}%</span>
+                </div>
+              ))}
+              {split.shares.length > 4 && (
+                <div style={{ fontSize: 11, color: T.color.textSecondary, marginTop: 2 }}>
+                  +{split.shares.length - 4}人
+                </div>
+              )}
+            </div>
+          </div>
+        </Card>
+      </div>
+
+      <SectionLabel>分配結果</SectionLabel>
+      <div style={{ padding: '0 16px 16px' }}>
+        <Card padding={0}>
+          {split.shares.map((s, i) => (
+            <div key={s.name} style={{display:"contents"}}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 16px' }}>
+                <div style={{ width: 26, fontSize: 12, color: T.color.textSecondary, fontWeight: 700 }}>{i + 1}</div>
+                <Avatar name={s.name} size={32} />
+                <div style={{ flex: 1, fontSize: 14, fontWeight: 600 }}>{s.name}</div>
+                <div style={{ width: 80, height: 6, background: '#F0EBE0', borderRadius: 4, overflow: 'hidden' }}>
+                  <div style={{ width: `${(s.pct / split.shares[0].pct) * 100}%`, height: '100%',
+                    background: donutColors[i % donutColors.length] }} />
+                </div>
+                <div style={{ width: 52, textAlign: 'right', fontSize: 13, fontWeight: 700 }}>{s.pct.toFixed(2)}%</div>
+              </div>
+              {i < split.shares.length - 1 && <Divider inset={16} />}
+            </div>
+          ))}
+        </Card>
+      </div>
+
+      <SectionLabel>分配ルール</SectionLabel>
+      <div style={{ padding: '0 16px 16px' }}>
+        <Card padding={16}>
+          <WeightBar label="当番ベース" pct={split.dutyWeight} color={T.color.role} />
+          <div style={{ height: 12 }} />
+          <WeightBar label="サンクスベース" pct={split.thanksWeight} color={T.color.contrib} />
+          <Divider style={{ margin: '14px -16px' }} />
+          <div style={{ fontSize: 12, color: T.color.textSecondary, marginTop: 14, marginBottom: 10, fontWeight: 600 }}>サンクス内の重み</div>
+          <div style={{ display: 'flex', gap: 10 }}>
+            <div style={{ flex: 1, padding: 12, borderRadius: T.radius.sm, background: T.color.bg, textAlign: 'center' }}>
+              <div style={{ fontSize: 11, color: T.color.textSecondary }}>受け取り</div>
+              <div style={{ fontSize: 18, fontWeight: 800, color: T.color.contrib }}>{split.thanksRecv}%</div>
+            </div>
+            <div style={{ flex: 1, padding: 12, borderRadius: T.radius.sm, background: T.color.bg, textAlign: 'center' }}>
+              <div style={{ fontSize: 11, color: T.color.textSecondary }}>送付</div>
+              <div style={{ fontSize: 18, fontWeight: 800, color: T.color.primary }}>{split.thanksSent}%</div>
+            </div>
+          </div>
+        </Card>
+      </div>
+
+      <div style={{ padding: '0 16px' }}>
+        <Card padding={0}>
+          <button onClick={() => setShowTech(!showTech)} style={{
+            width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+            padding: '14px 16px', background: 'none', border: 'none', cursor: 'pointer', fontFamily: T.font,
+          }}>
+            <span style={{ fontSize: 13, fontWeight: 700, color: T.color.textSecondary }}>技術情報</span>
+            <Icon name="chevron-down" size={16} color={T.color.textSecondary}
+              style={{ transform: showTech ? 'rotate(180deg)' : 'none' }} />
+          </button>
+          {showTech && (
+            <>
+              <Divider />
+              <TechRow label="ENS" value={split.ens} />
+              <TechRow label="Contract" value={split.contract} />
+            </>
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+const WeightBar = ({ label, pct, color }) => (
+  <div>
+    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 6 }}>
+      <span style={{ fontWeight: 600 }}>{label}</span>
+      <span style={{ fontWeight: 700, color }}>{pct}%</span>
+    </div>
+    <div style={{ height: 8, background: '#F0EBE0', borderRadius: 4, overflow: 'hidden' }}>
+      <div style={{ width: `${pct}%`, height: '100%', background: color }} />
+    </div>
+  </div>
+);
+
+const TechRow = ({ label, value }) => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 16px' }}>
+    <div style={{ width: 80, fontSize: 11, color: T.color.textSecondary, fontWeight: 600 }}>{label}</div>
+    <div style={{ flex: 1, fontSize: 12, fontFamily: 'ui-monospace, SF Mono, monospace',
+      color: T.color.textPrimary, overflow: 'hidden', textOverflow: 'ellipsis' }}>{value}</div>
+    <button style={{ background: 'none', border: 'none', cursor: 'pointer', color: T.color.textSecondary }}>
+      <Icon name="copy" size={16} />
+    </button>
+  </div>
+);
+
+// ─── MEMBERS ─────────────────────────────────────────────────
+function MembersScreen({ goto, ws, openWsMenu }) {
+  const [q, setQ] = useState('');
+  const filtered = D.members.filter(m => !q || m.name.toLowerCase().includes(q.toLowerCase()));
+  return (
+    <div style={{ paddingBottom: 24 }}>
+      <AppHeader ws={ws} openWsMenu={openWsMenu} />
+      <div style={{ padding: '4px 20px 16px' }}>
+        <div style={{ fontSize: 22, fontWeight: 700, letterSpacing: -0.3 }}>メンバー</div>
+        <div style={{ fontSize: 13, color: T.color.textSecondary, marginTop: 2 }}>{D.members.length}人が参加中</div>
+      </div>
+      <div style={{ padding: '0 16px 12px' }}>
+        <Input icon="search" placeholder="ユーザー名 or ウォレットアドレス" value={q} onChange={setQ} />
+      </div>
+      <div style={{ padding: '0 16px' }}>
+        <Card padding={0}>
+          {filtered.map((m, i) => (
+            <div key={m.id} style={{display:"contents"}}>
+              <Row
+                left={<Avatar name={m.name} size={40} />}
+                title={m.name}
+                subtitle={m.addr}
+                right={<Badge kind={m.role}>{m.role === 'lead' ? '当番リード' : m.role === 'supporter' ? 'サポーター' : 'Member'}</Badge>}
+                onClick={() => goto({ name: 'member-detail', memberId: m.id })}
+              />
+              {i < filtered.length - 1 && <Divider inset={68} />}
+            </div>
+          ))}
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+// ─── MEMBER DETAIL ───────────────────────────────────────────
+function MemberDetailScreen({ goto, memberId }) {
+  const m = memberById(memberId);
+  const dutiesOf = D.duties.filter(d => d.assignee === memberId || d.supporters.includes(memberId));
+  return (
+    <div style={{ paddingBottom: 24 }}>
+      <ScreenHeader title="メンバー" onBack={() => goto({ name: 'members' })} />
+      <div style={{ padding: '8px 24px 24px', textAlign: 'center' }}>
+        <Avatar name={m.name} size={84} />
+        <div style={{ fontSize: 22, fontWeight: 700, marginTop: 12 }}>{m.name}</div>
+        <div style={{ fontSize: 12, color: T.color.textSecondary, fontFamily: 'ui-monospace, monospace', marginTop: 4 }}>{m.addr}</div>
+        <div style={{ marginTop: 10 }}>
+          <Badge kind={m.role}>{m.role === 'lead' ? '当番リード' : m.role === 'supporter' ? 'サポーター' : 'Member'}</Badge>
+        </div>
+      </div>
+      <div style={{ padding: '0 16px 16px' }}>
+        <div style={{ display: 'flex', gap: 10 }}>
+          <StatCard label="今週の貢献" value={m.contribs} unit="件" />
+          <StatCard label="受け取った" value={m.received} unit="THX" accent={T.color.contrib} />
+        </div>
+      </div>
+
+      <SectionLabel>関わっている当番</SectionLabel>
+      <div style={{ padding: '0 16px 16px' }}>
+        <Card padding={0}>
+          {dutiesOf.length === 0 ? (
+            <div style={{ padding: 20, textAlign: 'center', color: T.color.textSecondary, fontSize: 13 }}>
+              関わっている当番はまだありません
+            </div>
+          ) : dutiesOf.map((d, i) => (
+            <div key={d.id} style={{display:"contents"}}>
+              <Row
+                left={<div style={{ width: 36, height: 36, borderRadius: T.radius.sm, background: '#F2EAD9',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <Icon name="duty" size={18} color="#7A5A2E" />
+                </div>}
+                title={d.name}
+                subtitle={d.assignee === memberId ? '担当者' : 'サポーター'}
+                right={<Icon name="chevron-right" size={16} color={T.color.textSecondary} />}
+                onClick={() => goto({ name: 'duty-detail', dutyId: d.id })}
+              />
+              {i < dutiesOf.length - 1 && <Divider inset={64} />}
+            </div>
+          ))}
+        </Card>
+      </div>
+
+      <div style={{ padding: '8px 16px' }}>
+        <Button variant="primary" full icon="send" onClick={() => goto({ name: 'thanks-recipient', preselect: memberId })}>サンクスを送る</Button>
+      </div>
+    </div>
+  );
+}
+
+const StatCard = ({ label, value, unit, accent }) => (
+  <Card padding={14} style={{ flex: 1, textAlign: 'center' }}>
+    <div style={{ fontSize: 11, color: T.color.textSecondary, fontWeight: 600 }}>{label}</div>
+    <div style={{ marginTop: 4, display: 'flex', alignItems: 'baseline', justifyContent: 'center', gap: 4 }}>
+      <span style={{ fontSize: 26, fontWeight: 800, letterSpacing: -0.5, color: accent || T.color.textPrimary }}>{value}</span>
+      <span style={{ fontSize: 12, color: T.color.textSecondary, fontWeight: 700 }}>{unit}</span>
+    </div>
+  </Card>
+);
+
+// ─── WALLET ─────────────────────────────────────────────────
+function WalletScreen({ goto, ws, openWsMenu }) {
+  return (
+    <div style={{ paddingBottom: 24 }}>
+      <AppHeader ws={ws} openWsMenu={openWsMenu} />
+      <div style={{ padding: '4px 20px 12px' }}>
+        <div style={{ fontSize: 22, fontWeight: 700, letterSpacing: -0.3 }}>ウォレット</div>
+      </div>
+      <div style={{ padding: '4px 16px 16px' }}>
+        <Card padding={20} style={{ background: T.color.textPrimary, border: 'none' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <Avatar name={D.user.name} size={52} />
+            <div>
+              <div style={{ fontSize: 18, fontWeight: 700, color: '#fff' }}>{D.user.name}</div>
+              <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.6)', fontFamily: 'ui-monospace, monospace', marginTop: 2 }}>{D.user.address}</div>
+            </div>
+            <div style={{ marginLeft: 'auto' }}>
+              <button style={{ ...iconBtn, background: 'rgba(255,255,255,0.1)', border: '1px solid rgba(255,255,255,0.15)', color: '#fff' }}>
+                <Icon name="qr" size={18} color="#fff" />
+              </button>
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: 12, marginTop: 18 }}>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.6)', fontWeight: 600 }}>送れる</div>
+              <div style={{ marginTop: 4, display: 'flex', alignItems: 'baseline', gap: 4 }}>
+                <span style={{ fontSize: 28, fontWeight: 800, color: T.color.primary, letterSpacing: -0.5 }}>120</span>
+                <span style={{ fontSize: 12, color: 'rgba(255,255,255,0.6)', fontWeight: 700 }}>THX</span>
+              </div>
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.6)', fontWeight: 600 }}>受け取った</div>
+              <div style={{ marginTop: 4, display: 'flex', alignItems: 'baseline', gap: 4 }}>
+                <span style={{ fontSize: 28, fontWeight: 800, color: T.color.contrib, letterSpacing: -0.5 }}>80</span>
+                <span style={{ fontSize: 12, color: 'rgba(255,255,255,0.6)', fontWeight: 700 }}>THX</span>
+              </div>
+            </div>
+          </div>
+        </Card>
+      </div>
+
+      <SectionLabel>所属ワークスペース</SectionLabel>
+      <div style={{ padding: '0 16px 16px' }}>
+        <Card padding={0}>
+          {D.workspaces.map((w, i) => (
+            <div key={w.id} style={{display:"contents"}}>
+              <Row
+                left={<div style={{ width: 36, height: 36, borderRadius: T.radius.full, background: w.color,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#fff', fontWeight: 700 }}>{w.icon}</div>}
+                title={w.name}
+                subtitle={`${w.members}人`}
+                right={w.id === ws.id ? <Badge kind="member">現在</Badge> : <Icon name="chevron-right" size={16} color={T.color.textSecondary} />}
+              />
+              {i < D.workspaces.length - 1 && <Divider inset={64} />}
+            </div>
+          ))}
+        </Card>
+      </div>
+
+      <div style={{ padding: '8px 16px 0', display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <Button variant="secondary" full icon="edit">プロフィール編集</Button>
+        <Button variant="ghost" full icon="logout" style={{ color: T.color.danger }}>ウォレット接続を解除</Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── SEND THANKS FLOW ────────────────────────────────────────
+function ThanksFlow({ initial, onClose, onSent }) {
+  // initial: { preselect?: memberId }
+  const [step, setStep] = useState(initial?.preselect ? 'compose' : 'recipient');
+  const [recipient, setRecipient] = useState(initial?.preselect ? memberById(initial.preselect) : null);
+  const [amount, setAmount] = useState(50);
+  const [msg, setMsg] = useState('');
+  const [q, setQ] = useState('');
+
+  const sendable = 120;
+  const filtered = D.members.filter(m => !q || m.name.toLowerCase().includes(q.toLowerCase()));
+  const presets = [25, 50, 100, sendable];
+
+  if (step === 'recipient') {
+    return (
+      <div>
+        <ScreenHeader title="サンクスを送る" onBack={onClose} subtitle={`送れるサンクス: ${sendable} THX`} />
+        <div style={{ padding: '4px 16px 12px' }}>
+          <Input icon="search" placeholder="ユーザー名 or ウォレットアドレス" value={q} onChange={setQ} />
+        </div>
+        <div style={{ padding: '0 20px 8px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ fontSize: 12, color: T.color.textSecondary, fontWeight: 700, letterSpacing: 0.4 }}>最近関わった人</div>
+          <button style={{ background: 'none', border: 'none', display: 'flex', alignItems: 'center', gap: 4,
+            color: T.color.textSecondary, fontSize: 12, fontWeight: 600, fontFamily: T.font, cursor: 'pointer' }}>
+            <Icon name="qr" size={14} /> QR
+          </button>
+        </div>
+        <div style={{ padding: '0 16px 16px', display: 'flex', gap: 10, overflowX: 'auto' }}>
+          {['homma', 'ryu', 'shinya', 'sg', 'eri'].map(name => (
+            <button key={name} onClick={() => { setRecipient(memberById(name)); setStep('compose'); }}
+              style={{ background: 'none', border: 'none', display: 'flex', flexDirection: 'column',
+                alignItems: 'center', gap: 6, cursor: 'pointer', minWidth: 56 }}>
+              <Avatar name={name} size={48} />
+              <span style={{ fontSize: 11, fontWeight: 600, color: T.color.textPrimary }}>{name}</span>
+            </button>
+          ))}
+        </div>
+        <SectionLabel>メンバー一覧</SectionLabel>
+        <div style={{ padding: '0 16px' }}>
+          <Card padding={0}>
+            {filtered.map((m, i) => (
+              <div key={m.id} style={{display:"contents"}}>
+                <Row
+                  left={<Avatar name={m.name} size={36} />}
+                  title={m.name}
+                  subtitle={m.addr}
+                  right={<Icon name="chevron-right" size={16} color={T.color.textSecondary} />}
+                  onClick={() => { setRecipient(m); setStep('compose'); }}
+                />
+                {i < filtered.length - 1 && <Divider inset={64} />}
+              </div>
+            ))}
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  if (step === 'compose') {
+    const valid = amount > 0 && amount <= sendable;
+    return (
+      <div>
+        <ScreenHeader title={`${recipient.name} にサンクスを送る`} onBack={() => setStep('recipient')} subtitle={`送れるサンクス: ${sendable} THX`} />
+        <div style={{ padding: '8px 20px 0' }}>
+          <FieldLabel>送る量</FieldLabel>
+          <Card padding={20} style={{ textAlign: 'center', background: T.color.primarySoft, border: `1px solid ${T.color.primary}55` }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 14 }}>
+              <button onClick={() => setAmount(Math.max(0, amount - 5))} style={amountBtn}><Icon name="chevron-left" size={20} /></button>
+              <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+                <span style={{ fontSize: 56, fontWeight: 800, letterSpacing: -1.5, lineHeight: 1, color: T.color.textPrimary }}>{amount}</span>
+                <span style={{ fontSize: 16, fontWeight: 700, color: '#7A5A2E' }}>THX</span>
+              </div>
+              <button onClick={() => setAmount(Math.min(sendable, amount + 5))} style={amountBtn}><Icon name="chevron-right" size={20} /></button>
+            </div>
+          </Card>
+          <div style={{ marginTop: 12, display: 'flex', gap: 8 }}>
+            {presets.map(p => (
+              <button key={p} onClick={() => setAmount(p)} style={{
+                flex: 1, height: 36, borderRadius: T.radius.full, fontFamily: T.font,
+                background: amount === p ? T.color.textPrimary : T.color.surface,
+                color: amount === p ? '#fff' : T.color.textPrimary,
+                border: `1px solid ${amount === p ? T.color.textPrimary : T.color.border}`,
+                fontSize: 13, fontWeight: 700, cursor: 'pointer',
+              }}>{p === sendable ? 'すべて' : p}</button>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ padding: '20px 20px 0' }}>
+          <FieldLabel>メッセージ</FieldLabel>
+          <Input multiline rows={3} placeholder="ありがとうを入力" value={msg} onChange={setMsg} />
+          <div style={{ marginTop: 10, display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {['手伝ってくれてありがとう！', '準備してくれて助かりました', '今日の対応ありがとう'].map(s => (
+              <button key={s} onClick={() => setMsg(s)} style={{
+                fontSize: 12, padding: '6px 10px', borderRadius: T.radius.full,
+                background: T.color.surface, border: `1px solid ${T.color.border}`,
+                cursor: 'pointer', fontFamily: T.font, color: T.color.textSecondary,
+              }}>{s}</button>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ padding: 16, marginTop: 16 }}>
+          <Button variant="primary" full disabled={!valid} onClick={() => setStep('confirm')}>次へ</Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (step === 'confirm') {
+    return (
+      <div>
+        <ScreenHeader title="送信内容の確認" onBack={() => setStep('compose')} />
+        <div style={{ padding: '8px 16px 16px' }}>
+          <Card padding={20} style={{ textAlign: 'center' }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 16, marginBottom: 18 }}>
+              <Avatar name={D.user.name} size={48} />
+              <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                <div style={{ width: 24, height: 1, background: T.color.border }} />
+                <Icon name="heart" size={16} color={T.color.primary} />
+                <div style={{ width: 24, height: 1, background: T.color.border }} />
+              </div>
+              <Avatar name={recipient.name} size={48} />
+            </div>
+            <div style={{ fontSize: 13, color: T.color.textSecondary }}>{D.user.name} → {recipient.name}</div>
+            <div style={{ marginTop: 16, display: 'flex', alignItems: 'baseline', justifyContent: 'center', gap: 6 }}>
+              <span style={{ fontSize: 48, fontWeight: 800, letterSpacing: -1, color: T.color.textPrimary }}>{amount}</span>
+              <span style={{ fontSize: 14, fontWeight: 700, color: '#7A5A2E' }}>THX</span>
+            </div>
+            {msg && <div style={{ marginTop: 14, padding: 14, background: T.color.bg, borderRadius: T.radius.sm,
+              fontSize: 13, color: T.color.textPrimary, lineHeight: 1.5 }}>{msg}</div>}
+          </Card>
+        </div>
+        <div style={{ padding: '0 16px', display: 'flex', gap: 10 }}>
+          <Button variant="secondary" onClick={() => setStep('compose')}>戻って修正</Button>
+          <Button variant="primary" full onClick={() => { setStep('sending'); setTimeout(() => setStep('done'), 900); }}>送信する</Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (step === 'sending') {
+    return (
+      <div style={{ padding: '120px 24px', textAlign: 'center' }}>
+        <div style={{ width: 64, height: 64, borderRadius: T.radius.full, background: T.color.primarySoft,
+          margin: '0 auto 24px', display: 'flex', alignItems: 'center', justifyContent: 'center',
+          animation: 'tobanPulse 1.2s ease infinite' }}>
+          <Icon name="send" size={28} color={T.color.primary} />
+        </div>
+        <div style={{ fontSize: 17, fontWeight: 700 }}>サンクスを送信しています…</div>
+      </div>
+    );
+  }
+
+  // done
+  return (
+    <div style={{ padding: '40px 24px 24px', textAlign: 'center' }}>
+      <div style={{ width: 88, height: 88, borderRadius: T.radius.full, background: T.color.contrib,
+        margin: '0 auto 20px', display: 'flex', alignItems: 'center', justifyContent: 'center',
+        boxShadow: `0 0 0 12px ${T.color.contrib}22` }}>
+        <Icon name="check" size={42} color="#fff" stroke={2.5} />
+      </div>
+      <div style={{ fontSize: 22, fontWeight: 700, marginBottom: 8 }}>サンクスを送りました</div>
+      <div style={{ fontSize: 13, color: T.color.textSecondary, marginBottom: 24, lineHeight: 1.5 }}>
+        <strong style={{ color: T.color.textPrimary }}>{recipient.name}</strong> に <strong style={{ color: T.color.textPrimary }}>{amount} THX</strong> を送りました。<br/>あなたのありがとうが記録されました。
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <Button variant="primary" full onClick={() => { onSent?.({ to: recipient.name, amount, msg }); onClose(); }}>ホームへ戻る</Button>
+        <Button variant="ghost" full onClick={() => { setRecipient(null); setAmount(50); setMsg(''); setStep('recipient'); }}>もう一人に送る</Button>
+      </div>
+    </div>
+  );
+}
+
+const amountBtn = {
+  width: 36, height: 36, borderRadius: T.radius.full,
+  background: T.color.surface, border: 'none',
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+  cursor: 'pointer', color: T.color.textPrimary,
+  boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+};
+
+// ─── SPLIT CREATE ─────────────────────────────────────────────
+function SplitCreateScreen({ goto }) {
+  const [step, setStep] = useState('form');
+  const [name, setName] = useState('kuu village day 8');
+  const [duty, setDuty] = useState(75);
+  const [recv, setRecv] = useState(30);
+  const [selectedDuties, setSelectedDuties] = useState(new Set(['dishes', 'breakfast', 'food']));
+
+  const previewShares = useMemo(() => {
+    const base = D.splits[0].shares.map((s, i) => ({ ...s, pct: s.pct * (0.9 + (i * 0.03)) }));
+    const sum = base.reduce((a, b) => a + b.pct, 0);
+    return base.map(s => ({ ...s, pct: (s.pct / sum) * 100 }));
+  }, [duty, recv, selectedDuties]);
+
+  if (step === 'done') {
+    return (
+      <div style={{ padding: '40px 24px 24px', textAlign: 'center' }}>
+        <div style={{ width: 88, height: 88, borderRadius: T.radius.full, background: T.color.split,
+          margin: '0 auto 20px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <Icon name="pie" size={40} color="#fff" />
+        </div>
+        <div style={{ fontSize: 22, fontWeight: 700, marginBottom: 8 }}>分配ルールを作成しました</div>
+        <div style={{ fontSize: 13, color: T.color.textSecondary, marginBottom: 28 }}>
+          <strong style={{ color: T.color.textPrimary }}>{name}</strong> が作成されました。
+        </div>
+        <Button variant="primary" full onClick={() => goto({ name: 'splits' })}>分配一覧へ戻る</Button>
+      </div>
+    );
+  }
+
+  if (step === 'preview') {
+    return (
+      <div style={{ paddingBottom: 24 }}>
+        <ScreenHeader title="分配プレビュー" subtitle="この設定での分配結果" onBack={() => setStep('form')} />
+        <div style={{ padding: '8px 16px 0' }}>
+          <Card padding={20} style={{ textAlign: 'center', background: '#F0F6FB', borderColor: '#5DADEC44' }}>
+            <DonutChart shares={previewShares} size={140} total={previewShares.length} />
+            <div style={{ marginTop: 8, fontSize: 12, color: T.color.textSecondary }}>{name}</div>
+          </Card>
+        </div>
+        <SectionLabel>分配の内訳</SectionLabel>
+        <div style={{ padding: '0 16px 16px' }}>
+          <Card padding={0}>
+            {previewShares.map((s, i) => (
+              <div key={s.name} style={{display:"contents"}}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 16px' }}>
+                  <Avatar name={s.name} size={32} />
+                  <div style={{ flex: 1, fontSize: 14, fontWeight: 600 }}>{s.name}</div>
+                  <div style={{ fontSize: 14, fontWeight: 700 }}>{s.pct.toFixed(2)}%</div>
+                </div>
+                {i < previewShares.length - 1 && <Divider inset={16} />}
+              </div>
+            ))}
+          </Card>
+        </div>
+        <div style={{ padding: '0 16px 16px' }}>
+          <Card padding={14} style={{ background: T.color.primarySoft, borderColor: T.color.primary + '55' }}>
+            <div style={{ fontSize: 12, color: '#7A5A2E', fontWeight: 700, marginBottom: 6 }}>分配のもとになった要素</div>
+            <div style={{ fontSize: 12, color: T.color.textPrimary, lineHeight: 1.6 }}>
+              ・ 当番への参加（{duty}%）<br/>
+              ・ サンクスの受け取り・送付（{100 - duty}%）
+            </div>
+          </Card>
+        </div>
+        <div style={{ padding: '0 16px', display: 'flex', gap: 10 }}>
+          <Button variant="secondary" onClick={() => setStep('form')}>戻って修正</Button>
+          <Button variant="primary" full onClick={() => setStep('done')}>作成する</Button>
+        </div>
+      </div>
+    );
+  }
+
+  const valid = name.trim() && selectedDuties.size > 0;
+  return (
+    <div style={{ paddingBottom: 24 }}>
+      <ScreenHeader title="分配ルールを作成" onBack={() => goto({ name: 'splits' })} />
+      <div style={{ padding: '4px 20px 0' }}>
+        <FieldLabel>分配ルール名</FieldLabel>
+        <Input value={name} onChange={setName} />
+      </div>
+      <div style={{ padding: '20px 20px 0' }}>
+        <FieldLabel>何を重視する？</FieldLabel>
+        <Card padding={16}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 8 }}>
+            <span style={{ fontWeight: 600 }}>当番ベース</span>
+            <span style={{ fontWeight: 700, color: T.color.role }}>{duty}%</span>
+          </div>
+          <input type="range" min={0} max={100} value={duty} onChange={e => setDuty(+e.target.value)}
+            style={{ width: '100%', accentColor: T.color.primary }} />
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginTop: 12, marginBottom: 4 }}>
+            <span style={{ fontWeight: 600 }}>サンクスベース</span>
+            <span style={{ fontWeight: 700, color: T.color.contrib }}>{100 - duty}%</span>
+          </div>
+        </Card>
+      </div>
+
+      <div style={{ padding: '20px 20px 0' }}>
+        <FieldLabel>サンクスの中で何を重視する？</FieldLabel>
+        <Card padding={16}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 8 }}>
+            <span style={{ fontWeight: 600 }}>受け取った量</span>
+            <span style={{ fontWeight: 700, color: T.color.contrib }}>{recv}%</span>
+          </div>
+          <input type="range" min={0} max={100} value={recv} onChange={e => setRecv(+e.target.value)}
+            style={{ width: '100%', accentColor: T.color.contrib }} />
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginTop: 12 }}>
+            <span style={{ fontWeight: 600 }}>送った量</span>
+            <span style={{ fontWeight: 700, color: T.color.primary }}>{100 - recv}%</span>
+          </div>
+        </Card>
+      </div>
+
+      <div style={{ padding: '20px 20px 0' }}>
+        <FieldLabel>対象にする当番</FieldLabel>
+        <Card padding={0}>
+          {D.duties.map((d, i) => {
+            const checked = selectedDuties.has(d.id);
+            return (
+              <div key={d.id} style={{display:"contents"}}>
+                <button onClick={() => {
+                  const next = new Set(selectedDuties);
+                  next.has(d.id) ? next.delete(d.id) : next.add(d.id);
+                  setSelectedDuties(next);
+                }} style={{
+                  width: '100%', display: 'flex', alignItems: 'center', gap: 12,
+                  padding: '12px 16px', background: 'none', border: 'none',
+                  cursor: 'pointer', fontFamily: T.font, textAlign: 'left',
+                }}>
+                  <div style={{
+                    width: 22, height: 22, borderRadius: 6,
+                    background: checked ? T.color.primary : T.color.surface,
+                    border: `1.5px solid ${checked ? T.color.primary : T.color.border}`,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 'none',
+                  }}>{checked && <Icon name="check" size={14} color="#fff" stroke={2.5} />}</div>
+                  <span style={{ flex: 1, fontSize: 14, fontWeight: 600 }}>{d.name}</span>
+                </button>
+                {i < D.duties.length - 1 && <Divider inset={50} />}
+              </div>
+            );
+          })}
+        </Card>
+      </div>
+
+      <div style={{ padding: 16, marginTop: 16 }}>
+        <Button variant="primary" full disabled={!valid} icon="pie" onClick={() => setStep('preview')}>プレビューを見る</Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── WORKSPACE LIST ─────────────────────────────────────────
+function WorkspaceListScreen({ ws, onPick, onCreate }) {
+  return (
+    <div style={{ paddingBottom: 24 }}>
+      <div style={{ padding: '14px 20px 8px' }}>
+        <div style={{ fontSize: 13, color: T.color.textSecondary }}>こんにちは、{D.user.name} さん</div>
+        <div style={{ fontSize: 24, fontWeight: 800, marginTop: 2, letterSpacing: -0.4 }}>ワークスペース</div>
+      </div>
+      <div style={{ padding: '4px 16px 16px' }}>
+        <Input icon="search" placeholder="ワークスペースを検索" value="" onChange={() => {}} />
+      </div>
+      <SectionLabel>参加中</SectionLabel>
+      <div style={{ padding: '0 16px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {D.workspaces.map(w => (
+          <Card key={w.id} onClick={() => onPick(w)} padding={16}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+              <div style={{ width: 48, height: 48, borderRadius: T.radius.md, background: w.color, color: '#fff',
+                display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 22, fontWeight: 700 }}>{w.icon}</div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 16, fontWeight: 700 }}>{w.name}</div>
+                <div style={{ fontSize: 12, color: T.color.textSecondary, marginTop: 3,
+                  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{w.desc}</div>
+                <div style={{ fontSize: 11, color: T.color.textSecondary, marginTop: 6 }}>
+                  {w.members}人 ・ 最近の活動: {w.lastActive}
+                </div>
+              </div>
+              {ws?.id === w.id && <Badge kind="member">現在</Badge>}
+            </div>
+          </Card>
+        ))}
+      </div>
+      <div style={{ padding: 16, marginTop: 8 }}>
+        <Button variant="secondary" full icon="plus" onClick={onCreate}>新しいワークスペースを作成</Button>
+      </div>
+    </div>
+  );
+}
+
+// expose
+Object.assign(window, {
+  HomeScreen, DutiesScreen, DutyDetailScreen, AssignDutyScreen,
+  SplitsScreen, SplitDetailScreen, SplitCreateScreen,
+  MembersScreen, MemberDetailScreen, WalletScreen,
+  ThanksFlow, WorkspaceListScreen,
+});

--- a/docs/design/handoff/project/thanks-insights.jsx
+++ b/docs/design/handoff/project/thanks-insights.jsx
@@ -1,0 +1,397 @@
+// Thanks insights — list / treemap / friendship rankings
+
+(() => {
+  const NAMES_EXTRA = ['ひらやま', 'james', 'unosaya', 'taro', '中田柚葉', '前田陽太', '濱田太陽', 'はたしょう', '秋山淳', 'irohas', 'まつお', 'genks', 'ゴロー', 'スケン', '村上', '大久保', '日向', '東大介'];
+  const allNames = [
+    ...window.TOBAN_DATA.members.map(m => m.name),
+    'me-ryoma', ...NAMES_EXTRA,
+  ].map(n => n === 'me-ryoma' ? 'ryoma' : n);
+
+  // Deterministic PRNG so re-renders match
+  function mulberry(seed) {
+    return function() {
+      seed |= 0; seed = seed + 0x6D2B79F5 | 0;
+      let t = Math.imul(seed ^ seed >>> 15, 1 | seed);
+      t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+      return ((t ^ t >>> 14) >>> 0) / 4294967296;
+    };
+  }
+  const messages = [
+    '手伝ってくれてありがとう！', '準備してくれて助かりました', '今日の対応ありがとう',
+    'EXPOにお誘いいただきありがとうございます', '運動会おつかれさまでした',
+    'いつも気にかけてくれてありがとう', 'Tobanの仕様確認ありがとう！',
+    'ご飯作ってくれてありがとう', '送迎ありがとうございました',
+  ];
+  const rand = mulberry(42);
+  const TXS = [];
+  const NOW = new Date('2026-05-08T22:30:00');
+  // 80 transactions across 60 days
+  for (let i = 0; i < 80; i++) {
+    let from = allNames[Math.floor(rand() * allNames.length)];
+    let to = allNames[Math.floor(rand() * allNames.length)];
+    if (from === to) to = allNames[(allNames.indexOf(to) + 1) % allNames.length];
+    const amounts = [10, 14, 20, 25, 30, 50, 100];
+    // bias popular pairs
+    const popularPairs = [['ひらやま', 'homma'], ['前田陽太', 'genks'], ['前田陽太', 'はたしょう'], ['sg', 'genks'], ['sg', '濱田太陽'], ['atsu', 'taro']];
+    if (rand() < 0.35) {
+      const pp = popularPairs[Math.floor(rand() * popularPairs.length)];
+      from = pp[Math.floor(rand() * 2)];
+      to = pp[1 - pp.indexOf(from)];
+    }
+    const amt = amounts[Math.floor(rand() * amounts.length)];
+    const daysAgo = Math.floor(rand() * 60);
+    const hoursAgo = Math.floor(rand() * 24);
+    const t = new Date(NOW.getTime() - (daysAgo * 24 + hoursAgo) * 3600 * 1000);
+    TXS.push({
+      id: 'tx' + i, from, to, amount: amt, time: t,
+      msg: rand() < 0.6 ? messages[Math.floor(rand() * messages.length)] : '',
+    });
+  }
+  TXS.sort((a, b) => b.time - a.time);
+  window.TOBAN_TXS = TXS;
+})();
+
+function ThanksInsightsScreen({ goto }) {
+  const [tab, setTab] = useState('list');
+  const [period, setPeriod] = useState('month'); // week | month | all
+  const [sort, setSort] = useState('amount'); // amount | count
+
+  const NOW = new Date('2026-05-08T22:30:00');
+  const cutoff = period === 'week' ? new Date(NOW - 7 * 86400000)
+    : period === 'month' ? new Date(NOW - 30 * 86400000)
+      : new Date(0);
+
+  const txs = window.TOBAN_TXS.filter(t => t.time >= cutoff);
+
+  return (
+    <div style={{ paddingBottom: 24 }}>
+      <ScreenHeader title="サンクスのデータ" subtitle={`${txs.length}件の送付`} onBack={() => goto({ name: 'home' })} />
+
+      {/* Period chips */}
+      <div style={{ padding: '0 16px 12px', display: 'flex', gap: 8, overflowX: 'auto' }}>
+        {[
+          { v: 'week', label: '今週' },
+          { v: 'month', label: '30日' },
+          { v: 'all', label: '全期間' },
+        ].map(p => {
+          const active = period === p.v;
+          return (
+            <button key={p.v} onClick={() => setPeriod(p.v)} style={{
+              padding: '6px 14px', borderRadius: 999,
+              background: active ? T.color.textPrimary : T.color.surface,
+              color: active ? '#fff' : T.color.textPrimary,
+              border: `1px solid ${active ? T.color.textPrimary : T.color.border}`,
+              fontFamily: T.font, fontSize: 12, fontWeight: 600,
+              cursor: 'pointer', whiteSpace: 'nowrap', flex: 'none',
+            }}>{p.label}</button>
+          );
+        })}
+        <div style={{ flex: 1 }} />
+        <button style={{
+          padding: '6px 12px', borderRadius: 999,
+          background: T.color.surface, color: T.color.textSecondary,
+          border: `1px solid ${T.color.border}`,
+          fontFamily: T.font, fontSize: 12, fontWeight: 600,
+          display: 'inline-flex', alignItems: 'center', gap: 4,
+          cursor: 'pointer', flex: 'none',
+        }}>
+          <Icon name="search" size={12} /> カスタム
+        </button>
+      </div>
+
+      {/* Tabs */}
+      <div style={{
+        display: 'flex', borderBottom: `1px solid ${T.color.border}`,
+        margin: '0 16px', gap: 24,
+      }}>
+        {[
+          { v: 'list', label: 'リスト' },
+          { v: 'graph', label: 'グラフ' },
+          { v: 'friends', label: 'フレンドシップ' },
+        ].map(o => {
+          const active = tab === o.v;
+          return (
+            <button key={o.v} onClick={() => setTab(o.v)} style={{
+              padding: '10px 0', background: 'transparent', border: 'none',
+              borderBottom: `2px solid ${active ? T.color.textPrimary : 'transparent'}`,
+              fontFamily: T.font, fontSize: 14,
+              fontWeight: active ? 700 : 500,
+              color: active ? T.color.textPrimary : T.color.textSecondary,
+              cursor: 'pointer', marginBottom: -1,
+            }}>{o.label}</button>
+          );
+        })}
+      </div>
+
+      {/* Summary */}
+      <div style={{ padding: '12px 16px' }}>
+        <Card padding={14}>
+          <div style={{ display: 'flex', justifyContent: 'space-around', textAlign: 'center' }}>
+            <SummaryStat label="送付件数" value={txs.length} unit="件" />
+            <Splitter />
+            <SummaryStat label="合計" value={txs.reduce((s, t) => s + t.amount, 0)} unit="THX" tone="green" />
+            <Splitter />
+            <SummaryStat label="参加者" value={new Set(txs.flatMap(t => [t.from, t.to])).size} unit="人" />
+          </div>
+        </Card>
+      </div>
+
+      {tab === 'list' && <TxList txs={txs} />}
+      {tab === 'graph' && <TxGraph txs={txs} />}
+      {tab === 'friends' && <TxFriends txs={txs} sort={sort} setSort={setSort} />}
+    </div>
+  );
+}
+
+const Splitter = () => <div style={{ width: 1, background: T.color.border }} />;
+
+const SummaryStat = ({ label, value, unit, tone }) => (
+  <div style={{ flex: 1 }}>
+    <div style={{ fontSize: 11, color: T.color.textSecondary, fontWeight: 600 }}>{label}</div>
+    <div style={{ fontSize: 22, fontWeight: 700, color: tone === 'green' ? T.color.contrib : T.color.textPrimary, marginTop: 2, letterSpacing: -0.5, fontFamily: T.fontDisplay || T.font }}>
+      {value.toLocaleString()}<span style={{ fontSize: 11, color: T.color.textSecondary, fontWeight: 600, marginLeft: 3 }}>{unit}</span>
+    </div>
+  </div>
+);
+
+// ─── List view ───────────────────────────────────────────────
+function TxList({ txs }) {
+  const fmt = (d) => {
+    const m = d.getMonth() + 1, day = d.getDate();
+    const hh = String(d.getHours()).padStart(2, '0');
+    const mm = String(d.getMinutes()).padStart(2, '0');
+    return `${m}/${day} ${hh}:${mm}`;
+  };
+  return (
+    <div style={{ padding: '0 16px' }}>
+      {txs.slice(0, 30).map(t => (
+        <div key={t.id} style={{
+          background: '#E8F6EE',
+          border: `1px solid ${T.color.contrib}33`,
+          borderRadius: T.radius.md,
+          padding: 12, marginBottom: 8,
+          position: 'relative',
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: t.msg ? 6 : 0 }}>
+            <Avatar name={t.from} size={28} />
+            <div style={{ fontSize: 13, fontWeight: 700, flex: 'none' }}>{t.from}</div>
+            <div style={{
+              flex: 1, display: 'flex', alignItems: 'center', gap: 6,
+              padding: '0 4px', minWidth: 0,
+            }}>
+              <div style={{ flex: 1, height: 1, background: T.color.contrib + '66' }} />
+              <div style={{ fontSize: 14, fontWeight: 700, color: '#2F8B58', whiteSpace: 'nowrap', flex: 'none' }}>
+                {t.amount}<span style={{ fontSize: 10, marginLeft: 2 }}>THX</span>
+              </div>
+              <div style={{ flex: 1, height: 1, background: T.color.contrib + '66' }} />
+              <Icon name="chevron-right" size={12} color={T.color.contrib} />
+            </div>
+            <div style={{ fontSize: 13, fontWeight: 700, flex: 'none' }}>{t.to}</div>
+            <Avatar name={t.to} size={28} />
+          </div>
+          {t.msg && (
+            <div style={{ fontSize: 12, color: T.color.textPrimary, lineHeight: 1.5,
+              paddingLeft: 36, paddingRight: 36 }}>{t.msg}</div>
+          )}
+          <div style={{ fontSize: 10, color: T.color.textSecondary, marginTop: 6, paddingLeft: 36 }}>{fmt(t.time)}</div>
+        </div>
+      ))}
+      {txs.length > 30 && (
+        <div style={{ textAlign: 'center', padding: '16px 0', fontSize: 12, color: T.color.textSecondary }}>
+          残り {txs.length - 30} 件
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Treemap (squarified) ────────────────────────────────────
+function squarify(values, x, y, w, h) {
+  const total = values.reduce((s, v) => s + v.value, 0);
+  if (total <= 0 || values.length === 0) return [];
+  const items = values.map(v => ({ ...v, area: v.value / total * w * h }));
+  const result = [];
+  let remaining = items.slice();
+  let rect = { x, y, w, h };
+
+  function worst(row, length) {
+    const sum = row.reduce((s, r) => s + r.area, 0);
+    let max = 0, min = Infinity;
+    row.forEach(r => { max = Math.max(max, r.area); min = Math.min(min, r.area); });
+    return Math.max((length * length * max) / (sum * sum), (sum * sum) / (length * length * min));
+  }
+  function layoutRow(row, length, rect) {
+    const sum = row.reduce((s, r) => s + r.area, 0);
+    const isHoriz = rect.w >= rect.h;
+    const sideLen = sum / length;
+    let off = 0;
+    for (const r of row) {
+      const sz = r.area / sideLen;
+      if (isHoriz) {
+        result.push({ ...r, x: rect.x, y: rect.y + off, w: sideLen, h: sz });
+        off += sz;
+      } else {
+        result.push({ ...r, x: rect.x + off, y: rect.y, w: sz, h: sideLen });
+        off += sz;
+      }
+    }
+    if (isHoriz) return { x: rect.x + sideLen, y: rect.y, w: rect.w - sideLen, h: rect.h };
+    return { x: rect.x, y: rect.y + sideLen, w: rect.w, h: rect.h - sideLen };
+  }
+
+  while (remaining.length > 0) {
+    const length = Math.min(rect.w, rect.h);
+    if (length <= 0) break;
+    let row = [];
+    let bestRatio = Infinity;
+    while (remaining.length > 0) {
+      const next = [...row, remaining[0]];
+      const r = worst(next, length);
+      if (row.length === 0 || r < bestRatio) {
+        row = next; bestRatio = r;
+        remaining = remaining.slice(1);
+      } else break;
+    }
+    rect = layoutRow(row, length, rect);
+  }
+  return result;
+}
+
+function TxGraph({ txs }) {
+  const W = 360, H = 240;
+
+  const heldMap = {}, sentMap = {};
+  for (const t of txs) {
+    heldMap[t.to] = (heldMap[t.to] || 0) + t.amount;
+    sentMap[t.from] = (sentMap[t.from] || 0) + t.amount;
+  }
+  const heldArr = Object.entries(heldMap).map(([name, v]) => ({ name, value: v })).sort((a, b) => b.value - a.value);
+  const sentArr = Object.entries(sentMap).map(([name, v]) => ({ name, value: v })).sort((a, b) => b.value - a.value);
+
+  return (
+    <div style={{ padding: '0 16px' }}>
+      <Treemap title="保有しているサンクストークン" data={heldArr} W={W} H={H} fill="#5DADEC" />
+      <div style={{ height: 16 }} />
+      <Treemap title="送ったサンクストークン" data={sentArr} W={W} H={H} fill="#F5B82E" />
+
+      <Card padding={14} style={{ marginTop: 16 }}>
+        <div style={{ fontSize: 12, color: T.color.textSecondary, fontWeight: 600, marginBottom: 8 }}>読みかた</div>
+        <div style={{ fontSize: 12, lineHeight: 1.6 }}>
+          四角の<strong>面積</strong>が、その人の保有量・送付量の大きさを表しています。
+          上段は受け取った合計、下段は送った合計です。
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function Treemap({ title, data, W, H, fill }) {
+  const rects = useMemo(() => squarify(data, 0, 0, W, H), [data, W, H]);
+  return (
+    <Card padding={14}>
+      <div style={{ fontSize: 13, color: T.color.textSecondary, fontWeight: 600, marginBottom: 10, textAlign: 'center' }}>{title}</div>
+      <div style={{ position: 'relative', width: W, height: H, margin: '0 auto' }}>
+        {rects.map((r, i) => {
+          const small = r.w < 36 || r.h < 26;
+          const fontSize = Math.min(Math.max(Math.min(r.w, r.h) * 0.22, 8), 14);
+          return (
+            <div key={r.name} style={{
+              position: 'absolute',
+              left: r.x + 1, top: r.y + 1,
+              width: Math.max(r.w - 2, 0), height: Math.max(r.h - 2, 0),
+              background: fill,
+              borderRadius: 4,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              color: '#fff',
+              fontSize, fontWeight: 600,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              padding: 2,
+              opacity: 0.7 + 0.3 * (1 - i / Math.max(rects.length - 1, 1)),
+            }} title={`${r.name}: ${r.value} THX`}>
+              {!small && <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{r.name}</span>}
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}
+
+// ─── Friendship rankings ─────────────────────────────────────
+function TxFriends({ txs, sort, setSort }) {
+  const pairs = useMemo(() => {
+    const m = {};
+    for (const t of txs) {
+      const k = [t.from, t.to].sort().join('|');
+      if (!m[k]) m[k] = { a: k.split('|')[0], b: k.split('|')[1], total: 0, count: 0 };
+      m[k].total += t.amount;
+      m[k].count += 1;
+    }
+    const arr = Object.values(m);
+    arr.sort((x, y) => sort === 'amount' ? y.total - x.total : y.count - x.count);
+    return arr;
+  }, [txs, sort]);
+
+  const top = pairs.slice(0, 24);
+
+  const palettes = [
+    { bg: '#FFF2CF', fg: '#7A5A2E', dot: '#F5B82E' },                  // gold
+    { bg: '#EEEEEE', fg: '#5A5A5A', dot: '#A0A0A0' },                  // silver
+    { bg: '#FCE4D8', fg: '#A33C18', dot: '#D9531D' },                  // bronze
+  ];
+  const lavender = { bg: '#F2EBF8', fg: '#6E4DAA', dot: '#9B7AD8' };
+
+  return (
+    <div style={{ padding: '0 16px' }}>
+      <Segmented value={sort} onChange={setSort} options={[
+        { value: 'amount', label: '総交換量順' },
+        { value: 'count', label: '取引回数順' },
+      ]} />
+      <div style={{ height: 12 }} />
+      {top.map((p, i) => {
+        const pal = palettes[i] || lavender;
+        return (
+          <div key={p.a + '|' + p.b} style={{
+            background: pal.bg, borderRadius: T.radius.md,
+            padding: '12px 14px', marginBottom: 8,
+            display: 'flex', alignItems: 'center', gap: 12,
+          }}>
+            <div style={{
+              width: 36, height: 36, borderRadius: 999, background: pal.dot,
+              color: '#fff', fontWeight: 700, fontSize: 16,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              flex: 'none',
+            }}>{i + 1}</div>
+            <div style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 8, justifyContent: 'center' }}>
+              <PairAvatar name={p.a} />
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', color: pal.fg }}>
+                <Icon name="arrow-right" size={14} color={pal.fg} />
+                <Icon name="arrow-right" size={14} color={pal.fg} style={{ transform: 'scaleX(-1)' }} />
+              </div>
+              <PairAvatar name={p.b} />
+            </div>
+            <div style={{ textAlign: 'right', flex: 'none' }}>
+              <div style={{ fontSize: 18, fontWeight: 700, color: pal.fg, fontFamily: T.fontDisplay || T.font, letterSpacing: -0.5 }}>{p.total}</div>
+              <div style={{ fontSize: 10, color: pal.fg, opacity: 0.85 }}>{p.count}回</div>
+            </div>
+          </div>
+        );
+      })}
+      {top.length === 0 && (
+        <div style={{ textAlign: 'center', padding: '40px 20px', color: T.color.textSecondary, fontSize: 13 }}>
+          この期間にはサンクスの送付がありません
+        </div>
+      )}
+    </div>
+  );
+}
+
+const PairAvatar = ({ name }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+    <Avatar name={name} size={32} />
+    <div style={{ fontSize: 10, fontWeight: 600, color: T.color.textPrimary, maxWidth: 60, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{name}</div>
+  </div>
+);
+
+Object.assign(window, { ThanksInsightsScreen });

--- a/docs/design/handoff/project/tokens.js
+++ b/docs/design/handoff/project/tokens.js
@@ -1,0 +1,25 @@
+// Toban design tokens
+window.TOBAN = {
+  color: {
+    primary: '#F5B82E',
+    primarySoft: '#FFF2CF',
+    bg: '#FAF7F0',
+    surface: '#FFFFFF',
+    textPrimary: '#1F1F1F',
+    textSecondary: '#68645D',
+    border: '#E7E1D7',
+    contrib: '#65C98A',
+    split: '#5DADEC',
+    role: '#D6B995',
+    danger: '#E45C4F',
+    overlay: 'rgba(31,31,31,0.45)',
+  },
+  radius: { xs: 8, sm: 12, md: 20, lg: 28, full: 999 },
+  space: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 8: 32, 10: 40, 12: 48 },
+  shadow: {
+    1: '0 1px 2px rgba(31,31,31,0.04)',
+    2: '0 2px 8px rgba(31,31,31,0.06)',
+    3: '0 8px 24px rgba(31,31,31,0.08)',
+  },
+  font: '"Hiragino Sans", "Yu Gothic UI", "Noto Sans JP", -apple-system, system-ui, sans-serif',
+};


### PR DESCRIPTION
## Summary
- `docs/design/handoff/` 配下に Claude Design プロトタイプのソース（HTML / JSX / JS、計 280KB）と対話ログを追加
- README で「あくまで参考、完全ではない」「Desktop は特にレイアウト崩れあり」を明記
- フロントエンドフルリニューアル（#418）の子 Issue 32 件すべてに `docs/design/handoff/` への参照を追記済み（本 PR マージ後にリンクが解決）

## Test plan
- [ ] `docs/design/handoff/README.md` が GitHub 上で正しくレンダリングされる
- [ ] `Toban Prototype.html` / `Toban Desktop.html` をローカルブラウザで開いてプロトタイプが動く

Refs: #418