### PR TITLE
chore: add Claude Code worktree hooks for parallel development

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/claude-worktree-create.sh"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/claude-worktree-remove.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules
 **/.env
 .serena
+.claude/worktrees/
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -294,3 +294,80 @@ These solutions were combined with ideas from [Hats Protocol](https://www.hatspr
     # --module には bigBangコントラクトの時に出力される hatsTimeFrameModule のアドレスを当てはめること！
     pnpm contract batchMintHat --hatid 39145842972085145413893403125858635166881967613628980006401871953526784 --csv ./data/example-wearers.csv --module 0xA193a4CE929168A594744A53Fb17Ba4caBb507a4 --network sepolia
     ```
+
+## Development with Claude Code (worktree)
+
+`.claude/settings.json` に `WorktreeCreate` / `WorktreeRemove` フックを登録済みです。`claude --worktree <name>` 一発で issue ごとに独立した作業環境を立ち上げ、PR 作成まで進められます。
+
+### Quick reference
+
+| 操作 | コマンド |
+| --- | --- |
+| worktree を作成して Claude セッション起動 | `claude --worktree issue/xxx` |
+| worktree 一覧 | `git worktree list` |
+| PR 作成 (リモート main 向け) | `gh pr create --base main` |
+| セッション終了 (フックで worktree も削除) | Claude セッション内で `/exit` |
+
+### 1. worktree を作成して Claude を起動
+
+別ペイン（tmux/VS Code split など）で実行:
+
+```bash
+claude --worktree issue/xxx
+```
+
+`WorktreeCreate` フックが `scripts/claude-worktree-create.sh` を起動し、以下を実行します:
+
+1. `.claude/worktrees/issue/xxx/` に worktree を作成 (ブランチ名: `worktree-issue/xxx`)
+2. `pkgs/{cli,contract,frontend}/.env` を main repo からコピー
+3. `pnpm install --frozen-lockfile`
+4. `pnpm frontend codegen` (graphql-codegen)
+5. `pnpm contract compile` (hardhat compile)
+
+bootstrap ログは `.claude/worktrees/issue/xxx/.worktree-setup.log` に出力されます。
+
+デフォルトでは現在の `HEAD` から分岐します。リモート `main` のクリーンな状態から始めたい場合:
+
+```bash
+TOBAN_WORKTREE_BASE_REF=origin/main claude --worktree issue/xxx
+```
+
+### 2. 編集 → コミット
+
+worktree 内で通常どおり開発します。Claude セッションは worktree の中で起動しているので、Claude に依頼してそのまま編集 / コミットさせて構いません。手動の場合:
+
+```bash
+cd .claude/worktrees/issue/xxx
+git add -A
+git commit -m "feat: ..."
+```
+
+メインリポジトリと同じ lefthook の pre-commit (biome + frontend typecheck) が走ります。
+
+### 3. リモート main 向け PR を作成
+
+```bash
+# Claude セッション内、または worktree ディレクトリで
+git push -u origin worktree-issue/xxx
+gh pr create --base main --title "<PR title>" --body "Closes #xxx"
+```
+
+Claude に「PR を作って」と頼めば push と `gh pr create` まで自動化されます。
+
+### 4. worktree を終了・削除
+
+Claude セッション内で `/exit` すると `WorktreeRemove` フック (`scripts/claude-worktree-remove.sh`) が発火し、worktree とローカルブランチが自動で削除されます。
+
+セッション外から手動で片付ける場合:
+
+```bash
+git worktree remove .claude/worktrees/issue/xxx
+git branch -D worktree-issue/xxx
+git push origin --delete worktree-issue/xxx  # リモート追跡ブランチも消す場合
+```
+
+### Tips
+
+- **並行作業**: `claude --worktree issue/aaa` と `claude --worktree issue/bbb` を別ペインで同時起動。各 worktree は独立した `node_modules` と `.env` を持つので衝突しません。
+- **bootstrap 失敗は非ブロッキング**: codegen が goldsky API ネットワーク問題で落ちても worktree 自体は作成完了。`.worktree-setup.log` を確認してください。
+- **gitignore 済み**: `.claude/worktrees/` と `.claude/settings.local.json` はリポジトリ管理外。`.claude/settings.json` (チーム共有のフック設定) と `scripts/claude-worktree-*.sh` のみコミット対象です。

--- a/scripts/claude-worktree-create.sh
+++ b/scripts/claude-worktree-create.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Claude Code WorktreeCreate hook for Toban (pnpm workspace monorepo).
+#
+# Contract (https://code.claude.com/docs/en/hooks):
+#   - Receives JSON on stdin with a `.name` field (the requested worktree name).
+#   - MUST print the absolute worktree path on stdout (and nothing else).
+#   - Progress output goes to /dev/tty so it does not pollute stdout.
+#   - Non-zero exit aborts worktree creation.
+
+set -euo pipefail
+
+INPUT=$(cat)
+NAME=$(echo "$INPUT" | jq -r '.name')
+REPO_PATH="$CLAUDE_PROJECT_DIR"
+WORKTREE_PATH="${REPO_PATH}/.claude/worktrees/${NAME}"
+BRANCH="worktree-${NAME}"
+BASE_REF="${TOBAN_WORKTREE_BASE_REF:-HEAD}"
+
+TTY=/dev/tty
+log() { echo "$*" > "$TTY" 2>/dev/null || true; }
+
+mkdir -p "${REPO_PATH}/.claude/worktrees"
+
+log "Creating worktree '${NAME}' from ${BASE_REF}..."
+if git -C "$REPO_PATH" rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
+  git -C "$REPO_PATH" worktree add "$WORKTREE_PATH" "$BRANCH" >/dev/null 2>&1
+else
+  git -C "$REPO_PATH" worktree add -b "$BRANCH" "$WORKTREE_PATH" "$BASE_REF" >/dev/null 2>&1
+fi
+
+# Copy gitignored env files. .worktreeinclude is bypassed when this hook
+# replaces default git behavior, so handle it explicitly.
+log "Copying env files..."
+ENV_FILES=(
+  "pkgs/cli/.env"
+  "pkgs/contract/.env"
+  "pkgs/frontend/.env"
+)
+for f in "${ENV_FILES[@]}"; do
+  if [ -f "${REPO_PATH}/$f" ]; then
+    mkdir -p "$(dirname "${WORKTREE_PATH}/$f")"
+    cp "${REPO_PATH}/$f" "${WORKTREE_PATH}/$f"
+  fi
+done
+
+LOGFILE="${WORKTREE_PATH}/.worktree-setup.log"
+SETUP_ERRORS=()
+
+log "Running pnpm install (output: ${LOGFILE})..."
+(cd "$WORKTREE_PATH" && pnpm install --frozen-lockfile) >> "$LOGFILE" 2>&1 \
+  || SETUP_ERRORS+=("pnpm install failed")
+
+log "Running frontend graphql-codegen..."
+(cd "$WORKTREE_PATH" && pnpm frontend codegen) >> "$LOGFILE" 2>&1 \
+  || SETUP_ERRORS+=("frontend codegen failed (network or schema issue?)")
+
+log "Running contract hardhat compile..."
+(cd "$WORKTREE_PATH" && pnpm contract compile) >> "$LOGFILE" 2>&1 \
+  || SETUP_ERRORS+=("contract compile failed")
+
+if [ ${#SETUP_ERRORS[@]} -gt 0 ]; then
+  log "Worktree created with warnings:"
+  printf '  - %s\n' "${SETUP_ERRORS[@]}" > "$TTY" 2>/dev/null || true
+  log "Details: ${LOGFILE}"
+else
+  log "Worktree ready: ${WORKTREE_PATH}"
+fi
+
+# THE ONLY thing on stdout — Claude parses this as the worktree path.
+echo "$WORKTREE_PATH"

--- a/scripts/claude-worktree-remove.sh
+++ b/scripts/claude-worktree-remove.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Claude Code WorktreeRemove hook for Toban.
+# Receives JSON on stdin with `.name`. Failures are non-blocking (logged only).
+set -euo pipefail
+
+INPUT=$(cat)
+NAME=$(echo "$INPUT" | jq -r '.name')
+REPO_PATH="$CLAUDE_PROJECT_DIR"
+WORKTREE_PATH="${REPO_PATH}/.claude/worktrees/${NAME}"
+BRANCH="worktree-${NAME}"
+
+git -C "$REPO_PATH" worktree remove --force "$WORKTREE_PATH" >/dev/null 2>&1 || true
+git -C "$REPO_PATH" branch -D "$BRANCH" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

- `.claude/settings.json` に `WorktreeCreate` / `WorktreeRemove` フックを登録し、`claude --worktree <name>` 一発で issue ごとの隔離環境を立ち上げ可能に
- `scripts/claude-worktree-create.sh` で worktree 作成 → `.env` コピー → `pnpm install --frozen-lockfile` → `pnpm frontend codegen` → `pnpm contract compile` の bootstrap を自動化。`scripts/claude-worktree-remove.sh` でセッション終了時に worktree とブランチを掃除
- README に「Development with Claude Code (worktree)」節を追加し、worktree 作成から PR 作成・終了までの手順をドキュメント化

## なぜ

Claude Code 2.x で worktree フック (`WorktreeCreate` / `WorktreeRemove`) が公式仕様化され、複数ペインでの並行作業時に `pnpm install` や `.env` 配置などの初期化を自動化できるようになったため。

## Test plan

- [ ] `claude --worktree test/bootstrap` を実行し `.claude/worktrees/test/bootstrap/` に worktree が作成されること
- [ ] worktree 内に `pkgs/{cli,contract,frontend}/.env` がコピーされていること
- [ ] `node_modules` が新たに作成され、`pnpm frontend codegen` と `pnpm contract compile` が成功していること（`.worktree-setup.log` で確認）
- [ ] セッション終了 (`/exit`) で worktree と `worktree-test/bootstrap` ブランチが自動削除されること
- [ ] `TOBAN_WORKTREE_BASE_REF=origin/main claude --worktree test/clean` で `origin/main` 起点に分岐すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)