### PR TITLE
feat: introduce Zustand for global UI state (#423)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .serena
 .claude/worktrees/
 .claude/settings.local.json
+.worktree-setup.log

--- a/README.md
+++ b/README.md
@@ -321,8 +321,9 @@ claude --worktree issue/xxx
 1. `.claude/worktrees/issue/xxx/` に worktree を作成 (ブランチ名: `worktree-issue/xxx`)
 2. `pkgs/{cli,contract,frontend}/.env` を main repo からコピー
 3. `pnpm install --frozen-lockfile`
-4. `pnpm frontend codegen` (graphql-codegen)
-5. `pnpm contract compile` (hardhat compile)
+4. `pnpm contract compile` (hardhat compile)
+
+frontend で生成された GraphQL 型 (`pkgs/frontend/gql/`) はリポジトリにコミット済みなので、codegen は worktree 作成時に走らせません。スキーマ更新が必要なときだけ手動で `pnpm frontend codegen` を実行してください。
 
 bootstrap ログは `.claude/worktrees/issue/xxx/.worktree-setup.log` に出力されます。
 
@@ -369,5 +370,5 @@ git push origin --delete worktree-issue/xxx  # リモート追跡ブランチも
 ### Tips
 
 - **並行作業**: `claude --worktree issue/aaa` と `claude --worktree issue/bbb` を別ペインで同時起動。各 worktree は独立した `node_modules` と `.env` を持つので衝突しません。
-- **bootstrap 失敗は非ブロッキング**: codegen が goldsky API ネットワーク問題で落ちても worktree 自体は作成完了。`.worktree-setup.log` を確認してください。
+- **bootstrap 失敗は非ブロッキング**: `pnpm install` や `pnpm contract compile` が落ちても worktree 自体は作成完了。`.worktree-setup.log` を確認してください。
 - **gitignore 済み**: `.claude/worktrees/` と `.claude/settings.local.json` はリポジトリ管理外。`.claude/settings.json` (チーム共有のフック設定) と `scripts/claude-worktree-*.sh` のみコミット対象です。

--- a/pkgs/frontend/app/stores/index.ts
+++ b/pkgs/frontend/app/stores/index.ts
@@ -1,0 +1,3 @@
+export { useWorkspaceStore } from "./workspace";
+export { useUIStore, type Theme } from "./ui";
+export { useSessionStore, type SessionIdentity } from "./session";

--- a/pkgs/frontend/app/stores/session.ts
+++ b/pkgs/frontend/app/stores/session.ts
@@ -1,0 +1,35 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type SessionIdentity = {
+  address: string;
+  name?: string;
+  domain?: string;
+  ensName?: string;
+  avatarUrl?: string;
+  smartWalletAddress?: string;
+};
+
+type SessionState = {
+  identity: SessionIdentity | null;
+  setIdentity: (identity: SessionIdentity | null) => void;
+  patchIdentity: (patch: Partial<SessionIdentity>) => void;
+  clear: () => void;
+};
+
+export const useSessionStore = create<SessionState>()(
+  persist(
+    (set) => ({
+      identity: null,
+      setIdentity: (identity) => set({ identity }),
+      patchIdentity: (patch) =>
+        set((state) =>
+          state.identity
+            ? { identity: { ...state.identity, ...patch } }
+            : { identity: null },
+        ),
+      clear: () => set({ identity: null }),
+    }),
+    { name: "toban:session" },
+  ),
+);

--- a/pkgs/frontend/app/stores/ui.ts
+++ b/pkgs/frontend/app/stores/ui.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type Theme = "light" | "system";
+
+type UIState = {
+  sheetOpen: boolean;
+  modalOpen: boolean;
+  theme: Theme;
+  setSheetOpen: (open: boolean) => void;
+  setModalOpen: (open: boolean) => void;
+  setTheme: (theme: Theme) => void;
+};
+
+export const useUIStore = create<UIState>()(
+  persist(
+    (set) => ({
+      sheetOpen: false,
+      modalOpen: false,
+      theme: "light",
+      setSheetOpen: (open) => set({ sheetOpen: open }),
+      setModalOpen: (open) => set({ modalOpen: open }),
+      setTheme: (theme) => set({ theme }),
+    }),
+    {
+      name: "toban:ui",
+      partialize: (state) => ({ theme: state.theme }),
+    },
+  ),
+);

--- a/pkgs/frontend/app/stores/workspace.ts
+++ b/pkgs/frontend/app/stores/workspace.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+const RECENT_LIMIT = 5;
+
+type WorkspaceState = {
+  currentWorkspaceId: string | null;
+  recent: string[];
+  switch: (workspaceId: string) => void;
+  clear: () => void;
+};
+
+export const useWorkspaceStore = create<WorkspaceState>()(
+  persist(
+    (set) => ({
+      currentWorkspaceId: null,
+      recent: [],
+      switch: (workspaceId) =>
+        set((state) => ({
+          currentWorkspaceId: workspaceId,
+          recent: [
+            workspaceId,
+            ...state.recent.filter((id) => id !== workspaceId),
+          ].slice(0, RECENT_LIMIT),
+        })),
+      clear: () => set({ currentWorkspaceId: null, recent: [] }),
+    }),
+    { name: "toban:workspace" },
+  ),
+);

--- a/pkgs/frontend/package.json
+++ b/pkgs/frontend/package.json
@@ -51,7 +51,8 @@
     "react-toastify": "^11.0.3",
     "remix-toast": "1.2.2",
     "swiper": "^11.2.6",
-    "viem": "^2.21.51"
+    "viem": "^2.21.51",
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "5.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         version: 1.0.12(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.6.3))(typescript@5.6.3)(utf-8-validate@5.0.10))
       '@nomicfoundation/hardhat-toolbox-viem':
         specifier: ^3.0.0
-        version: 3.0.0(wcohiwlccbikieispq5dfja7yq)
+        version: 3.0.0(6628620019a37fdfed165a6730bfd55a)
       '@nomicfoundation/hardhat-verify':
         specifier: ^2.1.1
         version: 2.1.1(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.6.3))(typescript@5.6.3)(utf-8-validate@5.0.10))
@@ -283,6 +283,9 @@ importers:
       viem:
         specifier: ^2.21.51
         version: 2.30.5(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.25.34)
+      zustand:
+        specifier: ^5.0.5
+        version: 5.0.5(@types/react@18.3.23)(immer@10.0.2)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))
     devDependencies:
       '@graphql-codegen/cli':
         specifier: 5.0.3
@@ -367,7 +370,7 @@ importers:
     dependencies:
       '@graphprotocol/graph-cli':
         specifier: 0.51.0
-        version: 0.51.0(@types/node@22.15.24)(bufferutil@4.0.9)(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.6.3)(utf-8-validate@5.0.10)
+        version: 0.51.0(@types/node@22.15.24)(bufferutil@4.0.9)(encoding@0.1.13)(node-fetch@3.3.2)(typescript@5.6.3)(utf-8-validate@5.0.10)
       '@graphprotocol/graph-ts':
         specifier: 0.31.0
         version: 0.31.0
@@ -7377,28 +7380,31 @@ packages:
   glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@5.0.15:
     resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -11616,6 +11622,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terser-webpack-plugin@5.3.14:
     resolution: {integrity: sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==}
@@ -12237,15 +12244,17 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uvu@0.5.6:
@@ -15902,7 +15911,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
-  '@graphprotocol/graph-cli@0.51.0(@types/node@22.15.24)(bufferutil@4.0.9)(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.6.3)(utf-8-validate@5.0.10)':
+  '@graphprotocol/graph-cli@0.51.0(@types/node@22.15.24)(bufferutil@4.0.9)(encoding@0.1.13)(node-fetch@3.3.2)(typescript@5.6.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@float-capital/float-subgraph-uncrashable': 0.0.0-internal-testing.5
       '@oclif/core': 2.8.4(@types/node@22.15.24)(typescript@5.6.3)
@@ -15919,7 +15928,7 @@ snapshots:
       gluegun: 5.1.2(debug@4.3.4)
       graphql: 15.5.0
       immutable: 4.2.1
-      ipfs-http-client: 55.0.0(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
+      ipfs-http-client: 55.0.0(encoding@0.1.13)(node-fetch@3.3.2)
       jayson: 4.0.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       js-yaml: 3.14.1
       prettier: 1.19.1
@@ -16944,7 +16953,7 @@ snapshots:
       ethereumjs-util: 7.1.5
       hardhat: 2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.6.3))(typescript@5.6.3)(utf-8-validate@5.0.10)
 
-  '@nomicfoundation/hardhat-toolbox-viem@3.0.0(wcohiwlccbikieispq5dfja7yq)':
+  '@nomicfoundation/hardhat-toolbox-viem@3.0.0(6628620019a37fdfed165a6730bfd55a)':
     dependencies:
       '@nomicfoundation/hardhat-ignition-viem': 0.15.11(@nomicfoundation/hardhat-ignition@0.15.11(@nomicfoundation/hardhat-verify@2.1.1(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.6.3))(typescript@5.6.3)(utf-8-validate@5.0.10)))(bufferutil@4.0.9)(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.6.3))(typescript@5.6.3)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10))(@nomicfoundation/hardhat-viem@2.0.6(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.6.3))(typescript@5.6.3)(utf-8-validate@5.0.10))(typescript@5.6.3)(viem@2.30.5(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.25.34))(zod@3.25.34))(@nomicfoundation/ignition-core@0.15.11(bufferutil@4.0.9)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.6.3))(typescript@5.6.3)(utf-8-validate@5.0.10))(viem@2.30.5(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)(zod@3.25.34))
       '@nomicfoundation/hardhat-network-helpers': 1.0.12(hardhat@2.26.3(bufferutil@4.0.9)(ts-node@10.9.2(@types/node@22.15.24)(typescript@5.6.3))(typescript@5.6.3)(utf-8-validate@5.0.10))
@@ -22051,10 +22060,10 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  dns-over-http-resolver@1.2.3(node-fetch@2.7.0(encoding@0.1.13)):
+  dns-over-http-resolver@1.2.3(node-fetch@3.3.2):
     dependencies:
       debug: 4.4.1(supports-color@8.1.1)
-      native-fetch: 3.0.0(node-fetch@2.7.0(encoding@0.1.13))
+      native-fetch: 3.0.0(node-fetch@3.3.2)
       receptacle: 1.3.2
     transitivePeerDependencies:
       - node-fetch
@@ -24300,23 +24309,23 @@ snapshots:
 
   ipaddr.js@2.2.0: {}
 
-  ipfs-core-types@0.9.0(node-fetch@2.7.0(encoding@0.1.13)):
+  ipfs-core-types@0.9.0(node-fetch@3.3.2):
     dependencies:
       interface-datastore: 6.1.1
-      multiaddr: 10.0.1(node-fetch@2.7.0(encoding@0.1.13))
+      multiaddr: 10.0.1(node-fetch@3.3.2)
       multiformats: 9.9.0
     transitivePeerDependencies:
       - node-fetch
       - supports-color
 
-  ipfs-core-utils@0.13.0(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13)):
+  ipfs-core-utils@0.13.0(encoding@0.1.13)(node-fetch@3.3.2):
     dependencies:
       any-signal: 2.1.2
       blob-to-it: 1.0.4
       browser-readablestream-to-it: 1.0.3
       debug: 4.4.1(supports-color@8.1.1)
       err-code: 3.0.1
-      ipfs-core-types: 0.9.0(node-fetch@2.7.0(encoding@0.1.13))
+      ipfs-core-types: 0.9.0(node-fetch@3.3.2)
       ipfs-unixfs: 6.0.9
       ipfs-utils: 9.0.14(encoding@0.1.13)
       it-all: 1.0.6
@@ -24324,8 +24333,8 @@ snapshots:
       it-peekable: 1.0.3
       it-to-stream: 1.0.0
       merge-options: 3.0.4
-      multiaddr: 10.0.1(node-fetch@2.7.0(encoding@0.1.13))
-      multiaddr-to-uri: 8.0.0(node-fetch@2.7.0(encoding@0.1.13))
+      multiaddr: 10.0.1(node-fetch@3.3.2)
+      multiaddr-to-uri: 8.0.0(node-fetch@3.3.2)
       multiformats: 9.9.0
       nanoid: 3.3.11
       parse-duration: 1.1.2
@@ -24336,7 +24345,7 @@ snapshots:
       - node-fetch
       - supports-color
 
-  ipfs-http-client@55.0.0(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13)):
+  ipfs-http-client@55.0.0(encoding@0.1.13)(node-fetch@3.3.2):
     dependencies:
       '@ipld/dag-cbor': 7.0.3
       '@ipld/dag-json': 8.0.11
@@ -24345,13 +24354,13 @@ snapshots:
       any-signal: 2.1.2
       debug: 4.4.1(supports-color@8.1.1)
       err-code: 3.0.1
-      ipfs-core-types: 0.9.0(node-fetch@2.7.0(encoding@0.1.13))
-      ipfs-core-utils: 0.13.0(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
+      ipfs-core-types: 0.9.0(node-fetch@3.3.2)
+      ipfs-core-utils: 0.13.0(encoding@0.1.13)(node-fetch@3.3.2)
       ipfs-utils: 9.0.14(encoding@0.1.13)
       it-first: 1.0.7
       it-last: 1.0.6
       merge-options: 3.0.4
-      multiaddr: 10.0.1(node-fetch@2.7.0(encoding@0.1.13))
+      multiaddr: 10.0.1(node-fetch@3.3.2)
       multiformats: 9.9.0
       native-abort-controller: 1.0.4(abort-controller@3.0.0)
       parse-duration: 1.1.2
@@ -26257,16 +26266,16 @@ snapshots:
 
   ms@2.1.3: {}
 
-  multiaddr-to-uri@8.0.0(node-fetch@2.7.0(encoding@0.1.13)):
+  multiaddr-to-uri@8.0.0(node-fetch@3.3.2):
     dependencies:
-      multiaddr: 10.0.1(node-fetch@2.7.0(encoding@0.1.13))
+      multiaddr: 10.0.1(node-fetch@3.3.2)
     transitivePeerDependencies:
       - node-fetch
       - supports-color
 
-  multiaddr@10.0.1(node-fetch@2.7.0(encoding@0.1.13)):
+  multiaddr@10.0.1(node-fetch@3.3.2):
     dependencies:
-      dns-over-http-resolver: 1.2.3(node-fetch@2.7.0(encoding@0.1.13))
+      dns-over-http-resolver: 1.2.3(node-fetch@3.3.2)
       err-code: 3.0.1
       is-ip: 3.1.0
       multiformats: 9.9.0
@@ -26313,6 +26322,10 @@ snapshots:
   native-fetch@3.0.0(node-fetch@2.7.0(encoding@0.1.13)):
     dependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
+
+  native-fetch@3.0.0(node-fetch@3.3.2):
+    dependencies:
+      node-fetch: 3.3.2
 
   natural-compare@1.4.0: {}
 

--- a/scripts/claude-worktree-create.sh
+++ b/scripts/claude-worktree-create.sh
@@ -50,10 +50,6 @@ log "Running pnpm install (output: ${LOGFILE})..."
 (cd "$WORKTREE_PATH" && pnpm install --frozen-lockfile) >> "$LOGFILE" 2>&1 \
   || SETUP_ERRORS+=("pnpm install failed")
 
-log "Running frontend graphql-codegen..."
-(cd "$WORKTREE_PATH" && pnpm frontend codegen) >> "$LOGFILE" 2>&1 \
-  || SETUP_ERRORS+=("frontend codegen failed (network or schema issue?)")
-
 log "Running contract hardhat compile..."
 (cd "$WORKTREE_PATH" && pnpm contract compile) >> "$LOGFILE" 2>&1 \
   || SETUP_ERRORS+=("contract compile failed")


### PR DESCRIPTION
## Summary
- Adds `zustand@^5.0.5` to `pkgs/frontend` and creates `pkgs/frontend/app/stores/` with three minimal stores per Phase 1-5 of #418.
- `workspace` (currentWorkspaceId, recent[], switch — persisted), `ui` (sheetOpen/modalOpen + theme, only theme persisted), `session` (cached ENS/avatar/smart-wallet identity — persisted).
- Stores are additive only — no existing components wired up. Migration of existing local state is intentionally deferred to follow-ups (gated on Phase 1 framework migration #419 and Phase 2 design-system work #426–#428).

### Bundled worktree-hook cleanup
- Add `.worktree-setup.log` to `.gitignore` so the bootstrap log from `scripts/claude-worktree-create.sh` no longer surfaces as untracked.
- Drop `pnpm frontend codegen` from the worktree create hook. The generated `gql/` types are committed, so re-running codegen against the live Goldsky schema produced ephemeral diffs on every new worktree. Devs run codegen manually when the schema actually changes.
- README updated to reflect the new worktree bootstrap steps.

Closes #423

## Test plan
- [x] `pnpm --filter frontend typecheck` passes (also via lefthook pre-commit).
- [x] `npx biome check pkgs/frontend/app/stores` passes.
- [ ] Manual smoke: `pnpm --filter frontend dev` boots and existing pages render without regression — stores are not consumed yet so behavior should be identical.
- [ ] Verify `localStorage` keys `toban:workspace`, `toban:ui`, `toban:session` round-trip after a reload once a consumer is added.
- [ ] Spin up a fresh worktree (`claude --worktree test/foo`) and confirm `.worktree-setup.log` is ignored and `pkgs/frontend/gql/graphql.ts` stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
