### PR TITLE
feat(contract): add HatsQuestModule for trustless RoleShare distribution (#417)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -26,6 +26,7 @@
       "**/subgraph/generated",
       "**/subgraph/build",
       "**/frontend/gql",
+      "**/frontend/.react-router",
       "**/frontend/**/downloads"
     ]
   },

--- a/pkgs/contract/contracts/bigbang/BigBang.sol
+++ b/pkgs/contract/contracts/bigbang/BigBang.sol
@@ -23,6 +23,8 @@ contract BigBang is OwnableUpgradeable, UUPSUpgradeable {
 
     address public HatsFractionTokenModule_IMPL;
 
+    address public HatsQuestModule_IMPL;
+
     address public SplitsFactoryV2;
 
     address public ThanksTokenFactory;
@@ -39,6 +41,7 @@ contract BigBang is OwnableUpgradeable, UUPSUpgradeable {
         address hatsTimeFrameModule,
         address hatsHatCreatorModule,
         address hatsFractionTokenModule,
+        address hatsQuestModule,
         address splitCreator,
         address thanksToken
     );
@@ -61,6 +64,7 @@ contract BigBang is OwnableUpgradeable, UUPSUpgradeable {
         address _hatsTimeFrameModule_IMPL,
         address _hatsHatCreatorModule_IMPL,
         address _hatsFractionTokenModule_IMPL,
+        address _hatsQuestModule_IMPL,
         address _splitsCreatorFactory,
         address _splitFactoryV2,
         address _thanksTokenFactory
@@ -71,6 +75,7 @@ contract BigBang is OwnableUpgradeable, UUPSUpgradeable {
         HatsTimeFrameModule_IMPL = _hatsTimeFrameModule_IMPL;
         HatsHatCreatorModule_IMPL = _hatsHatCreatorModule_IMPL;
         HatsFractionTokenModule_IMPL = _hatsFractionTokenModule_IMPL;
+        HatsQuestModule_IMPL = _hatsQuestModule_IMPL;
         SplitsCreatorFactory = ISplitsCreatorFactory(_splitsCreatorFactory);
         SplitsFactoryV2 = _splitFactoryV2;
         ThanksTokenFactory = _thanksTokenFactory;
@@ -183,6 +188,15 @@ contract BigBang is OwnableUpgradeable, UUPSUpgradeable {
             0
         );
 
+        // 7.5 HatsQuestModuleのデプロイ（FractionToken のアドレスを紐付け）
+        address hatsQuestModule = HatsModuleFactory.createHatsModule(
+            HatsQuestModule_IMPL,
+            topHatId,
+            "",
+            abi.encode(hatsFractionTokenModule),
+            0
+        );
+
         // 8. HatterHatにHatModuleをMint
         uint256[] memory hatIds = new uint256[](2);
         hatIds[0] = hatterHatId;
@@ -217,6 +231,7 @@ contract BigBang is OwnableUpgradeable, UUPSUpgradeable {
                 hatsTimeFrameModule,
                 hatsFractionTokenModule,
                 thanksToken,
+                hatsQuestModule,
                 keccak256(abi.encodePacked(topHatId))
             );
 
@@ -232,6 +247,7 @@ contract BigBang is OwnableUpgradeable, UUPSUpgradeable {
             hatsTimeFrameModule,
             hatsHatCreatorModule,
             hatsFractionTokenModule,
+            hatsQuestModule,
             splitCreator,
             thanksToken
         );
@@ -271,6 +287,12 @@ contract BigBang is OwnableUpgradeable, UUPSUpgradeable {
         address _hatsFractionTokenModuleImpl
     ) external onlyOwner {
         HatsFractionTokenModule_IMPL = _hatsFractionTokenModuleImpl;
+    }
+
+    function setHatsQuestModuleImpl(
+        address _hatsQuestModuleImpl
+    ) external onlyOwner {
+        HatsQuestModule_IMPL = _hatsQuestModuleImpl;
     }
 
     function setSplitsFactoryV2(address _splitsFactoryV2) external onlyOwner {

--- a/pkgs/contract/contracts/bigbang/mock/BigBang_Mock_v2.sol
+++ b/pkgs/contract/contracts/bigbang/mock/BigBang_Mock_v2.sol
@@ -25,6 +25,8 @@ contract BigBang_Mock_v2 is OwnableUpgradeable, UUPSUpgradeable {
 
     address public HatsFractionTokenModule_IMPL;
 
+    address public HatsQuestModule_IMPL;
+
     address public SplitsFactoryV2;
 
     address public ThanksTokenFactory;
@@ -41,6 +43,7 @@ contract BigBang_Mock_v2 is OwnableUpgradeable, UUPSUpgradeable {
         address hatsTimeFrameModule,
         address hatsHatCreatorModule,
         address hatsFractionTokenModule,
+        address hatsQuestModule,
         address splitCreator,
         address thanksToken
     );
@@ -63,6 +66,7 @@ contract BigBang_Mock_v2 is OwnableUpgradeable, UUPSUpgradeable {
         address _hatsTimeFrameModule_IMPL,
         address _hatsHatCreatorModule_IMPL,
         address _hatsFractionTokenModule_IMPL,
+        address _hatsQuestModule_IMPL,
         address _splitsCreatorFactory,
         address _splitFactoryV2,
         address _thanksTokenFactory
@@ -73,6 +77,7 @@ contract BigBang_Mock_v2 is OwnableUpgradeable, UUPSUpgradeable {
         HatsTimeFrameModule_IMPL = _hatsTimeFrameModule_IMPL;
         HatsHatCreatorModule_IMPL = _hatsHatCreatorModule_IMPL;
         HatsFractionTokenModule_IMPL = _hatsFractionTokenModule_IMPL;
+        HatsQuestModule_IMPL = _hatsQuestModule_IMPL;
         SplitsCreatorFactory = ISplitsCreatorFactory(_splitsCreatorFactory);
         SplitsFactoryV2 = _splitFactoryV2;
         ThanksTokenFactory = _thanksTokenFactory;
@@ -183,6 +188,15 @@ contract BigBang_Mock_v2 is OwnableUpgradeable, UUPSUpgradeable {
             0
         );
 
+        // 6.5 HatsQuestModuleのデプロイ
+        address hatsQuestModule = HatsModuleFactory.createHatsModule(
+            HatsQuestModule_IMPL,
+            topHatId,
+            "",
+            abi.encode(hatsFractionTokenModule),
+            0
+        );
+
         // 7. HatterHatにHatModuleをMint
         uint256[] memory hatIds = new uint256[](2);
         hatIds[0] = hatterHatId;
@@ -217,6 +231,7 @@ contract BigBang_Mock_v2 is OwnableUpgradeable, UUPSUpgradeable {
                 hatsTimeFrameModule,
                 hatsFractionTokenModule,
                 thanksToken,
+                hatsQuestModule,
                 keccak256(abi.encodePacked(topHatId))
             );
 
@@ -232,6 +247,7 @@ contract BigBang_Mock_v2 is OwnableUpgradeable, UUPSUpgradeable {
             hatsTimeFrameModule,
             hatsHatCreatorModule,
             hatsFractionTokenModule,
+            hatsQuestModule,
             splitCreator,
             thanksToken
         );
@@ -271,6 +287,12 @@ contract BigBang_Mock_v2 is OwnableUpgradeable, UUPSUpgradeable {
         address _hatsFractionTokenModuleImpl
     ) external onlyOwner {
         HatsFractionTokenModule_IMPL = _hatsFractionTokenModuleImpl;
+    }
+
+    function setHatsQuestModuleImpl(
+        address _hatsQuestModuleImpl
+    ) external onlyOwner {
+        HatsQuestModule_IMPL = _hatsQuestModuleImpl;
     }
 
     function setSplitsFactoryV2(address _splitsFactoryV2) external onlyOwner {

--- a/pkgs/contract/contracts/hatsmodules/fractiontoken/HatsFractionTokenModule.sol
+++ b/pkgs/contract/contracts/hatsmodules/fractiontoken/HatsFractionTokenModule.sol
@@ -255,8 +255,12 @@ contract HatsFractionTokenModule is
         uint256 _amount,
         bytes memory _data
     ) public override {
-        // Prevent complete token transfers to maintain hat association
-        if (balanceOf(_from, _id) == _amount) {
+        // Only the original wearer must retain at least one token to keep the
+        // hat association; intermediate holders (e.g. escrow modules) are
+        // allowed to transfer their full balance.
+        if (
+            _isOriginalWearer(_id, _from) && balanceOf(_from, _id) == _amount
+        ) {
             revert CannotTransferAllTokens();
         }
 
@@ -290,6 +294,16 @@ contract HatsFractionTokenModule is
         uint256[] memory _amounts,
         bytes memory _data
     ) public override {
+        // Apply the same wearer-only retention rule per token id.
+        for (uint256 i = 0; i < _ids.length; i++) {
+            if (
+                _isOriginalWearer(_ids[i], _from) &&
+                balanceOf(_from, _ids[i]) == _amounts[i]
+            ) {
+                revert CannotTransferAllTokens();
+            }
+        }
+
         super.safeBatchTransferFrom(_from, _to, _ids, _amounts, _data);
 
         for (uint256 i = 0; i < _ids.length; i++) {
@@ -485,6 +499,21 @@ contract HatsFractionTokenModule is
             }
         }
         return false;
+    }
+
+    /**
+     * @notice Whether `_account` is the original wearer that minted `_tokenId`
+     * @dev The wearer is recorded as the first entry of `tokenRecipients` by
+     *      `mintInitialSupply`. Returning false for unminted tokens is fine —
+     *      they have no balance and the transfer guard cannot fire on them.
+     */
+    function _isOriginalWearer(
+        uint256 _tokenId,
+        address _account
+    ) private view returns (bool) {
+        address[] storage recipients = tokenRecipients[_tokenId];
+        if (recipients.length == 0) return false;
+        return recipients[0] == _account;
     }
 
     function _update(

--- a/pkgs/contract/contracts/hatsmodules/quest/HatsQuestModule.sol
+++ b/pkgs/contract/contracts/hatsmodules/quest/HatsQuestModule.sol
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {HatsModule} from "../../hats/module/HatsModule.sol";
+import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import {IHatsQuestModule} from "./IHatsQuestModule.sol";
+import {IHatsFractionTokenModule} from "../fractiontoken/IHatsFractionTokenModule.sol";
+
+/**
+ * @title HatsQuestModule
+ * @notice Trustless distribution of RoleShare via the quest workflow.
+ * @dev    Creators escrow RoleShare into this module when they create a quest.
+ *         A submitter declares completion, and either the creator alone or two
+ *         distinct workspace hat holders approve to release the escrow to the
+ *         submitter. The creator can cancel an Open quest to reclaim escrow.
+ *
+ *         One instance is deployed per workspace (TopHat domain) and bound to
+ *         that workspace's HatsFractionTokenModule via init data.
+ */
+contract HatsQuestModule is HatsModule, ERC1155Holder, IHatsQuestModule {
+    // ============ Storage ============
+
+    IHatsFractionTokenModule private _fractionToken;
+    uint32 private _domain;
+    uint256 private _nextQuestId;
+
+    mapping(uint256 => Quest) private _quests;
+    mapping(uint256 => mapping(address => bool)) private _hasApproved;
+    mapping(uint256 => uint8) private _approvalCount;
+
+    // creator => fractionTokenId => total amount currently escrowed
+    mapping(address => mapping(uint256 => uint256)) private _escrowedByCreator;
+
+    // ============ Constructor ============
+
+    constructor(string memory _version) HatsModule(_version) {}
+
+    /**
+     * @dev Initializes the module with the workspace's HatsFractionTokenModule address.
+     * @param _initData ABI-encoded `(address fractionToken)`.
+     */
+    function _setUp(bytes calldata _initData) internal override {
+        address fractionTokenAddress = abi.decode(_initData, (address));
+        _fractionToken = IHatsFractionTokenModule(fractionTokenAddress);
+        _domain = HATS().getTopHatDomain(hatId());
+    }
+
+    // ============ Lifecycle ============
+
+    /// @inheritdoc IHatsQuestModule
+    function createQuest(
+        uint256 hatId_,
+        address wearer,
+        uint256 amount,
+        bytes32 metadataHash
+    ) external override returns (uint256 questId) {
+        if (amount == 0) revert InvalidAmount();
+        if (HATS().getTopHatDomain(hatId_) != _domain) revert InvalidHatDomain();
+        if (_fractionToken.balanceOf(msg.sender, wearer, hatId_) < amount) {
+            revert InsufficientShare();
+        }
+
+        questId = _nextQuestId++;
+        _quests[questId] = Quest({
+            hatId: hatId_,
+            wearer: wearer,
+            creator: msg.sender,
+            submitter: address(0),
+            amount: amount,
+            status: QuestStatus.Open,
+            metadataHash: metadataHash,
+            createdAt: uint64(block.timestamp),
+            submittedAt: 0
+        });
+
+        uint256 tokenId = _fractionToken.getTokenId(hatId_, wearer);
+        _escrowedByCreator[msg.sender][tokenId] += amount;
+
+        IERC1155(address(_fractionToken)).safeTransferFrom(
+            msg.sender,
+            address(this),
+            tokenId,
+            amount,
+            ""
+        );
+
+        emit QuestCreated(questId, msg.sender, hatId_, wearer, amount, metadataHash);
+    }
+
+    /// @inheritdoc IHatsQuestModule
+    function submitCompletion(
+        uint256 questId,
+        uint256 membershipHatId
+    ) external override {
+        Quest storage quest = _quests[questId];
+        if (quest.creator == address(0)) revert QuestNotFound();
+        if (quest.status != QuestStatus.Open) revert InvalidStatus();
+        if (msg.sender == quest.creator) revert CannotSubmitOwnQuest();
+        _requireWorkspaceMember(msg.sender, membershipHatId);
+
+        quest.submitter = msg.sender;
+        quest.status = QuestStatus.PendingReview;
+        quest.submittedAt = uint64(block.timestamp);
+
+        emit CompletionSubmitted(questId, msg.sender);
+    }
+
+    /// @inheritdoc IHatsQuestModule
+    function approve(
+        uint256 questId,
+        uint256 membershipHatId
+    ) external override {
+        Quest storage quest = _quests[questId];
+        if (quest.creator == address(0)) revert QuestNotFound();
+        if (quest.status != QuestStatus.PendingReview) revert InvalidStatus();
+        if (msg.sender == quest.submitter) revert CannotApproveOwnSubmission();
+        if (_hasApproved[questId][msg.sender]) revert AlreadyApproved();
+        _requireWorkspaceMember(msg.sender, membershipHatId);
+
+        _hasApproved[questId][msg.sender] = true;
+        uint8 newCount = _approvalCount[questId] + 1;
+        _approvalCount[questId] = newCount;
+
+        emit QuestApproved(questId, msg.sender, newCount);
+
+        // Creator's single approval finalizes the quest immediately;
+        // otherwise two distinct hat-holder approvals are required.
+        bool completed = (msg.sender == quest.creator) || (newCount >= 2);
+
+        if (completed) {
+            quest.status = QuestStatus.Completed;
+
+            uint256 tokenId = _fractionToken.getTokenId(quest.hatId, quest.wearer);
+            _escrowedByCreator[quest.creator][tokenId] -= quest.amount;
+
+            IERC1155(address(_fractionToken)).safeTransferFrom(
+                address(this),
+                quest.submitter,
+                tokenId,
+                quest.amount,
+                ""
+            );
+
+            emit QuestCompleted(questId, quest.submitter, quest.amount);
+        }
+    }
+
+    /// @inheritdoc IHatsQuestModule
+    function cancel(uint256 questId) external override {
+        Quest storage quest = _quests[questId];
+        if (quest.creator == address(0)) revert QuestNotFound();
+        if (quest.status != QuestStatus.Open) revert InvalidStatus();
+        if (msg.sender != quest.creator) revert NotCreator();
+
+        quest.status = QuestStatus.Cancelled;
+
+        uint256 tokenId = _fractionToken.getTokenId(quest.hatId, quest.wearer);
+        _escrowedByCreator[quest.creator][tokenId] -= quest.amount;
+
+        IERC1155(address(_fractionToken)).safeTransferFrom(
+            address(this),
+            quest.creator,
+            tokenId,
+            quest.amount,
+            ""
+        );
+
+        emit QuestCancelled(questId, quest.creator, quest.amount);
+    }
+
+    // ============ Views ============
+
+    /// @inheritdoc IHatsQuestModule
+    function getQuest(uint256 questId) external view override returns (Quest memory) {
+        return _quests[questId];
+    }
+
+    /// @inheritdoc IHatsQuestModule
+    function getApprovalCount(uint256 questId) external view override returns (uint8) {
+        return _approvalCount[questId];
+    }
+
+    /// @inheritdoc IHatsQuestModule
+    function hasApprovedBy(
+        uint256 questId,
+        address approver
+    ) external view override returns (bool) {
+        return _hasApproved[questId][approver];
+    }
+
+    /// @inheritdoc IHatsQuestModule
+    function getEscrowedBalance(
+        address creator,
+        uint256 hatId_,
+        address wearer
+    ) external view override returns (uint256) {
+        return _escrowedByCreator[creator][_fractionToken.getTokenId(hatId_, wearer)];
+    }
+
+    /// @inheritdoc IHatsQuestModule
+    function getDomain() external view override returns (uint32) {
+        return _domain;
+    }
+
+    /// @inheritdoc IHatsQuestModule
+    function FRACTION_TOKEN() external view override returns (address) {
+        return address(_fractionToken);
+    }
+
+    /**
+     * @notice Returns the next quest id that will be assigned by `createQuest`.
+     */
+    function nextQuestId() external view returns (uint256) {
+        return _nextQuestId;
+    }
+
+    // ============ ERC1155 receiver gating ============
+
+    /// @dev Only accept escrow transfers initiated by the bound fraction token.
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 value,
+        bytes memory data
+    ) public virtual override returns (bytes4) {
+        if (msg.sender != address(_fractionToken)) revert InvalidStatus();
+        return super.onERC1155Received(operator, from, id, value, data);
+    }
+
+    /// @dev Batch transfers are not used by this module; reject for safety.
+    function onERC1155BatchReceived(
+        address,
+        address,
+        uint256[] memory,
+        uint256[] memory,
+        bytes memory
+    ) public pure override returns (bytes4) {
+        revert InvalidStatus();
+    }
+
+    // ============ Internal ============
+
+    function _requireWorkspaceMember(
+        address account,
+        uint256 membershipHatId
+    ) internal view {
+        if (!HATS().isWearerOfHat(account, membershipHatId)) revert NotWorkspaceMember();
+        if (HATS().getTopHatDomain(membershipHatId) != _domain) revert InvalidHatDomain();
+    }
+}

--- a/pkgs/contract/contracts/hatsmodules/quest/HatsQuestModule.sol
+++ b/pkgs/contract/contracts/hatsmodules/quest/HatsQuestModule.sol
@@ -29,6 +29,10 @@ contract HatsQuestModule is HatsModule, ERC1155Holder, IHatsQuestModule {
     mapping(uint256 => mapping(address => bool)) private _hasApproved;
     mapping(uint256 => uint8) private _approvalCount;
 
+    // Tracks the addresses that have approved each quest so the approval
+    // state can be cleanly reset when a submission is withdrawn or rejected.
+    mapping(uint256 => address[]) private _approvers;
+
     // creator => fractionTokenId => total amount currently escrowed
     mapping(address => mapping(uint256 => uint256)) private _escrowedByCreator;
 
@@ -107,6 +111,32 @@ contract HatsQuestModule is HatsModule, ERC1155Holder, IHatsQuestModule {
     }
 
     /// @inheritdoc IHatsQuestModule
+    function withdrawSubmission(uint256 questId) external override {
+        Quest storage quest = _quests[questId];
+        if (quest.creator == address(0)) revert QuestNotFound();
+        if (quest.status != QuestStatus.PendingReview) revert InvalidStatus();
+        if (msg.sender != quest.submitter) revert NotSubmitter();
+
+        address oldSubmitter = quest.submitter;
+        _resetSubmission(questId);
+
+        emit SubmissionWithdrawn(questId, oldSubmitter);
+    }
+
+    /// @inheritdoc IHatsQuestModule
+    function rejectSubmission(uint256 questId) external override {
+        Quest storage quest = _quests[questId];
+        if (quest.creator == address(0)) revert QuestNotFound();
+        if (quest.status != QuestStatus.PendingReview) revert InvalidStatus();
+        if (msg.sender != quest.creator) revert NotCreator();
+
+        address oldSubmitter = quest.submitter;
+        _resetSubmission(questId);
+
+        emit SubmissionRejected(questId, msg.sender, oldSubmitter);
+    }
+
+    /// @inheritdoc IHatsQuestModule
     function approve(
         uint256 questId,
         uint256 membershipHatId
@@ -119,6 +149,7 @@ contract HatsQuestModule is HatsModule, ERC1155Holder, IHatsQuestModule {
         _requireWorkspaceMember(msg.sender, membershipHatId);
 
         _hasApproved[questId][msg.sender] = true;
+        _approvers[questId].push(msg.sender);
         uint8 newCount = _approvalCount[questId] + 1;
         _approvalCount[questId] = newCount;
 
@@ -248,5 +279,21 @@ contract HatsQuestModule is HatsModule, ERC1155Holder, IHatsQuestModule {
     ) internal view {
         if (!HATS().isWearerOfHat(account, membershipHatId)) revert NotWorkspaceMember();
         if (HATS().getTopHatDomain(membershipHatId) != _domain) revert InvalidHatDomain();
+    }
+
+    /// @dev Returns the quest to Open, clearing submitter and approval state.
+    function _resetSubmission(uint256 questId) internal {
+        Quest storage quest = _quests[questId];
+
+        address[] storage approvers = _approvers[questId];
+        for (uint256 i = 0; i < approvers.length; i++) {
+            _hasApproved[questId][approvers[i]] = false;
+        }
+        delete _approvers[questId];
+        _approvalCount[questId] = 0;
+
+        quest.submitter = address(0);
+        quest.submittedAt = 0;
+        quest.status = QuestStatus.Open;
     }
 }

--- a/pkgs/contract/contracts/hatsmodules/quest/IHatsQuestModule.sol
+++ b/pkgs/contract/contracts/hatsmodules/quest/IHatsQuestModule.sol
@@ -55,6 +55,7 @@ interface IHatsQuestModule {
     error QuestNotFound();
     error InvalidStatus();
     error NotCreator();
+    error NotSubmitter();
     error CannotSubmitOwnQuest();
     error CannotApproveOwnSubmission();
     error AlreadyApproved();
@@ -71,6 +72,12 @@ interface IHatsQuestModule {
         bytes32 metadataHash
     );
     event CompletionSubmitted(uint256 indexed questId, address indexed submitter);
+    event SubmissionWithdrawn(uint256 indexed questId, address indexed submitter);
+    event SubmissionRejected(
+        uint256 indexed questId,
+        address indexed creator,
+        address indexed submitter
+    );
     event QuestApproved(uint256 indexed questId, address indexed approver, uint8 newApprovalCount);
     event QuestCompleted(uint256 indexed questId, address indexed submitter, uint256 amount);
     event QuestCancelled(uint256 indexed questId, address indexed creator, uint256 amount);
@@ -100,6 +107,20 @@ interface IHatsQuestModule {
      *        prove workspace membership.
      */
     function submitCompletion(uint256 questId, uint256 membershipHatId) external;
+
+    /**
+     * @notice Lets the current submitter retract their own submission while the
+     *         quest is in PendingReview, returning the quest to Open. Any
+     *         approvals already collected for this submission are cleared.
+     */
+    function withdrawSubmission(uint256 questId) external;
+
+    /**
+     * @notice Lets the creator reject the current submission, returning the
+     *         quest to Open so a different submitter can apply. Approvals
+     *         collected for the rejected submission are cleared.
+     */
+    function rejectSubmission(uint256 questId) external;
 
     /**
      * @notice Approves a quest in PendingReview.

--- a/pkgs/contract/contracts/hatsmodules/quest/IHatsQuestModule.sol
+++ b/pkgs/contract/contracts/hatsmodules/quest/IHatsQuestModule.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/**
+ * @title IHatsQuestModule
+ * @notice Interface for the HatsQuestModule contract.
+ * @dev Defines the data model, events, errors, and external functions used to
+ *      escrow RoleShare (HatsFractionTokenModule) tokens and distribute them
+ *      trustlessly via a quest creation / submission / approval workflow.
+ */
+interface IHatsQuestModule {
+    // ============ Types ============
+
+    /**
+     * @notice Lifecycle status of a quest.
+     * @dev Open -> PendingReview -> Completed and Open -> Cancelled are the
+     *      only valid transitions; every transition is irreversible.
+     */
+    enum QuestStatus {
+        Open,
+        PendingReview,
+        Completed,
+        Cancelled
+    }
+
+    /**
+     * @notice On-chain representation of a single quest.
+     * @param hatId The hat that backs the escrowed RoleShare.
+     * @param wearer The wearer key of the share (tokenId = keccak256(hatId, wearer)).
+     * @param creator The address that created the quest and posted the escrow.
+     * @param submitter The address that submitted completion (zero until submitted).
+     * @param amount The amount of RoleShare escrowed for this quest.
+     * @param status Current lifecycle state.
+     * @param metadataHash Off-chain pointer (e.g. IPFS CID hash) for quest details.
+     * @param createdAt Timestamp when the quest was created.
+     * @param submittedAt Timestamp when the completion was submitted (zero until submitted).
+     */
+    struct Quest {
+        uint256 hatId;
+        address wearer;
+        address creator;
+        address submitter;
+        uint256 amount;
+        QuestStatus status;
+        bytes32 metadataHash;
+        uint64 createdAt;
+        uint64 submittedAt;
+    }
+
+    // ============ Errors ============
+
+    error InvalidAmount();
+    error InsufficientShare();
+    error InvalidHatDomain();
+    error QuestNotFound();
+    error InvalidStatus();
+    error NotCreator();
+    error CannotSubmitOwnQuest();
+    error CannotApproveOwnSubmission();
+    error AlreadyApproved();
+    error NotWorkspaceMember();
+
+    // ============ Events ============
+
+    event QuestCreated(
+        uint256 indexed questId,
+        address indexed creator,
+        uint256 indexed hatId,
+        address wearer,
+        uint256 amount,
+        bytes32 metadataHash
+    );
+    event CompletionSubmitted(uint256 indexed questId, address indexed submitter);
+    event QuestApproved(uint256 indexed questId, address indexed approver, uint8 newApprovalCount);
+    event QuestCompleted(uint256 indexed questId, address indexed submitter, uint256 amount);
+    event QuestCancelled(uint256 indexed questId, address indexed creator, uint256 amount);
+
+    // ============ Lifecycle ============
+
+    /**
+     * @notice Creates a quest backed by the caller's RoleShare.
+     * @dev Escrows `amount` of RoleShare from the caller into this contract.
+     * @param hatId The hat associated with the RoleShare.
+     * @param wearer The wearer key of the share to escrow.
+     * @param amount The amount of RoleShare to escrow.
+     * @param metadataHash Off-chain metadata pointer for the quest.
+     * @return questId The id assigned to the new quest.
+     */
+    function createQuest(
+        uint256 hatId,
+        address wearer,
+        uint256 amount,
+        bytes32 metadataHash
+    ) external returns (uint256 questId);
+
+    /**
+     * @notice Submits completion of an open quest. The caller becomes the submitter.
+     * @param questId The quest to submit completion for.
+     * @param membershipHatId A hat the caller wears in this workspace, used to
+     *        prove workspace membership.
+     */
+    function submitCompletion(uint256 questId, uint256 membershipHatId) external;
+
+    /**
+     * @notice Approves a quest in PendingReview.
+     *         Single creator approval or two distinct hat-holder approvals
+     *         transitions the quest to Completed and releases the escrow.
+     * @param questId The quest to approve.
+     * @param membershipHatId A hat the caller wears in this workspace.
+     */
+    function approve(uint256 questId, uint256 membershipHatId) external;
+
+    /**
+     * @notice Cancels an Open quest and returns the escrow to its creator.
+     * @param questId The quest to cancel.
+     */
+    function cancel(uint256 questId) external;
+
+    // ============ Views ============
+
+    /**
+     * @notice Returns the full quest record.
+     */
+    function getQuest(uint256 questId) external view returns (Quest memory);
+
+    /**
+     * @notice Returns the number of distinct approvals collected for a quest.
+     */
+    function getApprovalCount(uint256 questId) external view returns (uint8);
+
+    /**
+     * @notice Returns whether `approver` has already approved `questId`.
+     */
+    function hasApprovedBy(uint256 questId, address approver) external view returns (bool);
+
+    /**
+     * @notice Returns the total amount of RoleShare currently escrowed by
+     *         `creator` for the (hatId, wearer) share key.
+     * @dev Used by SplitsCreator to credit escrowed shares back to the creator
+     *      while a quest is in flight.
+     */
+    function getEscrowedBalance(
+        address creator,
+        uint256 hatId,
+        address wearer
+    ) external view returns (uint256);
+
+    /**
+     * @notice Returns the workspace domain id this module is bound to.
+     */
+    function getDomain() external view returns (uint32);
+
+    /**
+     * @notice Returns the address of the HatsFractionTokenModule used for escrow.
+     */
+    function FRACTION_TOKEN() external view returns (address);
+}

--- a/pkgs/contract/contracts/splitscreator/ISplitsCreatorFactory.sol
+++ b/pkgs/contract/contracts/splitscreator/ISplitsCreatorFactory.sol
@@ -12,6 +12,7 @@ interface ISplitsCreatorFactory {
 		address _hatsTimeFrameModule,
 		address _fractionToken,
 		address _thanksToken,
+		address _hatsQuestModule,
 		bytes32 _salt
 	) external returns (address);
 }

--- a/pkgs/contract/contracts/splitscreator/SplitsCreator.sol
+++ b/pkgs/contract/contracts/splitscreator/SplitsCreator.sol
@@ -10,6 +10,7 @@ import {SplitV2Lib} from "../splits/libraries/SplitV2.sol";
 import {IThanksToken} from "../thankstoken/IThanksToken.sol";
 import {IHatsFractionTokenModule} from "../hatsmodules/fractiontoken/IHatsFractionTokenModule.sol";
 import {IHatsTimeFrameModule} from "../hatsmodules/timeframe/IHatsTimeFrameModule.sol";
+import {IHatsQuestModule} from "../hatsmodules/quest/IHatsQuestModule.sol";
 import {Clone} from "solady/src/utils/Clone.sol";
 
 contract SplitsCreator is ISplitsCreator, Clone {
@@ -37,6 +38,10 @@ contract SplitsCreator is ISplitsCreator, Clone {
 
     function THANKS_TOKEN() public pure returns (IThanksToken) {
         return IThanksToken(_getArgAddress(140));
+    }
+
+    function HATS_QUEST_MODULE() public pure returns (IHatsQuestModule) {
+        return IHatsQuestModule(_getArgAddress(172));
     }
 
     /**
@@ -242,6 +247,8 @@ contract SplitsCreator is ISplitsCreator, Clone {
             uint256 totalAllocation
         )
     {
+        address questModule = address(HATS_QUEST_MODULE());
+
         uint256 numOfShareHolders = 0;
         for (uint256 i = 0; i < _splitsInfo.length; i++) {
             SplitsInfo memory _splitInfo = _splitsInfo[i];
@@ -256,7 +263,13 @@ contract SplitsCreator is ISplitsCreator, Clone {
                 if (recipients.length == 0) {
                     numOfShareHolders++;
                 } else {
-                    numOfShareHolders += recipients.length;
+                    uint256 effectiveCount = recipients.length;
+                    for (uint256 r = 0; r < recipients.length; r++) {
+                        if (recipients[r] == questModule) {
+                            effectiveCount -= 1;
+                        }
+                    }
+                    numOfShareHolders += effectiveCount;
                 }
             }
         }
@@ -290,6 +303,15 @@ contract SplitsCreator is ISplitsCreator, Clone {
                     _splitInfo.hatId
                 );
 
+                // Credit any escrow currently posted by the wearer back to them.
+                if (questModule != address(0)) {
+                    wearerBalance += HATS_QUEST_MODULE().getEscrowedBalance(
+                        _splitInfo.wearers[j],
+                        _splitInfo.hatId,
+                        _splitInfo.wearers[j]
+                    );
+                }
+
                 uint256 wearerScore = wearerBalance *
                     roleMultiplier *
                     hatsTimeFrameMultiplier;
@@ -309,12 +331,24 @@ contract SplitsCreator is ISplitsCreator, Clone {
 
                 for (uint256 k = 0; k < recipients.length; k++) {
                     if (recipients[k] == _splitInfo.wearers[j]) continue;
+                    // The quest module escrows shares on behalf of others,
+                    // so its raw balance is excluded from the recipients list.
+                    if (recipients[k] == questModule) continue;
 
                     uint256 recipientBalance = FRACTION_TOKEN().balanceOf(
                         recipients[k],
                         _splitInfo.wearers[j],
                         _splitInfo.hatId
                     );
+
+                    if (questModule != address(0)) {
+                        recipientBalance += HATS_QUEST_MODULE()
+                            .getEscrowedBalance(
+                                recipients[k],
+                                _splitInfo.hatId,
+                                _splitInfo.wearers[j]
+                            );
+                    }
 
                     uint256 recipientScore = recipientBalance *
                         roleMultiplier *

--- a/pkgs/contract/contracts/splitscreator/SplitsCreatorFactory.sol
+++ b/pkgs/contract/contracts/splitscreator/SplitsCreatorFactory.sol
@@ -16,7 +16,8 @@ contract SplitsCreatorFactory is OwnableUpgradeable, UUPSUpgradeable {
         address splitFactoryV2,
         address hatsTimeFrameModule,
         address fractionToken,
-        address thanksToken
+        address thanksToken,
+        address hatsQuestModule
     );
 
     address public SPLITS_CREATOR_IMPLEMENTATION;
@@ -38,6 +39,7 @@ contract SplitsCreatorFactory is OwnableUpgradeable, UUPSUpgradeable {
         address _hatsTimeFrameModule,
         address _fractionToken,
         address _thanksToken,
+        address _hatsQuestModule,
         bytes32 _salt
     ) external returns (address splitCreator) {
         if (_msgSender() != BIG_BANG) {
@@ -51,7 +53,8 @@ contract SplitsCreatorFactory is OwnableUpgradeable, UUPSUpgradeable {
                 _splitFactoryV2,
                 _hatsTimeFrameModule,
                 _fractionToken,
-                _thanksToken
+                _thanksToken,
+                _hatsQuestModule
             ),
             _getSalt(
                 _topHatId,
@@ -60,6 +63,7 @@ contract SplitsCreatorFactory is OwnableUpgradeable, UUPSUpgradeable {
                 _hatsTimeFrameModule,
                 _fractionToken,
                 _thanksToken,
+                _hatsQuestModule,
                 _salt
             )
         );
@@ -71,7 +75,8 @@ contract SplitsCreatorFactory is OwnableUpgradeable, UUPSUpgradeable {
             _splitFactoryV2,
             _hatsTimeFrameModule,
             _fractionToken,
-            _thanksToken
+            _thanksToken,
+            _hatsQuestModule
         );
     }
 
@@ -82,6 +87,7 @@ contract SplitsCreatorFactory is OwnableUpgradeable, UUPSUpgradeable {
         address _hatsTimeFrameModule,
         address _fractionToken,
         address _thanksToken,
+        address _hatsQuestModule,
         bytes32 _salt
     ) external view returns (address) {
         return
@@ -92,7 +98,8 @@ contract SplitsCreatorFactory is OwnableUpgradeable, UUPSUpgradeable {
                     _splitFactoryV2,
                     _hatsTimeFrameModule,
                     _fractionToken,
-                    _thanksToken
+                    _thanksToken,
+                    _hatsQuestModule
                 ),
                 _getSalt(
                     _topHatId,
@@ -101,6 +108,7 @@ contract SplitsCreatorFactory is OwnableUpgradeable, UUPSUpgradeable {
                     _hatsTimeFrameModule,
                     _fractionToken,
                     _thanksToken,
+                    _hatsQuestModule,
                     _salt
                 ),
                 address(this)
@@ -122,6 +130,7 @@ contract SplitsCreatorFactory is OwnableUpgradeable, UUPSUpgradeable {
         address _hatsTimeFrameModule,
         address _fractionToken,
         address _thanksToken,
+        address _hatsQuestModule,
         bytes32 _salt
     ) internal pure returns (bytes32) {
         return
@@ -133,6 +142,7 @@ contract SplitsCreatorFactory is OwnableUpgradeable, UUPSUpgradeable {
                     _hatsTimeFrameModule,
                     _fractionToken,
                     _thanksToken,
+                    _hatsQuestModule,
                     _salt
                 )
             );

--- a/pkgs/contract/helpers/deploy/BigBang.ts
+++ b/pkgs/contract/helpers/deploy/BigBang.ts
@@ -12,6 +12,7 @@ export const deployBigBang = async (
     hatsTimeFrameModule_impl: Address;
     hatsHatCreatorModule_impl: Address;
     hatsFractionTokenModule_impl?: Address;
+    hatsQuestModule_impl?: Address;
     splitsCreatorFactoryAddress: Address;
     splitsFactoryV2Address: Address;
     thanksTokenFactoryAddress: Address;
@@ -39,6 +40,7 @@ export const deployBigBang = async (
       params.hatsTimeFrameModule_impl,
       params.hatsHatCreatorModule_impl,
       params.hatsFractionTokenModule_impl,
+      params.hatsQuestModule_impl,
       params.splitsCreatorFactoryAddress,
       params.splitsFactoryV2Address,
       params.thanksTokenFactoryAddress,

--- a/pkgs/contract/helpers/deploy/Hats.ts
+++ b/pkgs/contract/helpers/deploy/Hats.ts
@@ -24,6 +24,10 @@ export type HatsFractionTokenModule = Awaited<
   ReturnType<typeof deployHatsFractionTokenModule>
 >["HatsFractionTokenModule"];
 
+export type HatsQuestModule = Awaited<
+  ReturnType<typeof deployHatsQuestModule>
+>["HatsQuestModule"];
+
 export const deployHatsProtocol = async () => {
   const Hats = await viem.deployContract("Hats", ["test", "https://test.com"]);
 
@@ -118,4 +122,28 @@ export const deployHatsFractionTokenModule = async (
   );
 
   return { HatsFractionTokenModule };
+};
+
+export const deployHatsQuestModule = async (
+  version = "0.0.0",
+  create2DeployerAddress?: string,
+) => {
+  const HatsQuestModuleFactory =
+    await ethers.getContractFactory("HatsQuestModule");
+  const HatsQuestModuleTx =
+    await HatsQuestModuleFactory.getDeployTransaction(version);
+  const HatsQuestModuleAddress = await deployContract_Create2(
+    baseSalt,
+    HatsQuestModuleTx.data || "0x",
+    ethers.keccak256(HatsQuestModuleTx.data),
+    "HatsQuestModule",
+    create2DeployerAddress,
+  );
+
+  const HatsQuestModule = await viem.getContractAt(
+    "HatsQuestModule",
+    HatsQuestModuleAddress as Address,
+  );
+
+  return { HatsQuestModule };
 };

--- a/pkgs/contract/scripts/deploy/create2.ts
+++ b/pkgs/contract/scripts/deploy/create2.ts
@@ -5,6 +5,7 @@ import { deployBigBang } from "../../helpers/deploy/BigBang";
 import {
   deployHatsFractionTokenModule,
   deployHatsHatCreatorModule,
+  deployHatsQuestModule,
   deployHatsTimeFrameModule,
 } from "../../helpers/deploy/Hats";
 import {
@@ -35,6 +36,9 @@ const deploy = async () => {
   const { HatsFractionTokenModule } =
     await deployHatsFractionTokenModule("0.0.0");
   const hatsFractionTokenModuleAddress = HatsFractionTokenModule.address;
+
+  const { HatsQuestModule } = await deployHatsQuestModule("0.0.0");
+  const hatsQuestModuleAddress = HatsQuestModule.address;
 
   console.log("Deploying ThanksToken...");
   const { ThanksToken } = await deployThanksToken();
@@ -77,6 +81,7 @@ const deploy = async () => {
     hatsTimeFrameModule_impl: hatsTimeFrameModuleAddress,
     hatsHatCreatorModule_impl: hatsHatCreatorModuleAddress,
     hatsFractionTokenModule_impl: hatsFractionTokenModuleAddress,
+    hatsQuestModule_impl: hatsQuestModuleAddress,
     splitsCreatorFactoryAddress: splitsCreatorFactoryAddress,
     splitsFactoryV2Address: process.env.PULL_SPLITS_FACTORY_ADDRESS as Address,
     thanksTokenFactoryAddress: thanksTokenFactoryAddress,
@@ -111,6 +116,10 @@ const deploy = async () => {
   console.log(
     "HatsFractionTokenModule:\n",
     `pnpm contract hardhat verify ${hatsFractionTokenModuleAddress} 0.0.0 --network ${network.name}\n`,
+  );
+  console.log(
+    "HatsQuestModule:\n",
+    `pnpm contract hardhat verify ${hatsQuestModuleAddress} 0.0.0 --network ${network.name}\n`,
   );
   console.log(
     "ThanksToken:\n",

--- a/pkgs/contract/test/BigBang.ts
+++ b/pkgs/contract/test/BigBang.ts
@@ -11,11 +11,13 @@ import {
   type HatsFractionTokenModule,
   type HatsHatCreatorModule,
   type HatsModuleFactory,
+  type HatsQuestModule,
   type HatsTimeFrameModule,
   deployHatsFractionTokenModule,
   deployHatsHatCreatorModule,
   deployHatsModuleFactory,
   deployHatsProtocol,
+  deployHatsQuestModule,
   deployHatsTimeFrameModule,
 } from "../helpers/deploy/Hats";
 import {
@@ -42,6 +44,7 @@ describe("BigBang", () => {
   let HatsTimeFrameModule_IMPL: HatsTimeFrameModule;
   let HatsHatCreatorModule_IMPL: HatsHatCreatorModule;
   let HatsFractionTokenModule_IMPL: HatsFractionTokenModule;
+  let HatsQuestModule_IMPL: HatsQuestModule;
   let SplitsWarehouse: SplitsWarehouse;
   let PullSplitsFactory: PullSplitsFactory;
   let PushSplitsFactory: PushSplitsFactory;
@@ -78,6 +81,10 @@ describe("BigBang", () => {
     const { HatsFractionTokenModule: _HatsFractionTokenModule_IMPL } =
       await deployHatsFractionTokenModule("0.0.0", Create2Deployer.address);
     HatsFractionTokenModule_IMPL = _HatsFractionTokenModule_IMPL;
+
+    const { HatsQuestModule: _HatsQuestModule_IMPL } =
+      await deployHatsQuestModule("0.0.0", Create2Deployer.address);
+    HatsQuestModule_IMPL = _HatsQuestModule_IMPL;
 
     const {
       SplitsWarehouse: _SplitsWarehouse,
@@ -129,6 +136,7 @@ describe("BigBang", () => {
         hatsTimeFrameModule_impl: HatsTimeFrameModule_IMPL.address,
         hatsHatCreatorModule_impl: HatsHatCreatorModule_IMPL.address,
         hatsFractionTokenModule_impl: HatsFractionTokenModule_IMPL.address,
+        hatsQuestModule_impl: HatsQuestModule_IMPL.address,
         splitsCreatorFactoryAddress: SplitsCreatorFactory.address,
         splitsFactoryV2Address: PullSplitsFactory.address,
         thanksTokenFactoryAddress: ThanksTokenFactory.address,

--- a/pkgs/contract/test/HatsFractionTokenModule.ts
+++ b/pkgs/contract/test/HatsFractionTokenModule.ts
@@ -351,5 +351,80 @@ describe("HatsFractionTokenModule", () => {
       ]);
       expect(balanceAddress3).to.equal(0n);
     });
+
+    it("non-wearer recipient can transfer all of their balance", async () => {
+      // The wearer-only retention rule must not block intermediate holders
+      // (e.g. escrow modules) from draining the full balance of a tokenId.
+      // address2 is the wearer; address3 is a recipient.
+      const tokenId = await HatsFractionTokenModule.read.getTokenId([
+        hatId1,
+        address2Validated,
+      ]);
+
+      // Top up: wearer keeps a balance, recipient gets some to drain.
+      await HatsFractionTokenModule.write.mint(
+        [hatId1, address2Validated, 2000n],
+        { account: address1Validated },
+      );
+      await HatsFractionTokenModule.write.safeTransferFrom(
+        [address2Validated, address3Validated, tokenId, 1000n, "0x"],
+        { account: address2Validated },
+      );
+
+      const recipientBalance = await HatsFractionTokenModule.read.balanceOf([
+        address3Validated,
+        tokenId,
+      ]);
+      expect(recipientBalance).to.equal(1000n);
+
+      // Recipient transfers their full balance — must NOT revert.
+      await HatsFractionTokenModule.write.safeTransferFrom(
+        [
+          address3Validated,
+          address1Validated,
+          tokenId,
+          recipientBalance,
+          "0x",
+        ],
+        { account: address3Validated },
+      );
+
+      expect(
+        await HatsFractionTokenModule.read.balanceOf([
+          address3Validated,
+          tokenId,
+        ]),
+      ).to.equal(0n);
+    });
+
+    it("wearer still cannot transfer their entire balance", async () => {
+      const tokenId = await HatsFractionTokenModule.read.getTokenId([
+        hatId1,
+        address2Validated,
+      ]);
+      const wearerBalance = await HatsFractionTokenModule.read.balanceOf([
+        address2Validated,
+        tokenId,
+      ]);
+      expect(wearerBalance > 0n, "wearer balance is non-zero").to.be.true;
+
+      let reverted = false;
+      try {
+        await HatsFractionTokenModule.write.safeTransferFrom(
+          [
+            address2Validated,
+            address3Validated,
+            tokenId,
+            wearerBalance,
+            "0x",
+          ],
+          { account: address2Validated },
+        );
+      } catch (error) {
+        reverted = true;
+        expect((error as Error).message).to.include("CannotTransferAllTokens");
+      }
+      expect(reverted, "wearer full transfer should revert").to.be.true;
+    });
   });
 });

--- a/pkgs/contract/test/HatsQuestModule.SplitsIntegration.ts
+++ b/pkgs/contract/test/HatsQuestModule.SplitsIntegration.ts
@@ -1,0 +1,495 @@
+import { expect } from "chai";
+import { viem } from "hardhat";
+import {
+  type Address,
+  type PublicClient,
+  type WalletClient,
+  decodeEventLog,
+  encodeAbiParameters,
+  keccak256,
+  zeroAddress,
+} from "viem";
+import {
+  type Create2Deployer,
+  deployCreate2Deployer,
+} from "../helpers/deploy/Create2Factory";
+import {
+  type Hats,
+  type HatsFractionTokenModule,
+  type HatsModuleFactory,
+  type HatsQuestModule,
+  type HatsTimeFrameModule,
+  deployHatsFractionTokenModule,
+  deployHatsModuleFactory,
+  deployHatsProtocol,
+  deployHatsQuestModule,
+  deployHatsTimeFrameModule,
+} from "../helpers/deploy/Hats";
+import {
+  type PullSplitsFactory,
+  type SplitsCreator,
+  type SplitsCreatorFactory,
+  type SplitsWarehouse,
+  deploySplitsCreator,
+  deploySplitsCreatorFactory,
+  deploySplitsProtocol,
+} from "../helpers/deploy/Splits";
+import {
+  type ThanksToken,
+  type ThanksTokenFactory,
+  deployThanksToken,
+  deployThanksTokenFactory,
+} from "../helpers/deploy/ThanksToken";
+
+/**
+ * Verifies the SplitsCreator <-> HatsQuestModule integration:
+ *  1. The quest module address is excluded from the recipients list.
+ *  2. While shares are escrowed, the creator's preview score includes the
+ *     escrowed amount.
+ *  3. After completion the share moves to the submitter and the creator's
+ *     score drops accordingly.
+ *  4. After cancellation the escrow returns to the creator and the score
+ *     matches the pre-escrow baseline.
+ */
+describe("HatsQuestModule + SplitsCreator integration", () => {
+  let Create2Deployer: Create2Deployer;
+  let Hats: Hats;
+  let HatsModuleFactory: HatsModuleFactory;
+  let HatsFractionTokenModule_IMPL: HatsFractionTokenModule;
+  let HatsTimeFrameModule_IMPL: HatsTimeFrameModule;
+  let HatsQuestModule_IMPL: HatsQuestModule;
+  let HatsFractionTokenModule: HatsFractionTokenModule;
+  let HatsTimeFrameModule: HatsTimeFrameModule;
+  let HatsQuestModule: HatsQuestModule;
+  let SplitsCreator_IMPL: SplitsCreator;
+  let SplitsCreatorFactory: SplitsCreatorFactory;
+  let SplitsCreator: SplitsCreator;
+  let ThanksToken_IMPL: ThanksToken;
+  let ThanksTokenFactory: ThanksTokenFactory;
+  let ThanksToken: ThanksToken;
+  let PullSplitsFactory: PullSplitsFactory;
+  let SplitsWarehouse: SplitsWarehouse;
+
+  let admin: WalletClient;
+  let creator: WalletClient;
+  let submitter: WalletClient;
+  let bigBang: WalletClient;
+  let publicClient: PublicClient;
+
+  let adminAddr: Address;
+  let creatorAddr: Address;
+  let submitterAddr: Address;
+
+  let topHatId: bigint;
+  let workHatId: bigint;
+
+  const validateAddress = (client: WalletClient): Address => {
+    if (!client.account?.address) throw new Error("missing account");
+    return client.account.address;
+  };
+
+  const weightsInfo = {
+    roleWeight: 1n,
+    thanksTokenWeight: 0n,
+    thanksTokenReceivedWeight: 1n,
+    thanksTokenSentWeight: 1n,
+  };
+
+  const previewScores = async () => {
+    const result = await SplitsCreator.read.preview([
+      [
+        {
+          hatId: workHatId,
+          wearers: [creatorAddr],
+          multiplierBottom: 1n,
+          multiplierTop: 1n,
+        },
+      ],
+      weightsInfo,
+    ]);
+    const shareHolders = result[0] as readonly Address[];
+    const allocations = result[1] as readonly bigint[];
+    const map: Record<string, bigint> = {};
+    for (let i = 0; i < shareHolders.length; i++) {
+      const addr = shareHolders[i].toLowerCase();
+      map[addr] = (map[addr] ?? 0n) + allocations[i];
+    }
+    return { shareHolders, allocations, map };
+  };
+
+  before(async () => {
+    [admin, creator, submitter, bigBang] = await viem.getWalletClients();
+    adminAddr = validateAddress(admin);
+    creatorAddr = validateAddress(creator);
+    submitterAddr = validateAddress(submitter);
+    publicClient = await viem.getPublicClient();
+
+    const { Create2Deployer: _Create2Deployer } = await deployCreate2Deployer();
+    Create2Deployer = _Create2Deployer;
+
+    const { Hats: _Hats } = await deployHatsProtocol();
+    Hats = _Hats;
+
+    const { HatsModuleFactory: _HMF } = await deployHatsModuleFactory(
+      Hats.address,
+    );
+    HatsModuleFactory = _HMF;
+
+    const { HatsTimeFrameModule: _tf } = await deployHatsTimeFrameModule(
+      "0.0.0",
+      Create2Deployer.address,
+    );
+    HatsTimeFrameModule_IMPL = _tf;
+
+    const { HatsFractionTokenModule: _ft } =
+      await deployHatsFractionTokenModule("0.0.0", Create2Deployer.address);
+    HatsFractionTokenModule_IMPL = _ft;
+
+    const { HatsQuestModule: _q } = await deployHatsQuestModule(
+      "0.0.0",
+      Create2Deployer.address,
+    );
+    HatsQuestModule_IMPL = _q;
+
+    const { SplitsCreator: _sc } = await deploySplitsCreator(
+      Create2Deployer.address,
+    );
+    SplitsCreator_IMPL = _sc;
+
+    const {
+      SplitsWarehouse: _sw,
+      PullSplitsFactory: _psf,
+    } = await deploySplitsProtocol();
+    SplitsWarehouse = _sw;
+    PullSplitsFactory = _psf;
+
+    const { ThanksToken: _tt } = await deployThanksToken(Create2Deployer.address);
+    ThanksToken_IMPL = _tt;
+
+    const { ThanksTokenFactory: _ttf } = await deployThanksTokenFactory(
+      {
+        initialOwner: adminAddr,
+        implementation: ThanksToken_IMPL.address,
+        hatsAddress: Hats.address,
+      },
+      Create2Deployer.address,
+    );
+    ThanksTokenFactory = _ttf;
+
+    // ====== Hats setup ======
+    await Hats.write.mintTopHat([adminAddr, "Workspace", "ipfs://workspace"]);
+    topHatId = BigInt(
+      "0x0000000100000000000000000000000000000000000000000000000000000000",
+    );
+
+    let txHash = await Hats.write.createHat([
+      topHatId,
+      "Hatter",
+      100,
+      "0x0000000000000000000000000000000000004A75",
+      "0x0000000000000000000000000000000000004A75",
+      true,
+      "",
+    ]);
+    let receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+    let hatterHatId: bigint | undefined;
+    for (const log of receipt.logs) {
+      const decoded = decodeEventLog({
+        abi: Hats.abi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === "HatCreated") hatterHatId = decoded.args.id as bigint;
+    }
+    if (!hatterHatId) throw new Error("hatter hat not created");
+
+    txHash = await Hats.write.createHat([
+      hatterHatId,
+      "Worker",
+      100,
+      "0x0000000000000000000000000000000000004A75",
+      "0x0000000000000000000000000000000000004A75",
+      true,
+      "",
+    ]);
+    receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+    for (const log of receipt.logs) {
+      const decoded = decodeEventLog({
+        abi: Hats.abi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === "HatCreated") workHatId = decoded.args.id as bigint;
+    }
+
+    // ====== Module clones ======
+    const ftInitData = encodeAbiParameters(
+      [{ type: "string" }, { type: "uint256" }],
+      ["", 10_000n],
+    );
+    await HatsModuleFactory.write.createHatsModule([
+      HatsFractionTokenModule_IMPL.address,
+      topHatId,
+      "0x",
+      ftInitData,
+      0n,
+    ]);
+    HatsFractionTokenModule = await viem.getContractAt(
+      "HatsFractionTokenModule",
+      (await HatsModuleFactory.read.getHatsModuleAddress([
+        HatsFractionTokenModule_IMPL.address,
+        topHatId,
+        "0x",
+        0n,
+      ])) as Address,
+    );
+
+    const tfInitData = encodeAbiParameters([{ type: "uint256" }], [topHatId]);
+    await HatsModuleFactory.write.createHatsModule([
+      HatsTimeFrameModule_IMPL.address,
+      topHatId,
+      "0x",
+      tfInitData,
+      0n,
+    ]);
+    HatsTimeFrameModule = await viem.getContractAt(
+      "HatsTimeFrameModule",
+      (await HatsModuleFactory.read.getHatsModuleAddress([
+        HatsTimeFrameModule_IMPL.address,
+        topHatId,
+        "0x",
+        0n,
+      ])) as Address,
+    );
+
+    const qInitData = encodeAbiParameters(
+      [{ type: "address" }],
+      [HatsFractionTokenModule.address],
+    );
+    await HatsModuleFactory.write.createHatsModule([
+      HatsQuestModule_IMPL.address,
+      topHatId,
+      "0x",
+      qInitData,
+      0n,
+    ]);
+    HatsQuestModule = await viem.getContractAt(
+      "HatsQuestModule",
+      (await HatsModuleFactory.read.getHatsModuleAddress([
+        HatsQuestModule_IMPL.address,
+        topHatId,
+        "0x",
+        0n,
+      ])) as Address,
+    );
+
+    // The TimeFrameModule must wear the hatter hat to be allowed to mint
+    // child hats (workHat). Mint hatter to both FractionToken and TimeFrame.
+    await Hats.write.mintHat([hatterHatId, HatsFractionTokenModule.address], {
+      account: admin.account,
+    });
+    await Hats.write.mintHat([hatterHatId, HatsTimeFrameModule.address], {
+      account: admin.account,
+    });
+    // Use TimeFrameModule so that woreTime is recorded with a past timestamp
+    // — otherwise `_getHatsTimeFrameMultiplier` returns 0 and
+    // SplitsCreator.preview panics on a divide-by-zero. The minter hat is
+    // topHatId (set in init); admin wears the top hat so they're authorized.
+    const pastWoreTime = 1n;
+    await HatsTimeFrameModule.write.mintHat(
+      [workHatId, creatorAddr, pastWoreTime],
+      { account: admin.account },
+    );
+    await HatsTimeFrameModule.write.mintHat(
+      [workHatId, submitterAddr, pastWoreTime],
+      { account: admin.account },
+    );
+
+    // Initial RoleShare: 10_000 to creator
+    await HatsFractionTokenModule.write.mintInitialSupply(
+      [workHatId, creatorAddr, 0n],
+      { account: creator.account },
+    );
+
+    // Allow QuestModule to escrow on behalf of creator
+    await HatsFractionTokenModule.write.setApprovalForAll(
+      [HatsQuestModule.address, true],
+      { account: creator.account },
+    );
+
+    // ====== ThanksToken (required by SplitsCreator constructor args) ======
+    await ThanksTokenFactory.write.setBigBang([validateAddress(bigBang)]);
+    const ttCreateTx =
+      await ThanksTokenFactory.write.createThanksTokenDeterministic(
+        [
+          "TT",
+          "TT",
+          validateAddress(bigBang),
+          HatsFractionTokenModule.address,
+          HatsTimeFrameModule.address,
+          ("0x" + "01".repeat(32)) as `0x${string}`,
+        ],
+        { account: bigBang.account },
+      );
+    const ttReceipt = await publicClient.waitForTransactionReceipt({
+      hash: ttCreateTx,
+    });
+    let thanksTokenAddress: Address | undefined;
+    for (const log of ttReceipt.logs) {
+      try {
+        const decoded = decodeEventLog({
+          abi: ThanksTokenFactory.abi,
+          data: log.data,
+          topics: log.topics,
+        });
+        if (decoded.eventName === "ThanksTokenCreated") {
+          thanksTokenAddress = decoded.args.tokenAddress as Address;
+        }
+      } catch {}
+    }
+    if (!thanksTokenAddress) throw new Error("thanks token not created");
+    ThanksToken = await viem.getContractAt("ThanksToken", thanksTokenAddress);
+
+    // ====== SplitsCreatorFactory + SplitsCreator clone wired with QuestModule ======
+    const { SplitsCreatorFactory: _scf } = await deploySplitsCreatorFactory(
+      SplitsCreator_IMPL.address,
+      Create2Deployer.address,
+    );
+    SplitsCreatorFactory = _scf;
+    await SplitsCreatorFactory.write.setBigBang([validateAddress(bigBang)]);
+
+    const salt = keccak256("0x4242");
+    const predicted =
+      await SplitsCreatorFactory.read.predictDeterministicAddress([
+        topHatId,
+        Hats.address,
+        PullSplitsFactory.address,
+        HatsTimeFrameModule.address,
+        HatsFractionTokenModule.address,
+        ThanksToken.address,
+        HatsQuestModule.address,
+        salt,
+      ]);
+    await SplitsCreatorFactory.write.createSplitCreatorDeterministic(
+      [
+        topHatId,
+        Hats.address,
+        PullSplitsFactory.address,
+        HatsTimeFrameModule.address,
+        HatsFractionTokenModule.address,
+        ThanksToken.address,
+        HatsQuestModule.address,
+        salt,
+      ],
+      { account: bigBang.account },
+    );
+    SplitsCreator = await viem.getContractAt(
+      "SplitsCreator",
+      predicted as Address,
+    );
+
+    expect((await SplitsCreator.read.HATS_QUEST_MODULE()).toLowerCase()).to.equal(
+      HatsQuestModule.address.toLowerCase(),
+    );
+  });
+
+  it("baseline preview: only the wearer appears in the recipients", async () => {
+    const { shareHolders, map } = await previewScores();
+    expect(shareHolders.map((a) => a.toLowerCase())).to.deep.equal([
+      creatorAddr.toLowerCase(),
+    ]);
+    expect(map[creatorAddr.toLowerCase()] > 0n, "creator score positive").to.be.true;
+  });
+
+  it("while escrowed: quest module is excluded from recipients and creator score is preserved", async () => {
+    const baseline = await previewScores();
+
+    await HatsQuestModule.write.createQuest(
+      [workHatId, creatorAddr, 4_000n, ("0x" + "ab".repeat(32)) as `0x${string}`],
+      { account: creator.account },
+    );
+
+    const escrowed = await previewScores();
+    const lowerHolders = escrowed.shareHolders.map((a) => a.toLowerCase());
+
+    // Quest module never appears in the recipient list.
+    expect(lowerHolders).to.not.include(HatsQuestModule.address.toLowerCase());
+
+    // The creator's score is unchanged (escrow credited back to them).
+    expect(escrowed.map[creatorAddr.toLowerCase()]).to.equal(
+      baseline.map[creatorAddr.toLowerCase()],
+    );
+
+    // The submitter is not yet a holder.
+    expect(escrowed.map[submitterAddr.toLowerCase()]).to.equal(undefined);
+  });
+
+  it("after completion: submitter shows up with the released share", async () => {
+    // The quest created above has questId = 0 (we created it in the previous test).
+    const questId = 0n;
+    await HatsQuestModule.write.submitCompletion([questId, workHatId], {
+      account: submitter.account,
+    });
+    await HatsQuestModule.write.approve([questId, workHatId], {
+      account: creator.account,
+    });
+
+    const { shareHolders, map } = await previewScores();
+    const lower = shareHolders.map((a) => a.toLowerCase());
+
+    expect(lower).to.include(submitterAddr.toLowerCase());
+    expect(lower).to.not.include(HatsQuestModule.address.toLowerCase());
+    expect(map[submitterAddr.toLowerCase()] > 0n, "submitter score positive").to.be.true;
+    expect(map[creatorAddr.toLowerCase()] > 0n, "creator score positive").to.be.true;
+
+    // Sanity: submitter score reflects released share, less than creator's
+    // because creator still holds the larger residual balance.
+    expect(
+      map[creatorAddr.toLowerCase()] > map[submitterAddr.toLowerCase()],
+      "creator > submitter",
+    ).to.be.true;
+  });
+
+  it("after cancellation: creator score returns to the pre-escrow baseline", async () => {
+    // Snapshot the score with the released share already moved to submitter.
+    const before = await previewScores();
+    const creatorBefore = before.map[creatorAddr.toLowerCase()];
+
+    // New quest; cancelled before any submission.
+    const txHash = await HatsQuestModule.write.createQuest(
+      [workHatId, creatorAddr, 1_500n, ("0x" + "cd".repeat(32)) as `0x${string}`],
+      { account: creator.account },
+    );
+    const receipt = await publicClient.waitForTransactionReceipt({
+      hash: txHash,
+    });
+    let newQuestId: bigint | undefined;
+    for (const log of receipt.logs) {
+      try {
+        const decoded = decodeEventLog({
+          abi: HatsQuestModule.abi,
+          data: log.data,
+          topics: log.topics,
+        });
+        if (decoded.eventName === "QuestCreated") {
+          newQuestId = decoded.args.questId as bigint;
+        }
+      } catch {}
+    }
+    if (newQuestId === undefined) throw new Error("quest id not found");
+
+    // While escrowed, creator score is preserved.
+    const duringEscrow = await previewScores();
+    expect(duringEscrow.map[creatorAddr.toLowerCase()]).to.equal(creatorBefore);
+
+    // After cancel, no change.
+    await HatsQuestModule.write.cancel([newQuestId], {
+      account: creator.account,
+    });
+    const after = await previewScores();
+    expect(after.map[creatorAddr.toLowerCase()]).to.equal(creatorBefore);
+    expect(
+      after.shareHolders.map((a) => a.toLowerCase()),
+    ).to.not.include(HatsQuestModule.address.toLowerCase());
+  });
+});

--- a/pkgs/contract/test/HatsQuestModule.ts
+++ b/pkgs/contract/test/HatsQuestModule.ts
@@ -1,0 +1,633 @@
+import { expect } from "chai";
+import { viem } from "hardhat";
+import {
+  type Address,
+  type PublicClient,
+  type WalletClient,
+  decodeEventLog,
+  encodeAbiParameters,
+} from "viem";
+import {
+  type Create2Deployer,
+  deployCreate2Deployer,
+} from "../helpers/deploy/Create2Factory";
+import {
+  type Hats,
+  type HatsFractionTokenModule,
+  type HatsModuleFactory,
+  type HatsQuestModule,
+  deployHatsFractionTokenModule,
+  deployHatsModuleFactory,
+  deployHatsProtocol,
+  deployHatsQuestModule,
+} from "../helpers/deploy/Hats";
+
+describe("HatsQuestModule", () => {
+  let Create2Deployer: Create2Deployer;
+  let Hats: Hats;
+  let HatsModuleFactory: HatsModuleFactory;
+  let HatsFractionTokenModule_IMPL: HatsFractionTokenModule;
+  let HatsFractionTokenModule: HatsFractionTokenModule;
+  let HatsQuestModule_IMPL: HatsQuestModule;
+  let HatsQuestModule: HatsQuestModule;
+
+  let admin: WalletClient;
+  let creator: WalletClient;
+  let submitter: WalletClient;
+  let approver: WalletClient;
+  let outsider: WalletClient;
+
+  let adminAddr: Address;
+  let creatorAddr: Address;
+  let submitterAddr: Address;
+  let approverAddr: Address;
+  let outsiderAddr: Address;
+
+  let publicClient: PublicClient;
+
+  let topHatId: bigint;
+  let hatterHatId: bigint;
+  let workHatId: bigint;
+  let foreignTopHatId: bigint;
+  let foreignHatId: bigint;
+
+  const validateAddress = (client: WalletClient): Address => {
+    if (!client.account?.address) throw new Error("missing account");
+    return client.account.address;
+  };
+
+  const decodeQuestId = (logs: any[]): bigint => {
+    for (const log of logs) {
+      try {
+        const decoded = decodeEventLog({
+          abi: HatsQuestModule.abi,
+          data: log.data,
+          topics: log.topics,
+        });
+        if (decoded.eventName === "QuestCreated") {
+          return decoded.args.questId as bigint;
+        }
+      } catch {}
+    }
+    throw new Error("QuestCreated event not found");
+  };
+
+  before(async () => {
+    [admin, creator, submitter, approver, outsider] =
+      await viem.getWalletClients();
+    adminAddr = validateAddress(admin);
+    creatorAddr = validateAddress(creator);
+    submitterAddr = validateAddress(submitter);
+    approverAddr = validateAddress(approver);
+    outsiderAddr = validateAddress(outsider);
+
+    publicClient = await viem.getPublicClient();
+
+    const { Create2Deployer: _Create2Deployer } = await deployCreate2Deployer();
+    Create2Deployer = _Create2Deployer;
+
+    const { Hats: _Hats } = await deployHatsProtocol();
+    Hats = _Hats;
+
+    const { HatsModuleFactory: _HatsModuleFactory } =
+      await deployHatsModuleFactory(_Hats.address);
+    HatsModuleFactory = _HatsModuleFactory;
+
+    const { HatsFractionTokenModule: _ftIMPL } =
+      await deployHatsFractionTokenModule("0.0.0", Create2Deployer.address);
+    HatsFractionTokenModule_IMPL = _ftIMPL;
+
+    const { HatsQuestModule: _qIMPL } = await deployHatsQuestModule(
+      "0.0.0",
+      Create2Deployer.address,
+    );
+    HatsQuestModule_IMPL = _qIMPL;
+
+    // Mint a top hat to admin (workspace 1)
+    await Hats.write.mintTopHat([adminAddr, "Workspace", "ipfs://workspace"]);
+    topHatId = BigInt(
+      "0x0000000100000000000000000000000000000000000000000000000000000000",
+    );
+
+    // Hatter hat under top hat (so workHat can be auto-minted)
+    let txHash = await Hats.write.createHat([
+      topHatId,
+      "Hatter",
+      100,
+      "0x0000000000000000000000000000000000004A75",
+      "0x0000000000000000000000000000000000004A75",
+      true,
+      "",
+    ]);
+    let receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+    for (const log of receipt.logs) {
+      const decoded = decodeEventLog({
+        abi: Hats.abi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === "HatCreated") {
+        hatterHatId = decoded.args.id as bigint;
+      }
+    }
+
+    // Work hat (the one we'll back with RoleShare)
+    txHash = await Hats.write.createHat([
+      hatterHatId,
+      "Worker",
+      100,
+      "0x0000000000000000000000000000000000004A75",
+      "0x0000000000000000000000000000000000004A75",
+      true,
+      "",
+    ]);
+    receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+    for (const log of receipt.logs) {
+      const decoded = decodeEventLog({
+        abi: Hats.abi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === "HatCreated") {
+        workHatId = decoded.args.id as bigint;
+      }
+    }
+
+    // Set up a separate workspace (different domain) to test cross-domain checks
+    await Hats.write.mintTopHat([
+      outsiderAddr,
+      "ForeignWorkspace",
+      "ipfs://foreign",
+    ]);
+    foreignTopHatId = BigInt(
+      "0x0000000200000000000000000000000000000000000000000000000000000000",
+    );
+    txHash = await Hats.write.createHat(
+      [
+        foreignTopHatId,
+        "ForeignHat",
+        10,
+        "0x0000000000000000000000000000000000004A75",
+        "0x0000000000000000000000000000000000004A75",
+        true,
+        "",
+      ],
+      { account: outsider.account },
+    );
+    receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+    for (const log of receipt.logs) {
+      const decoded = decodeEventLog({
+        abi: Hats.abi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === "HatCreated") {
+        foreignHatId = decoded.args.id as bigint;
+      }
+    }
+
+    // Deploy the FractionToken module (clone) under the top hat
+    const ftInitData = encodeAbiParameters(
+      [{ type: "string" }, { type: "uint256" }],
+      ["", 10_000n],
+    );
+    await HatsModuleFactory.write.createHatsModule([
+      HatsFractionTokenModule_IMPL.address,
+      topHatId,
+      "0x",
+      ftInitData,
+      0n,
+    ]);
+    const ftAddress = await HatsModuleFactory.read.getHatsModuleAddress([
+      HatsFractionTokenModule_IMPL.address,
+      topHatId,
+      "0x",
+      0n,
+    ]);
+    HatsFractionTokenModule = await viem.getContractAt(
+      "HatsFractionTokenModule",
+      ftAddress as Address,
+    );
+
+    // Mint hatter hat to FT module so it can mint child hats indirectly
+    await Hats.write.mintHat(
+      [hatterHatId, HatsFractionTokenModule.address],
+      { account: admin.account },
+    );
+
+    // Mint the work hat to creator, submitter, and approver so they are workspace members
+    await Hats.write.mintHat([workHatId, creatorAddr], {
+      account: admin.account,
+    });
+    await Hats.write.mintHat([workHatId, submitterAddr], {
+      account: admin.account,
+    });
+    await Hats.write.mintHat([workHatId, approverAddr], {
+      account: admin.account,
+    });
+
+    // Mint initial RoleShare supply for the creator (10_000)
+    await HatsFractionTokenModule.write.mintInitialSupply(
+      [workHatId, creatorAddr, 0n],
+      { account: creator.account },
+    );
+
+    // Deploy QuestModule (clone) bound to the FractionToken module
+    const qInitData = encodeAbiParameters(
+      [{ type: "address" }],
+      [HatsFractionTokenModule.address],
+    );
+    await HatsModuleFactory.write.createHatsModule([
+      HatsQuestModule_IMPL.address,
+      topHatId,
+      "0x",
+      qInitData,
+      0n,
+    ]);
+    const qAddress = await HatsModuleFactory.read.getHatsModuleAddress([
+      HatsQuestModule_IMPL.address,
+      topHatId,
+      "0x",
+      0n,
+    ]);
+    HatsQuestModule = await viem.getContractAt(
+      "HatsQuestModule",
+      qAddress as Address,
+    );
+
+    // Creator approves QuestModule to move RoleShare
+    await HatsFractionTokenModule.write.setApprovalForAll(
+      [HatsQuestModule.address, true],
+      { account: creator.account },
+    );
+  });
+
+  describe("initialization", () => {
+    it("binds to the correct fraction token and domain", async () => {
+      expect(
+        (await HatsQuestModule.read.FRACTION_TOKEN()).toLowerCase(),
+      ).to.equal(HatsFractionTokenModule.address.toLowerCase());
+      expect(await HatsQuestModule.read.getDomain()).to.equal(1);
+      expect(await HatsQuestModule.read.nextQuestId()).to.equal(0n);
+    });
+  });
+
+  describe("createQuest", () => {
+    it("reverts on amount = 0", async () => {
+      await expect(
+        HatsQuestModule.write.createQuest(
+          [workHatId, creatorAddr, 0n, "0x" + "00".repeat(32) as `0x${string}`],
+          { account: creator.account },
+        ),
+      ).to.be.rejectedWith(/InvalidAmount/);
+    });
+
+    it("reverts when hatId is outside the workspace domain", async () => {
+      await expect(
+        HatsQuestModule.write.createQuest(
+          [
+            foreignHatId,
+            creatorAddr,
+            100n,
+            "0x" + "00".repeat(32) as `0x${string}`,
+          ],
+          { account: creator.account },
+        ),
+      ).to.be.rejectedWith(/InvalidHatDomain/);
+    });
+
+    it("reverts when caller balance is insufficient", async () => {
+      await expect(
+        HatsQuestModule.write.createQuest(
+          [
+            workHatId,
+            creatorAddr,
+            10_001n,
+            "0x" + "00".repeat(32) as `0x${string}`,
+          ],
+          { account: creator.account },
+        ),
+      ).to.be.rejectedWith(/InsufficientShare/);
+    });
+
+    it("escrows the share and creates the quest in Open state", async () => {
+      const tokenId = await HatsFractionTokenModule.read.getTokenId([
+        workHatId,
+        creatorAddr,
+      ]);
+      const balanceBefore = await HatsFractionTokenModule.read.balanceOf([
+        creatorAddr,
+        tokenId,
+      ]);
+
+      const txHash = await HatsQuestModule.write.createQuest(
+        [
+          workHatId,
+          creatorAddr,
+          1_000n,
+          "0x" + "11".repeat(32) as `0x${string}`,
+        ],
+        { account: creator.account },
+      );
+      const receipt = await publicClient.waitForTransactionReceipt({
+        hash: txHash,
+      });
+      const questId = decodeQuestId(receipt.logs);
+      expect(questId).to.equal(0n);
+
+      const quest = await HatsQuestModule.read.getQuest([questId]);
+      expect(quest.creator.toLowerCase()).to.equal(creatorAddr.toLowerCase());
+      expect(quest.amount).to.equal(1_000n);
+      expect(quest.status).to.equal(0); // Open
+
+      // Escrow accounting
+      expect(
+        await HatsQuestModule.read.getEscrowedBalance([
+          creatorAddr,
+          workHatId,
+          creatorAddr,
+        ]),
+      ).to.equal(1_000n);
+
+      // Token actually moved into the module
+      expect(
+        await HatsFractionTokenModule.read.balanceOf([
+          HatsQuestModule.address,
+          tokenId,
+        ]),
+      ).to.equal(1_000n);
+      expect(
+        await HatsFractionTokenModule.read.balanceOf([creatorAddr, tokenId]),
+      ).to.equal(balanceBefore - 1_000n);
+    });
+  });
+
+  describe("submitCompletion", () => {
+    it("reverts when caller is the creator", async () => {
+      await expect(
+        HatsQuestModule.write.submitCompletion([0n, workHatId], {
+          account: creator.account,
+        }),
+      ).to.be.rejectedWith(/CannotSubmitOwnQuest/);
+    });
+
+    it("reverts when caller is not a workspace member", async () => {
+      // outsider does not wear any hat in this workspace
+      await expect(
+        HatsQuestModule.write.submitCompletion([0n, foreignHatId], {
+          account: outsider.account,
+        }),
+      ).to.be.rejectedWith(/NotWorkspaceMember|InvalidHatDomain/);
+    });
+
+    it("transitions the quest to PendingReview", async () => {
+      await HatsQuestModule.write.submitCompletion([0n, workHatId], {
+        account: submitter.account,
+      });
+      const quest = await HatsQuestModule.read.getQuest([0n]);
+      expect(quest.submitter.toLowerCase()).to.equal(
+        submitterAddr.toLowerCase(),
+      );
+      expect(quest.status).to.equal(1); // PendingReview
+    });
+
+    it("reverts on second submission of the same quest", async () => {
+      await expect(
+        HatsQuestModule.write.submitCompletion([0n, workHatId], {
+          account: approver.account,
+        }),
+      ).to.be.rejectedWith(/InvalidStatus/);
+    });
+  });
+
+  describe("approve", () => {
+    it("reverts when submitter tries to approve their own submission", async () => {
+      await expect(
+        HatsQuestModule.write.approve([0n, workHatId], {
+          account: submitter.account,
+        }),
+      ).to.be.rejectedWith(/CannotApproveOwnSubmission/);
+    });
+
+    it("completes the quest with creator's single approval and releases the escrow", async () => {
+      const tokenId = await HatsFractionTokenModule.read.getTokenId([
+        workHatId,
+        creatorAddr,
+      ]);
+      const submitterBefore = await HatsFractionTokenModule.read.balanceOf([
+        submitterAddr,
+        tokenId,
+      ]);
+      const moduleBefore = await HatsFractionTokenModule.read.balanceOf([
+        HatsQuestModule.address,
+        tokenId,
+      ]);
+
+      await HatsQuestModule.write.approve([0n, workHatId], {
+        account: creator.account,
+      });
+
+      const quest = await HatsQuestModule.read.getQuest([0n]);
+      expect(quest.status).to.equal(2); // Completed
+
+      expect(
+        await HatsFractionTokenModule.read.balanceOf([submitterAddr, tokenId]),
+      ).to.equal(submitterBefore + 1_000n);
+      expect(
+        await HatsFractionTokenModule.read.balanceOf([
+          HatsQuestModule.address,
+          tokenId,
+        ]),
+      ).to.equal(moduleBefore - 1_000n);
+
+      expect(
+        await HatsQuestModule.read.getEscrowedBalance([
+          creatorAddr,
+          workHatId,
+          creatorAddr,
+        ]),
+      ).to.equal(0n);
+    });
+  });
+
+  describe("approve (two hat-holder path)", () => {
+    let questId: bigint;
+
+    before(async () => {
+      const txHash = await HatsQuestModule.write.createQuest(
+        [
+          workHatId,
+          creatorAddr,
+          500n,
+          "0x" + "22".repeat(32) as `0x${string}`,
+        ],
+        { account: creator.account },
+      );
+      const receipt = await publicClient.waitForTransactionReceipt({
+        hash: txHash,
+      });
+      questId = decodeQuestId(receipt.logs);
+
+      await HatsQuestModule.write.submitCompletion([questId, workHatId], {
+        account: submitter.account,
+      });
+    });
+
+    it("does not complete after a single non-creator approval", async () => {
+      await HatsQuestModule.write.approve([questId, workHatId], {
+        account: approver.account,
+      });
+      const quest = await HatsQuestModule.read.getQuest([questId]);
+      expect(quest.status).to.equal(1); // still PendingReview
+      expect(await HatsQuestModule.read.getApprovalCount([questId])).to.equal(
+        1,
+      );
+    });
+
+    it("rejects double approval from the same address", async () => {
+      await expect(
+        HatsQuestModule.write.approve([questId, workHatId], {
+          account: approver.account,
+        }),
+      ).to.be.rejectedWith(/AlreadyApproved/);
+    });
+
+    it("completes after a second distinct hat-holder approves", async () => {
+      // admin wears the top hat (domain 1)
+      await HatsQuestModule.write.approve([questId, topHatId], {
+        account: admin.account,
+      });
+      const quest = await HatsQuestModule.read.getQuest([questId]);
+      expect(quest.status).to.equal(2); // Completed
+      expect(
+        await HatsQuestModule.read.getEscrowedBalance([
+          creatorAddr,
+          workHatId,
+          creatorAddr,
+        ]),
+      ).to.equal(0n);
+    });
+  });
+
+  describe("cancel", () => {
+    let questId: bigint;
+
+    before(async () => {
+      const txHash = await HatsQuestModule.write.createQuest(
+        [
+          workHatId,
+          creatorAddr,
+          200n,
+          "0x" + "33".repeat(32) as `0x${string}`,
+        ],
+        { account: creator.account },
+      );
+      const receipt = await publicClient.waitForTransactionReceipt({
+        hash: txHash,
+      });
+      questId = decodeQuestId(receipt.logs);
+    });
+
+    it("reverts when called by non-creator", async () => {
+      await expect(
+        HatsQuestModule.write.cancel([questId], { account: submitter.account }),
+      ).to.be.rejectedWith(/NotCreator/);
+    });
+
+    it("returns the escrow to the creator and marks the quest Cancelled", async () => {
+      const tokenId = await HatsFractionTokenModule.read.getTokenId([
+        workHatId,
+        creatorAddr,
+      ]);
+      const creatorBefore = await HatsFractionTokenModule.read.balanceOf([
+        creatorAddr,
+        tokenId,
+      ]);
+
+      await HatsQuestModule.write.cancel([questId], {
+        account: creator.account,
+      });
+
+      const quest = await HatsQuestModule.read.getQuest([questId]);
+      expect(quest.status).to.equal(3); // Cancelled
+      expect(
+        await HatsFractionTokenModule.read.balanceOf([creatorAddr, tokenId]),
+      ).to.equal(creatorBefore + 200n);
+      expect(
+        await HatsQuestModule.read.getEscrowedBalance([
+          creatorAddr,
+          workHatId,
+          creatorAddr,
+        ]),
+      ).to.equal(0n);
+    });
+
+    it("cannot cancel a quest in PendingReview", async () => {
+      // create and submit but do not approve
+      const txHash = await HatsQuestModule.write.createQuest(
+        [
+          workHatId,
+          creatorAddr,
+          100n,
+          "0x" + "44".repeat(32) as `0x${string}`,
+        ],
+        { account: creator.account },
+      );
+      const receipt = await publicClient.waitForTransactionReceipt({
+        hash: txHash,
+      });
+      const pendingId = decodeQuestId(receipt.logs);
+      await HatsQuestModule.write.submitCompletion([pendingId, workHatId], {
+        account: submitter.account,
+      });
+
+      await expect(
+        HatsQuestModule.write.cancel([pendingId], { account: creator.account }),
+      ).to.be.rejectedWith(/InvalidStatus/);
+    });
+  });
+
+  describe("escrow accounting across multiple quests", () => {
+    it("accumulates escrowed balance for the same tokenId", async () => {
+      // creator may need topup; mint extra so balance is plenty
+      await HatsFractionTokenModule.write.mint(
+        [workHatId, creatorAddr, 5_000n],
+        { account: admin.account },
+      );
+
+      const before = await HatsQuestModule.read.getEscrowedBalance([
+        creatorAddr,
+        workHatId,
+        creatorAddr,
+      ]);
+
+      await HatsQuestModule.write.createQuest(
+        [
+          workHatId,
+          creatorAddr,
+          150n,
+          "0x" + "55".repeat(32) as `0x${string}`,
+        ],
+        { account: creator.account },
+      );
+      await HatsQuestModule.write.createQuest(
+        [
+          workHatId,
+          creatorAddr,
+          250n,
+          "0x" + "66".repeat(32) as `0x${string}`,
+        ],
+        { account: creator.account },
+      );
+
+      const after = await HatsQuestModule.read.getEscrowedBalance([
+        creatorAddr,
+        workHatId,
+        creatorAddr,
+      ]);
+
+      // before may already include earlier pending quests; only assert delta
+      expect(after - before).to.equal(400n);
+    });
+  });
+});

--- a/pkgs/contract/test/HatsQuestModule.ts
+++ b/pkgs/contract/test/HatsQuestModule.ts
@@ -119,7 +119,9 @@ describe("HatsQuestModule", () => {
       true,
       "",
     ]);
-    let receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+    let receipt = await publicClient.waitForTransactionReceipt({
+      hash: txHash,
+    });
     for (const log of receipt.logs) {
       const decoded = decodeEventLog({
         abi: Hats.abi,
@@ -210,10 +212,9 @@ describe("HatsQuestModule", () => {
     );
 
     // Mint hatter hat to FT module so it can mint child hats indirectly
-    await Hats.write.mintHat(
-      [hatterHatId, HatsFractionTokenModule.address],
-      { account: admin.account },
-    );
+    await Hats.write.mintHat([hatterHatId, HatsFractionTokenModule.address], {
+      account: admin.account,
+    });
 
     // Mint the work hat to creator, submitter, and approver so they are workspace members
     await Hats.write.mintHat([workHatId, creatorAddr], {
@@ -276,7 +277,12 @@ describe("HatsQuestModule", () => {
     it("reverts on amount = 0", async () => {
       await expect(
         HatsQuestModule.write.createQuest(
-          [workHatId, creatorAddr, 0n, "0x" + "00".repeat(32) as `0x${string}`],
+          [
+            workHatId,
+            creatorAddr,
+            0n,
+            ("0x" + "00".repeat(32)) as `0x${string}`,
+          ],
           { account: creator.account },
         ),
       ).to.be.rejectedWith(/InvalidAmount/);
@@ -289,7 +295,7 @@ describe("HatsQuestModule", () => {
             foreignHatId,
             creatorAddr,
             100n,
-            "0x" + "00".repeat(32) as `0x${string}`,
+            ("0x" + "00".repeat(32)) as `0x${string}`,
           ],
           { account: creator.account },
         ),
@@ -303,7 +309,7 @@ describe("HatsQuestModule", () => {
             workHatId,
             creatorAddr,
             10_001n,
-            "0x" + "00".repeat(32) as `0x${string}`,
+            ("0x" + "00".repeat(32)) as `0x${string}`,
           ],
           { account: creator.account },
         ),
@@ -325,7 +331,7 @@ describe("HatsQuestModule", () => {
           workHatId,
           creatorAddr,
           1_000n,
-          "0x" + "11".repeat(32) as `0x${string}`,
+          ("0x" + "11".repeat(32)) as `0x${string}`,
         ],
         { account: creator.account },
       );
@@ -459,7 +465,7 @@ describe("HatsQuestModule", () => {
           workHatId,
           creatorAddr,
           500n,
-          "0x" + "22".repeat(32) as `0x${string}`,
+          ("0x" + "22".repeat(32)) as `0x${string}`,
         ],
         { account: creator.account },
       );
@@ -518,7 +524,7 @@ describe("HatsQuestModule", () => {
           workHatId,
           creatorAddr,
           200n,
-          "0x" + "33".repeat(32) as `0x${string}`,
+          ("0x" + "33".repeat(32)) as `0x${string}`,
         ],
         { account: creator.account },
       );
@@ -569,7 +575,7 @@ describe("HatsQuestModule", () => {
           workHatId,
           creatorAddr,
           100n,
-          "0x" + "44".repeat(32) as `0x${string}`,
+          ("0x" + "44".repeat(32)) as `0x${string}`,
         ],
         { account: creator.account },
       );
@@ -584,6 +590,142 @@ describe("HatsQuestModule", () => {
       await expect(
         HatsQuestModule.write.cancel([pendingId], { account: creator.account }),
       ).to.be.rejectedWith(/InvalidStatus/);
+    });
+  });
+
+  describe("withdrawSubmission / rejectSubmission", () => {
+    let questId: bigint;
+
+    beforeEach(async () => {
+      // Top up creator balance and create a fresh quest in PendingReview.
+      try {
+        await HatsFractionTokenModule.write.mint(
+          [workHatId, creatorAddr, 1_000n],
+          { account: admin.account },
+        );
+      } catch {}
+      const txHash = await HatsQuestModule.write.createQuest(
+        [
+          workHatId,
+          creatorAddr,
+          300n,
+          ("0x" + "77".repeat(32)) as `0x${string}`,
+        ],
+        { account: creator.account },
+      );
+      const receipt = await publicClient.waitForTransactionReceipt({
+        hash: txHash,
+      });
+      questId = decodeQuestId(receipt.logs);
+      await HatsQuestModule.write.submitCompletion([questId, workHatId], {
+        account: submitter.account,
+      });
+    });
+
+    it("submitter can withdraw their own submission and quest returns to Open", async () => {
+      await HatsQuestModule.write.withdrawSubmission([questId], {
+        account: submitter.account,
+      });
+      const quest = await HatsQuestModule.read.getQuest([questId]);
+      expect(quest.status).to.equal(0); // Open
+      expect(quest.submitter.toLowerCase()).to.equal(
+        "0x0000000000000000000000000000000000000000",
+      );
+    });
+
+    it("non-submitter cannot withdraw", async () => {
+      await expect(
+        HatsQuestModule.write.withdrawSubmission([questId], {
+          account: approver.account,
+        }),
+      ).to.be.rejectedWith(/NotSubmitter/);
+    });
+
+    it("creator can reject the current submission", async () => {
+      await HatsQuestModule.write.rejectSubmission([questId], {
+        account: creator.account,
+      });
+      const quest = await HatsQuestModule.read.getQuest([questId]);
+      expect(quest.status).to.equal(0); // Open
+      expect(quest.submitter.toLowerCase()).to.equal(
+        "0x0000000000000000000000000000000000000000",
+      );
+    });
+
+    it("non-creator cannot reject", async () => {
+      await expect(
+        HatsQuestModule.write.rejectSubmission([questId], {
+          account: approver.account,
+        }),
+      ).to.be.rejectedWith(/NotCreator/);
+    });
+
+    it("clears prior approvals so the next submitter starts fresh", async () => {
+      // approver gives a hat-holder approval (1/2)
+      await HatsQuestModule.write.approve([questId, workHatId], {
+        account: approver.account,
+      });
+      expect(await HatsQuestModule.read.getApprovalCount([questId])).to.equal(
+        1,
+      );
+      expect(
+        await HatsQuestModule.read.hasApprovedBy([questId, approverAddr]),
+      ).to.equal(true);
+
+      // creator rejects → state reset
+      await HatsQuestModule.write.rejectSubmission([questId], {
+        account: creator.account,
+      });
+      expect(await HatsQuestModule.read.getApprovalCount([questId])).to.equal(
+        0,
+      );
+      expect(
+        await HatsQuestModule.read.hasApprovedBy([questId, approverAddr]),
+      ).to.equal(false);
+
+      // a different person (admin / outsider would fail domain) submits anew
+      await HatsQuestModule.write.submitCompletion([questId, workHatId], {
+        account: approver.account,
+      });
+      const quest = await HatsQuestModule.read.getQuest([questId]);
+      expect(quest.submitter.toLowerCase()).to.equal(
+        approverAddr.toLowerCase(),
+      );
+      expect(quest.status).to.equal(1); // PendingReview again
+    });
+
+    it("reverts when called outside PendingReview", async () => {
+      // withdraw, returning the quest to Open, then call withdraw again
+      await HatsQuestModule.write.withdrawSubmission([questId], {
+        account: submitter.account,
+      });
+      await expect(
+        HatsQuestModule.write.withdrawSubmission([questId], {
+          account: submitter.account,
+        }),
+      ).to.be.rejectedWith(/InvalidStatus/);
+      await expect(
+        HatsQuestModule.write.rejectSubmission([questId], {
+          account: creator.account,
+        }),
+      ).to.be.rejectedWith(/InvalidStatus/);
+    });
+
+    it("escrow remains intact through reset (creator gets it back only on cancel)", async () => {
+      const escrowedBefore = await HatsQuestModule.read.getEscrowedBalance([
+        creatorAddr,
+        workHatId,
+        creatorAddr,
+      ]);
+      await HatsQuestModule.write.rejectSubmission([questId], {
+        account: creator.account,
+      });
+      const escrowedAfter = await HatsQuestModule.read.getEscrowedBalance([
+        creatorAddr,
+        workHatId,
+        creatorAddr,
+      ]);
+      expect(escrowedAfter).to.equal(escrowedBefore);
     });
   });
 
@@ -606,7 +748,7 @@ describe("HatsQuestModule", () => {
           workHatId,
           creatorAddr,
           150n,
-          "0x" + "55".repeat(32) as `0x${string}`,
+          ("0x" + "55".repeat(32)) as `0x${string}`,
         ],
         { account: creator.account },
       );
@@ -615,7 +757,7 @@ describe("HatsQuestModule", () => {
           workHatId,
           creatorAddr,
           250n,
-          "0x" + "66".repeat(32) as `0x${string}`,
+          ("0x" + "66".repeat(32)) as `0x${string}`,
         ],
         { account: creator.account },
       );

--- a/pkgs/contract/test/IntegrationTest.ts
+++ b/pkgs/contract/test/IntegrationTest.ts
@@ -23,11 +23,13 @@ import {
   type HatsTimeFrameModule,
   type HatsHatCreatorModule,
   type HatsFractionTokenModule,
+  type HatsQuestModule,
   deployHatsHatCreatorModule,
   deployHatsModuleFactory,
   deployHatsProtocol,
   deployHatsTimeFrameModule,
   deployHatsFractionTokenModule,
+  deployHatsQuestModule,
 } from "../helpers/deploy/Hats";
 import {
   type PullSplitsFactory,
@@ -52,6 +54,7 @@ describe("IntegrationTest", () => {
   let HatsTimeFrameModule_IMPL: HatsTimeFrameModule;
   let HatsHatCreatorModule_IMPL: HatsHatCreatorModule;
   let HatsFractionTokenModule_IMPL: HatsFractionTokenModule;
+  let HatsQuestModule_IMPL: HatsQuestModule;
   let SplitsWarehouse: SplitsWarehouse;
   let PullSplitsFactory: PullSplitsFactory;
   let PushSplitsFactory: PushSplitsFactory;
@@ -109,6 +112,10 @@ describe("IntegrationTest", () => {
       await deployHatsFractionTokenModule("0.0.0", Create2Deployer.address);
     HatsFractionTokenModule_IMPL = _HatsFractionTokenModule_IMPL;
 
+    const { HatsQuestModule: _HatsQuestModule_IMPL } =
+      await deployHatsQuestModule("0.0.0", Create2Deployer.address);
+    HatsQuestModule_IMPL = _HatsQuestModule_IMPL;
+
     const {
       SplitsWarehouse: _SplitsWarehouse,
       PullSplitsFactory: _PullSplitsFactory,
@@ -159,6 +166,7 @@ describe("IntegrationTest", () => {
         hatsTimeFrameModule_impl: HatsTimeFrameModule_IMPL.address,
         hatsHatCreatorModule_impl: HatsHatCreatorModule_IMPL.address,
         hatsFractionTokenModule_impl: HatsFractionTokenModule_IMPL.address,
+        hatsQuestModule_impl: HatsQuestModule_IMPL.address,
         splitsCreatorFactoryAddress: SplitsCreatorFactory.address,
         splitsFactoryV2Address: PullSplitsFactory.address,
         thanksTokenFactoryAddress: ThanksTokenFactory.address,
@@ -213,6 +221,21 @@ describe("IntegrationTest", () => {
             decodedLog.args.hatsHatCreatorModule;
           const hatsFractionTokenModuleAddress =
             decodedLog.args.hatsFractionTokenModule;
+          const hatsQuestModuleAddress = decodedLog.args.hatsQuestModule;
+          expect(hatsQuestModuleAddress).to.match(/^0x[0-9a-fA-F]{40}$/);
+          expect(hatsQuestModuleAddress.toLowerCase()).to.not.equal(
+            "0x0000000000000000000000000000000000000000",
+          );
+
+          // Verify the deployed quest module is bound to the same fraction token
+          const hatsQuestModuleByBigBang = await viem.getContractAt(
+            "HatsQuestModule",
+            hatsQuestModuleAddress,
+          );
+          expect(
+            (await hatsQuestModuleByBigBang.read.FRACTION_TOKEN()).toLowerCase(),
+          ).to.equal(hatsFractionTokenModuleAddress.toLowerCase());
+
           const splitsCreatorAddress = decodedLog.args.splitCreator;
           const thanksTokenAddress = decodedLog.args.thanksToken;
 

--- a/pkgs/contract/test/SplitsCreator.ts
+++ b/pkgs/contract/test/SplitsCreator.ts
@@ -305,6 +305,7 @@ describe("SplitsCreator Factory", () => {
         HatsTimeFrameModule.address,
         HatsFractionTokenModule.address,
         ThanksToken.address,
+        zeroAddress,
         keccak256("0x1234"),
       ]),
     ).to.be.a("string");
@@ -325,6 +326,7 @@ describe("SplitsCreator Factory", () => {
         HatsTimeFrameModule.address,
         HatsFractionTokenModule.address,
         ThanksToken.address,
+        zeroAddress,
         keccak256("0x1234"),
       ]);
 
@@ -336,6 +338,7 @@ describe("SplitsCreator Factory", () => {
         HatsTimeFrameModule.address,
         HatsFractionTokenModule.address,
         ThanksToken.address,
+        zeroAddress,
         keccak256("0x1234"),
       ],
       { account: bigBangAddress.account },
@@ -648,6 +651,7 @@ describe("CreateSplit without thanks token weight", () => {
         HatsTimeFrameModule.address,
         hatsFractionTokenModuleAddress,
         ThanksToken.address,
+        zeroAddress,
         keccak256("0x1234"),
       ],
       { account: bigBangAddress.account },
@@ -1521,6 +1525,7 @@ describe("CreateSplit with thanks token weight", () => {
         HatsTimeFrameModule.address,
         hatsFractionTokenModuleAddress,
         ThanksToken.address,
+        zeroAddress,
         keccak256("0x1234"),
       ],
       { account: bigBangAddress.account },
@@ -1814,6 +1819,7 @@ describe("CreateSplit with thanks token weight", () => {
             HatsTimeFrameModule.address,
             HatsFractionTokenModule.address,
             ThanksToken.address, // Now using actual ThanksToken address
+            zeroAddress,
             keccak256(
               encodeAbiParameters(
                 [{ type: "string" }],


### PR DESCRIPTION
Closes #417

## Summary
- Adds **HatsQuestModule** — a HatsModule clone deployed per workspace that escrows RoleShare (HatsFractionTokenModule ERC1155) on quest creation and releases it to the submitter once approved.
- Approval succeeds via either the **creator's single approval** or **two distinct hat-holder approvals**; cancel returns the escrow to the creator.
- Wires the module through **BigBang** (auto-deploy), **SplitsCreator** (escrow-aware aggregation), and the **SplitsCreatorFactory** (immutable arg).
- Relaxes the **FractionToken** transfer guard to fire only for the original wearer so intermediate holders (e.g. the quest module) can drain their full balance.

## Highlights

### New
- `contracts/hatsmodules/quest/HatsQuestModule.sol` — implementation (`HatsModule + ERC1155Holder`)
- `contracts/hatsmodules/quest/IHatsQuestModule.sol` — public interface (Quest struct, errors, events)
- `test/HatsQuestModule.ts` — 18 unit tests covering create / submit / approve (creator-single + 2-holder) / cancel / escrow accounting / domain checks
- `test/HatsQuestModule.SplitsIntegration.ts` — 4 integration tests verifying SplitsCreator preview before / during escrow / after completion / after cancel

### Changed
- `contracts/hatsmodules/fractiontoken/HatsFractionTokenModule.sol` — `safeTransferFrom` / `safeBatchTransferFrom` only revert on a full-balance transfer when `_from` is the original wearer (`tokenRecipients[id][0]`)
- `contracts/splitscreator/SplitsCreator.sol` — adds `HATS_QUEST_MODULE()` immutable arg (offset 172); `_calculateRoleAllocations` skips the quest module in the recipients list and adds `getEscrowedBalance` to the wearer's and other recipients' balances
- `contracts/splitscreator/SplitsCreatorFactory.sol` + `ISplitsCreatorFactory.sol` — `_hatsQuestModule` parameter threaded through `createSplitCreatorDeterministic` / `predictDeterministicAddress` / clone args / salt / `SplitCreatorCreated` event
- `contracts/bigbang/BigBang.sol` — new `HatsQuestModule_IMPL` storage + setter, `bigbang()` deploys the quest module between FractionToken and SplitsCreator and passes its address to SplitsCreator, `Executed` event extended
- `contracts/bigbang/mock/BigBang_Mock_v2.sol` — kept in sync for the upgrade-compatibility mock
- `helpers/deploy/Hats.ts` — `deployHatsQuestModule` helper + `HatsQuestModule` type
- `helpers/deploy/BigBang.ts` — accepts `hatsQuestModule_impl`
- `scripts/deploy/create2.ts` — deploys the new impl and emits the verify command
- Existing tests follow the new factory signature (`zeroAddress` is passed where the test doesn't exercise the quest path)

## Pre-existing test failures
The 2 pre-existing failing tests (`SplitsCreator preview` and `ThanksToken mintable amount`) are unrelated to this change and tracked in **#462**. After this PR: 87 passing / 2 failing — same 2 failures as the baseline on `v3`.

## Acceptance checklist (from #417)
- [x] HatsQuestModule implementation + interface
- [x] FractionToken transfer constraint scoped to wearer
- [x] SplitsCreator integration (quest module exclusion + escrow credit)
- [x] BigBang auto-deploys HatsQuestModule and wires it into SplitsCreator
- [x] Unit tests for create / submit / approve / cancel / escrow accounting
- [x] FractionToken regression tests (wearer can't drain; non-wearer can)
- [x] SplitsCreator integration tests (escrow / Completed / Cancelled scenarios)
- [x] BigBang integration test covers the new module
- [ ] Gas benchmark snapshot (deferred; can ship as a follow-up)

## Test plan
- [x] `pnpm --filter contract compile`
- [x] `pnpm --filter contract test` — 87 passing, 2 unrelated pre-existing failures
- [x] `npx hardhat test test/HatsQuestModule.ts` (18 passing)
- [x] `npx hardhat test test/HatsQuestModule.SplitsIntegration.ts` (4 passing)

## Follow-ups (separate issues)
- Subgraph schema + handler updates so the frontend can query quest data (will file a separate issue).
- The 2 pre-existing test failures (#462).

🤖 Generated with [Claude Code](https://claude.com/claude-code)