### PR TITLE
test(contract): fix two main-branch test failures (#462)

### DIFF
--- a/pkgs/contract/test/SplitsCreator.ts
+++ b/pkgs/contract/test/SplitsCreator.ts
@@ -2273,15 +2273,20 @@ describe("CreateSplit with thanks token weight", () => {
     const allocations = previewResult[1];
     const totalAllocation = previewResult[2];
 
-    const endWoreTime = await publicClient
-      .getBlock({
-        blockTag: "latest",
-      })
-      .then((block) => block.timestamp);
-
-    const address1Time = BigInt(endWoreTime - address1WoreTime);
-    const address2Time = BigInt(endWoreTime - address2WoreTime);
-    const address3Time = BigInt(endWoreTime - address3WoreTime);
+    // Read elapsed times from the same source the contract uses so the
+    // expected sqrt(time) matches block.timestamp at the preview eth_call.
+    const address1Time = await HatsTimeFrameModule.read.getWearingElapsedTime([
+      address1.account?.address!,
+      hat1_id,
+    ]);
+    const address2Time = await HatsTimeFrameModule.read.getWearingElapsedTime([
+      address2.account?.address!,
+      hat1_id,
+    ]);
+    const address3Time = await HatsTimeFrameModule.read.getWearingElapsedTime([
+      address3.account?.address!,
+      hat2_id,
+    ]);
 
     const sqrtAddress1Time = sqrt(address1Time);
     const sqrtAddress2Time = sqrt(address2Time);

--- a/pkgs/contract/test/ThanksToken.ts
+++ b/pkgs/contract/test/ThanksToken.ts
@@ -662,10 +662,45 @@ describe("ThanksToken", () => {
         relatedRoles,
       ]);
 
-      // Check that the expected mintable amount matches the actual amount
-      // ((10h * 1000 / 10000) + (20 / 10) GiveBack) * 30 Coefficient
-      // 3 * 30
-      expect(mintableAmount).to.equal(450000000000000000180000000000000000000n);
+      // Reproduce ThanksToken.mintableAmount:
+      //   roleBased     = (wearingTime/10min * shareBalance) / shareTotalSupply
+      //   totalMintable = ((roleBased * coefficient) / 1e18) * 1e18
+      //                 + balanceOf(owner) / 10
+      //   result        = totalMintable > minted ? totalMintable - minted : 0
+      const wearingTimeSeconds =
+        await HatsTimeFrameModule.read.getWearingElapsedTime([
+          address1Validated,
+          hatId,
+        ]);
+      const wearingTime10Minutes = wearingTimeSeconds / 600n;
+      const shareBalance = await HatsFractionTokenModule.read.balanceOf([
+        address2Validated,
+        address1Validated,
+        hatId,
+      ]);
+      const shareTotalSupply = await HatsFractionTokenModule.read.totalSupply([
+        address1Validated,
+        hatId,
+      ]);
+      const roleBasedAmount =
+        (wearingTime10Minutes * shareBalance) / shareTotalSupply;
+      const coefficient = await DeployedThanksToken.read.addressCoefficient([
+        address2Validated,
+      ]);
+      const ONE_ETHER = 10n ** 18n;
+      const ownerBalance = await DeployedThanksToken.read.balanceOf([
+        address2Validated,
+      ]);
+      const ownerMinted = await DeployedThanksToken.read.mintedAmount([
+        address2Validated,
+      ]);
+      const totalMintable =
+        ((roleBasedAmount * coefficient) / ONE_ETHER) * ONE_ETHER +
+        ownerBalance / 10n;
+      const expectedMintable =
+        totalMintable > ownerMinted ? totalMintable - ownerMinted : 0n;
+
+      expect(mintableAmount).to.equal(expectedMintable);
     });
 
     it("should prevent minting to yourself", async () => {


### PR DESCRIPTION
Closes #462.

## Summary
- **SplitsCreator `should preview allocations correctly` (with thanks token weight)** — test computed elapsed time as `getBlock("latest").timestamp - addressWoreTime`, which didn't match the `block.timestamp` seen by the `preview` eth_call after prior tests advanced time. Now reads `getWearingElapsedTime` directly from `HatsTimeFrameModule`, so the test sees exactly what the contract sees.
- **ThanksToken `should calculate mintable amount for user with RoleShare but without hat`** — expected was a hardcoded 39-digit literal with a spurious `1e18` factor and hours instead of the contract's 10-minute units. Now computes the expected value dynamically by mirroring `ThanksToken.mintableAmount` against contract state.

No contract code changed; only test-side expectations.

## Test plan
- [x] `pnpm --filter contract test` passes locally (65 passing, was 63 passing + 2 failing on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)