### PR TITLE
ci: fix Test Contracts workflow (#470)

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8.15.4
+          version: 9
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build Frontend
         run: pnpm frontend build

--- a/.github/workflows/deploy-document.yml
+++ b/.github/workflows/deploy-document.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8.15.4
+          version: 9
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build Document
         run: pnpm document build

--- a/.github/workflows/test-contract.yml
+++ b/.github/workflows/test-contract.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8.15.4
+          version: 9
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run Hardhat tests
         run: pnpm contract test

--- a/pkgs/contract/hardhat.config.ts
+++ b/pkgs/contract/hardhat.config.ts
@@ -30,6 +30,7 @@ const config: HardhatUserConfig = {
           optimizer: {
             runs: 200,
           },
+          evmVersion: "cancun",
         },
       },
     ],


### PR DESCRIPTION
Closes #470.

## Summary
- **CI pnpm version**: bumped from `8.15.4` → `9` across `test-contract.yml`, `build-frontend.yml`, `deploy-document.yml`. The repo lockfile is `lockfileVersion: '9.0'`, which pnpm 8 cannot read; `pnpm install` was silently re-resolving and pulling `@openzeppelin/contracts ^5.0.2` forward to a Cancun-`mcopy`-using release, breaking compile under Hardhat's default `paris` target. `--frozen-lockfile` is also added so future drift surfaces immediately.
- **Hardhat evmVersion**: set to `cancun` in `pkgs/contract/hardhat.config.ts`. Defense in depth — all deploy targets (Base, Sepolia, Holesky, Ethereum mainnet) have supported Cancun for over a year, and future OZ releases will keep adopting Cancun opcodes.

## Verification
- Locally with `pnpm 10.15.0` + `--frozen-lockfile`: `pnpm --filter contract exec hardhat compile` → `Compiled 117 Solidity files successfully (evm target: cancun)` against committed lockfile (OZ 5.3.0).
- Reproduced the CI failure mode by upgrading OZ to latest `5.6.1` (which contains 9 `mcopy` references in `Arrays.sol`); compile still passes with `evmVersion: cancun`.
- Note: the two contract test failures from #462 will still appear on this PR's `Test Contracts` run until #469 lands. The compile-error wall is the gate this PR removes.

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds on pnpm 10
- [x] `pnpm --filter contract exec hardhat compile` succeeds with both lockfile OZ (5.3.0) and latest OZ (5.6.1)
- [ ] On this PR's CI: `Test Contracts` job gets past compile (will report 2 failing tests due to #462 / fixed by #469)

🤖 Generated with [Claude Code](https://claude.com/claude-code)