### PR TITLE
feat(subgraph): index HatsQuestModule events for quest lifecycle (#468)

### DIFF
--- a/pkgs/subgraph/abis/BigBang.json
+++ b/pkgs/subgraph/abis/BigBang.json
@@ -151,6 +151,12 @@
       {
         "indexed": false,
         "internalType": "address",
+        "name": "hatsQuestModule",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
         "name": "splitCreator",
         "type": "address"
       },
@@ -254,6 +260,19 @@
     "outputs": [
       {
         "internalType": "contract IHatsModuleFactory",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "HatsQuestModule_IMPL",
+    "outputs": [
+      {
+        "internalType": "address",
         "name": "",
         "type": "address"
       }
@@ -409,6 +428,11 @@
       },
       {
         "internalType": "address",
+        "name": "_hatsQuestModule_IMPL",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
         "name": "_splitsCreatorFactory",
         "type": "address"
       },
@@ -509,6 +533,19 @@
       }
     ],
     "name": "setHatsModuleFactory",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_hatsQuestModuleImpl",
+        "type": "address"
+      }
+    ],
+    "name": "setHatsQuestModuleImpl",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/pkgs/subgraph/abis/HatsQuestModule.json
+++ b/pkgs/subgraph/abis/HatsQuestModule.json
@@ -1,0 +1,733 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_version",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyApproved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CannotApproveOwnSubmission",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CannotSubmitOwnQuest",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientShare",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidHatDomain",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidStatus",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotCreator",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotSubmitter",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotWorkspaceMember",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "QuestNotFound",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "submitter",
+        "type": "address"
+      }
+    ],
+    "name": "CompletionSubmitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "version",
+        "type": "uint64"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "approver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "newApprovalCount",
+        "type": "uint8"
+      }
+    ],
+    "name": "QuestApproved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "QuestCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "submitter",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "QuestCompleted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "hatId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "wearer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "metadataHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "QuestCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "submitter",
+        "type": "address"
+      }
+    ],
+    "name": "SubmissionRejected",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "submitter",
+        "type": "address"
+      }
+    ],
+    "name": "SubmissionWithdrawn",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "FRACTION_TOKEN",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "HATS",
+    "outputs": [
+      {
+        "internalType": "contract IHats",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "IMPLEMENTATION",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "membershipHatId",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      }
+    ],
+    "name": "cancel",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "hatId_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "wearer",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "metadataHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "createQuest",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getApprovalCount",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getDomain",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "hatId_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "wearer",
+        "type": "address"
+      }
+    ],
+    "name": "getEscrowedBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getQuest",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "hatId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "wearer",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "creator",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "submitter",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum IHatsQuestModule.QuestStatus",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint64",
+            "name": "createdAt",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "submittedAt",
+            "type": "uint64"
+          }
+        ],
+        "internalType": "struct IHatsQuestModule.Quest",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "approver",
+        "type": "address"
+      }
+    ],
+    "name": "hasApprovedBy",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hatId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nextQuestId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155BatchReceived",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      }
+    ],
+    "name": "rejectSubmission",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "_initData",
+        "type": "bytes"
+      }
+    ],
+    "name": "setUp",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "membershipHatId",
+        "type": "uint256"
+      }
+    ],
+    "name": "submitCompletion",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version_",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawSubmission",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/pkgs/subgraph/config/base.json
+++ b/pkgs/subgraph/config/base.json
@@ -9,7 +9,7 @@
       "entities": [{ "name": "Executed" }],
       "handlers": [
         {
-          "event": "Executed(indexed address,indexed address,indexed uint256,uint256,uint256,uint256,uint256,uint256,address,address,address,address,address)",
+          "event": "Executed(indexed address,indexed address,indexed uint256,uint256,uint256,uint256,uint256,uint256,address,address,address,address,address,address)",
           "handler": "handleExecuted"
         }
       ]
@@ -43,6 +43,46 @@
         {
           "event": "Transfer(indexed address,indexed address,uint256)",
           "handler": "handleTransfer"
+        }
+      ]
+    },
+    {
+      "file": "HatsQuestModule",
+      "mappingFile": "questMapping",
+      "entities": [
+        { "name": "Quest" },
+        { "name": "SubmissionAttempt" },
+        { "name": "QuestApproval" },
+        { "name": "EscrowedRoleShare" }
+      ],
+      "handlers": [
+        {
+          "event": "QuestCreated(indexed uint256,indexed address,indexed uint256,address,uint256,bytes32)",
+          "handler": "handleQuestCreated"
+        },
+        {
+          "event": "CompletionSubmitted(indexed uint256,indexed address)",
+          "handler": "handleCompletionSubmitted"
+        },
+        {
+          "event": "SubmissionWithdrawn(indexed uint256,indexed address)",
+          "handler": "handleSubmissionWithdrawn"
+        },
+        {
+          "event": "SubmissionRejected(indexed uint256,indexed address,indexed address)",
+          "handler": "handleSubmissionRejected"
+        },
+        {
+          "event": "QuestApproved(indexed uint256,indexed address,uint8)",
+          "handler": "handleQuestApproved"
+        },
+        {
+          "event": "QuestCompleted(indexed uint256,indexed address,uint256)",
+          "handler": "handleQuestCompleted"
+        },
+        {
+          "event": "QuestCancelled(indexed uint256,indexed address,uint256)",
+          "handler": "handleQuestCancelled"
         }
       ]
     }

--- a/pkgs/subgraph/config/sepolia.json
+++ b/pkgs/subgraph/config/sepolia.json
@@ -9,7 +9,7 @@
       "entities": [{ "name": "Executed" }],
       "handlers": [
         {
-          "event": "Executed(indexed address,indexed address,indexed uint256,uint256,uint256,uint256,uint256,uint256,address,address,address,address,address)",
+          "event": "Executed(indexed address,indexed address,indexed uint256,uint256,uint256,uint256,uint256,uint256,address,address,address,address,address,address)",
           "handler": "handleExecuted"
         }
       ]
@@ -43,6 +43,46 @@
         {
           "event": "Transfer(indexed address,indexed address,uint256)",
           "handler": "handleTransfer"
+        }
+      ]
+    },
+    {
+      "file": "HatsQuestModule",
+      "mappingFile": "questMapping",
+      "entities": [
+        { "name": "Quest" },
+        { "name": "SubmissionAttempt" },
+        { "name": "QuestApproval" },
+        { "name": "EscrowedRoleShare" }
+      ],
+      "handlers": [
+        {
+          "event": "QuestCreated(indexed uint256,indexed address,indexed uint256,address,uint256,bytes32)",
+          "handler": "handleQuestCreated"
+        },
+        {
+          "event": "CompletionSubmitted(indexed uint256,indexed address)",
+          "handler": "handleCompletionSubmitted"
+        },
+        {
+          "event": "SubmissionWithdrawn(indexed uint256,indexed address)",
+          "handler": "handleSubmissionWithdrawn"
+        },
+        {
+          "event": "SubmissionRejected(indexed uint256,indexed address,indexed address)",
+          "handler": "handleSubmissionRejected"
+        },
+        {
+          "event": "QuestApproved(indexed uint256,indexed address,uint8)",
+          "handler": "handleQuestApproved"
+        },
+        {
+          "event": "QuestCompleted(indexed uint256,indexed address,uint256)",
+          "handler": "handleQuestCompleted"
+        },
+        {
+          "event": "QuestCancelled(indexed uint256,indexed address,uint256)",
+          "handler": "handleQuestCancelled"
         }
       ]
     }

--- a/pkgs/subgraph/schema.graphql
+++ b/pkgs/subgraph/schema.graphql
@@ -11,10 +11,13 @@ type Workspace @entity {
   hatsTimeFrameModule: String!
   hatsHatCreatorModule: String!
   hatsFractionTokenModule: HatsFractionTokenModule!
+  hatsQuestModule: String!
   thanksToken: ThanksToken!
   splitCreator: String!
   blockTimestamp: BigInt!
   blockNumber: BigInt!
+  quests: [Quest!]! @derivedFrom(field: "workspace")
+  escrowedRoleShares: [EscrowedRoleShare!]! @derivedFrom(field: "workspace")
 }
 
 type HatsFractionTokenModule @entity {
@@ -110,5 +113,83 @@ type BalanceOfThanksToken @entity {
   owner: String!
   balance: BigInt!
   workspaceId: ID!
+  updatedAt: BigInt!
+}
+
+type HatsQuestModule @entity {
+  id: ID!
+  workspaceId: ID!
+  quests: [Quest!]! @derivedFrom(field: "questModuleEntity")
+}
+
+enum QuestStatus {
+  Open
+  PendingReview
+  Completed
+  Cancelled
+}
+
+enum SubmissionOutcome {
+  Pending
+  Withdrawn
+  Rejected
+  Approved
+}
+
+type Quest @entity {
+  id: ID!
+  workspace: Workspace!
+  questModuleEntity: HatsQuestModule!
+  questModule: String!
+  questId: BigInt!
+  hatId: BigInt!
+  wearer: String!
+  creator: String!
+  submitter: String
+  amount: BigInt!
+  status: QuestStatus!
+  metadataHash: Bytes!
+  approvalCount: Int!
+  attemptCount: Int!
+  attempts: [SubmissionAttempt!]! @derivedFrom(field: "quest")
+  createdAt: BigInt!
+  submittedAt: BigInt
+  completedAt: BigInt
+  cancelledAt: BigInt
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  txHash: Bytes!
+}
+
+type SubmissionAttempt @entity {
+  id: ID!
+  quest: Quest!
+  attemptIndex: Int!
+  submitter: String!
+  submittedAt: BigInt!
+  outcome: SubmissionOutcome!
+  withdrawnAt: BigInt
+  rejectedAt: BigInt
+  approvedAt: BigInt
+  approvals: [QuestApproval!]! @derivedFrom(field: "attempt")
+}
+
+type QuestApproval @entity {
+  id: ID!
+  quest: Quest!
+  attempt: SubmissionAttempt!
+  approver: String!
+  approvedAt: BigInt!
+  blockNumber: BigInt!
+  txHash: Bytes!
+}
+
+type EscrowedRoleShare @entity {
+  id: ID!
+  workspace: Workspace!
+  creator: String!
+  hatId: BigInt!
+  wearer: String!
+  amount: BigInt!
   updatedAt: BigInt!
 }

--- a/pkgs/subgraph/src/bigbangMapping.ts
+++ b/pkgs/subgraph/src/bigbangMapping.ts
@@ -1,12 +1,13 @@
-import { BigInt } from "@graphprotocol/graph-ts";
 import { Executed } from "../generated/BigBang/BigBang";
 import {
   HatsFractionTokenModule,
+  HatsQuestModule,
   ThanksToken,
   Workspace,
 } from "../generated/schema";
 import {
   HatsFractionTokenModule as HatsFractionTokenModuleTemplate,
+  HatsQuestModule as HatsQuestModuleTemplate,
   ThanksToken as ThanksTokenTemplate,
 } from "../generated/templates";
 import { hatIdToTreeId } from "./helper/hat";
@@ -27,6 +28,7 @@ export function handleExecuted(ev: Executed): void {
   workspace.hatsTimeFrameModule = ev.params.hatsTimeFrameModule.toHex();
   workspace.hatsHatCreatorModule = ev.params.hatsHatCreatorModule.toHex();
   workspace.hatsFractionTokenModule = ev.params.hatsFractionTokenModule.toHex();
+  workspace.hatsQuestModule = ev.params.hatsQuestModule.toHex();
   workspace.thanksToken = ev.params.thanksToken.toHex();
   workspace.splitCreator = ev.params.splitCreator.toHex();
   workspace.thanksToken = ev.params.thanksToken.toHex();
@@ -48,4 +50,12 @@ export function handleExecuted(ev: Executed): void {
   newThanksToken.save();
 
   ThanksTokenTemplate.create(ev.params.thanksToken);
+
+  const newHatsQuestModule = new HatsQuestModule(
+    ev.params.hatsQuestModule.toHex(),
+  );
+  newHatsQuestModule.workspaceId = treeId;
+  newHatsQuestModule.save();
+
+  HatsQuestModuleTemplate.create(ev.params.hatsQuestModule);
 }

--- a/pkgs/subgraph/src/questMapping.ts
+++ b/pkgs/subgraph/src/questMapping.ts
@@ -1,0 +1,289 @@
+import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
+import {
+  EscrowedRoleShare,
+  HatsQuestModule,
+  Quest,
+  QuestApproval,
+  SubmissionAttempt,
+} from "../generated/schema";
+import {
+  CompletionSubmitted,
+  QuestApproved,
+  QuestCancelled,
+  QuestCompleted,
+  QuestCreated,
+  SubmissionRejected,
+  SubmissionWithdrawn,
+} from "../generated/templates/HatsQuestModule/HatsQuestModule";
+
+const STATUS_OPEN = "Open";
+const STATUS_PENDING_REVIEW = "PendingReview";
+const STATUS_COMPLETED = "Completed";
+const STATUS_CANCELLED = "Cancelled";
+
+const OUTCOME_PENDING = "Pending";
+const OUTCOME_WITHDRAWN = "Withdrawn";
+const OUTCOME_REJECTED = "Rejected";
+const OUTCOME_APPROVED = "Approved";
+
+function questEntityId(module: Address, questId: BigInt): string {
+  return `${module.toHex()}-${questId.toString()}`;
+}
+
+function attemptEntityId(
+  module: Address,
+  questId: BigInt,
+  attemptIndex: i32,
+): string {
+  return `${module.toHex()}-${questId.toString()}-${attemptIndex.toString()}`;
+}
+
+function approvalEntityId(
+  module: Address,
+  questId: BigInt,
+  attemptIndex: i32,
+  approver: Address,
+): string {
+  return `${module.toHex()}-${questId.toString()}-${attemptIndex.toString()}-${approver.toHex()}`;
+}
+
+function escrowEntityId(
+  creator: Address,
+  hatId: BigInt,
+  wearer: Address,
+): string {
+  return `${creator.toHex()}-${hatId.toHexString()}-${wearer.toHex()}`;
+}
+
+function adjustEscrow(
+  workspaceId: string,
+  creator: Address,
+  hatId: BigInt,
+  wearer: Address,
+  delta: BigInt,
+  timestamp: BigInt,
+): void {
+  const id = escrowEntityId(creator, hatId, wearer);
+  let escrow = EscrowedRoleShare.load(id);
+  if (escrow === null) {
+    escrow = new EscrowedRoleShare(id);
+    escrow.workspace = workspaceId;
+    escrow.creator = creator.toHex();
+    escrow.hatId = hatId;
+    escrow.wearer = wearer.toHex();
+    escrow.amount = BigInt.zero();
+  }
+  escrow.amount = escrow.amount.plus(delta);
+  escrow.updatedAt = timestamp;
+  escrow.save();
+}
+
+export function handleQuestCreated(ev: QuestCreated): void {
+  const module = HatsQuestModule.load(ev.address.toHex());
+  if (module === null) return;
+
+  const id = questEntityId(ev.address, ev.params.questId);
+  let quest = Quest.load(id);
+  if (quest !== null) return;
+
+  quest = new Quest(id);
+  quest.workspace = module.workspaceId;
+  quest.questModuleEntity = module.id;
+  quest.questModule = ev.address.toHex();
+  quest.questId = ev.params.questId;
+  quest.hatId = ev.params.hatId;
+  quest.wearer = ev.params.wearer.toHex();
+  quest.creator = ev.params.creator.toHex();
+  quest.submitter = null;
+  quest.amount = ev.params.amount;
+  quest.status = STATUS_OPEN;
+  quest.metadataHash = ev.params.metadataHash;
+  quest.approvalCount = 0;
+  quest.attemptCount = 0;
+  quest.createdAt = ev.block.timestamp;
+  quest.submittedAt = null;
+  quest.completedAt = null;
+  quest.cancelledAt = null;
+  quest.blockNumber = ev.block.number;
+  quest.blockTimestamp = ev.block.timestamp;
+  quest.txHash = ev.transaction.hash;
+  quest.save();
+
+  adjustEscrow(
+    module.workspaceId,
+    ev.params.creator,
+    ev.params.hatId,
+    ev.params.wearer,
+    ev.params.amount,
+    ev.block.timestamp,
+  );
+}
+
+export function handleCompletionSubmitted(ev: CompletionSubmitted): void {
+  const id = questEntityId(ev.address, ev.params.questId);
+  const quest = Quest.load(id);
+  if (quest === null) return;
+
+  const attemptIndex = quest.attemptCount;
+  const attempt = new SubmissionAttempt(
+    attemptEntityId(ev.address, ev.params.questId, attemptIndex),
+  );
+  attempt.quest = quest.id;
+  attempt.attemptIndex = attemptIndex;
+  attempt.submitter = ev.params.submitter.toHex();
+  attempt.submittedAt = ev.block.timestamp;
+  attempt.outcome = OUTCOME_PENDING;
+  attempt.withdrawnAt = null;
+  attempt.rejectedAt = null;
+  attempt.approvedAt = null;
+  attempt.save();
+
+  quest.submitter = ev.params.submitter.toHex();
+  quest.submittedAt = ev.block.timestamp;
+  quest.status = STATUS_PENDING_REVIEW;
+  quest.approvalCount = 0;
+  quest.attemptCount = attemptIndex + 1;
+  quest.save();
+}
+
+function closeCurrentAttempt(
+  module: Address,
+  questId: BigInt,
+  attemptIndex: i32,
+  outcome: string,
+  timestamp: BigInt,
+): void {
+  const attempt = SubmissionAttempt.load(
+    attemptEntityId(module, questId, attemptIndex),
+  );
+  if (attempt === null) return;
+  attempt.outcome = outcome;
+  if (outcome == OUTCOME_WITHDRAWN) {
+    attempt.withdrawnAt = timestamp;
+  } else if (outcome == OUTCOME_REJECTED) {
+    attempt.rejectedAt = timestamp;
+  } else if (outcome == OUTCOME_APPROVED) {
+    attempt.approvedAt = timestamp;
+  }
+  attempt.save();
+}
+
+export function handleSubmissionWithdrawn(ev: SubmissionWithdrawn): void {
+  const id = questEntityId(ev.address, ev.params.questId);
+  const quest = Quest.load(id);
+  if (quest === null) return;
+
+  closeCurrentAttempt(
+    ev.address,
+    ev.params.questId,
+    quest.attemptCount - 1,
+    OUTCOME_WITHDRAWN,
+    ev.block.timestamp,
+  );
+
+  quest.submitter = null;
+  quest.submittedAt = null;
+  quest.status = STATUS_OPEN;
+  quest.approvalCount = 0;
+  quest.save();
+}
+
+export function handleSubmissionRejected(ev: SubmissionRejected): void {
+  const id = questEntityId(ev.address, ev.params.questId);
+  const quest = Quest.load(id);
+  if (quest === null) return;
+
+  closeCurrentAttempt(
+    ev.address,
+    ev.params.questId,
+    quest.attemptCount - 1,
+    OUTCOME_REJECTED,
+    ev.block.timestamp,
+  );
+
+  quest.submitter = null;
+  quest.submittedAt = null;
+  quest.status = STATUS_OPEN;
+  quest.approvalCount = 0;
+  quest.save();
+}
+
+export function handleQuestApproved(ev: QuestApproved): void {
+  const id = questEntityId(ev.address, ev.params.questId);
+  const quest = Quest.load(id);
+  if (quest === null) return;
+
+  const attemptIndex = quest.attemptCount - 1;
+  const attemptId = attemptEntityId(
+    ev.address,
+    ev.params.questId,
+    attemptIndex,
+  );
+  const attempt = SubmissionAttempt.load(attemptId);
+  if (attempt === null) return;
+
+  const approval = new QuestApproval(
+    approvalEntityId(
+      ev.address,
+      ev.params.questId,
+      attemptIndex,
+      ev.params.approver,
+    ),
+  );
+  approval.quest = quest.id;
+  approval.attempt = attempt.id;
+  approval.approver = ev.params.approver.toHex();
+  approval.approvedAt = ev.block.timestamp;
+  approval.blockNumber = ev.block.number;
+  approval.txHash = ev.transaction.hash;
+  approval.save();
+
+  quest.approvalCount = ev.params.newApprovalCount;
+  quest.save();
+}
+
+export function handleQuestCompleted(ev: QuestCompleted): void {
+  const id = questEntityId(ev.address, ev.params.questId);
+  const quest = Quest.load(id);
+  if (quest === null) return;
+
+  closeCurrentAttempt(
+    ev.address,
+    ev.params.questId,
+    quest.attemptCount - 1,
+    OUTCOME_APPROVED,
+    ev.block.timestamp,
+  );
+
+  quest.status = STATUS_COMPLETED;
+  quest.completedAt = ev.block.timestamp;
+  quest.save();
+
+  adjustEscrow(
+    quest.workspace,
+    Address.fromString(quest.creator),
+    quest.hatId,
+    Address.fromString(quest.wearer),
+    ev.params.amount.neg(),
+    ev.block.timestamp,
+  );
+}
+
+export function handleQuestCancelled(ev: QuestCancelled): void {
+  const id = questEntityId(ev.address, ev.params.questId);
+  const quest = Quest.load(id);
+  if (quest === null) return;
+
+  quest.status = STATUS_CANCELLED;
+  quest.cancelledAt = ev.block.timestamp;
+  quest.save();
+
+  adjustEscrow(
+    quest.workspace,
+    Address.fromString(quest.creator),
+    quest.hatId,
+    Address.fromString(quest.wearer),
+    ev.params.amount.neg(),
+    ev.block.timestamp,
+  );
+}


### PR DESCRIPTION
Closes #468

## Summary
- Adds **HatsQuestModule** as a subgraph template so every per-workspace quest module is auto-indexed when `BigBang` deploys it.
- Wires the full quest lifecycle (`QuestCreated` / `CompletionSubmitted` / `SubmissionWithdrawn` / `SubmissionRejected` / `QuestApproved` / `QuestCompleted` / `QuestCancelled`) into a new `questMapping.ts`, with per-attempt history and creator-side escrow accounting.
- Updates `BigBang.Executed` to the 14-arg signature shipped in #467 (adds `hatsQuestModule`).

## What changed
### ABIs (`pkgs/subgraph/abis/`)
- `HatsQuestModule.json` — new
- `BigBang.json` — refreshed from #467 artifact (now includes `hatsQuestModule`)

### Configs (`pkgs/subgraph/config/{base,sepolia}.json`)
- New `Executed` signature (14 args) on the BigBang data source
- New `HatsQuestModule` template entry binding the 7 lifecycle events to the new mapping

### Schema (`pkgs/subgraph/schema.graphql`)
- Enums: `QuestStatus { Open, PendingReview, Completed, Cancelled }`, `SubmissionOutcome { Pending, Withdrawn, Rejected, Approved }`
- New entities: `Quest`, `SubmissionAttempt`, `QuestApproval`, `EscrowedRoleShare`, `HatsQuestModule`
- `Workspace` extended with `hatsQuestModule`, `quests` (derived), and `escrowedRoleShares` (derived)
- Per the issue's "approvals on the rejected attempt should still be browseable" note, `QuestApproval` is parented to `SubmissionAttempt`, not directly to `Quest`. `Quest.approvalCount` always reflects the **current** attempt and is reset to 0 on withdraw/reject.

### Mappings
- `bigbangMapping.ts` — reads `hatsQuestModule` from `Executed`, writes `Workspace.hatsQuestModule`, persists a `HatsQuestModule` lookup entity, and instantiates the template
- `questMapping.ts` (new) — handlers for all 7 events. Notable behavior:
  - `Quest.attemptCount` increments on every `CompletionSubmitted`; the "current" attempt is `attemptCount - 1`
  - `withdraw` / `reject` close the current attempt (`Withdrawn` / `Rejected`) and reset the quest to `Open` with `submitter=null`, `submittedAt=null`, `approvalCount=0` — past approvals on the closed attempt remain queryable via `SubmissionAttempt.approvals`
  - `QuestApproved` writes a `QuestApproval` linked to both the quest and the current attempt, and stores `event.params.newApprovalCount` directly on the quest
  - `QuestCompleted` closes the attempt as `Approved`, marks the quest `Completed`, and decrements `EscrowedRoleShare`
  - `QuestCancelled` decrements the same escrow counter
  - `QuestCreated` increments `EscrowedRoleShare(creator, hatId, wearer)` so SplitsCreator-style "in-flight escrow per role" can be queried directly

## Acceptance checklist (from #468)
- [x] subgraph builds locally — `pnpm prepare:sepolia && pnpm codegen && pnpm build` ✓ and `pnpm prepare:base && pnpm codegen && pnpm build` ✓
- [x] `withdrawSubmission` / `rejectSubmission` reset Quest to Open and `approvalCount` to 0
- [x] BigBang `Executed` signature change keeps existing template instantiation (HatsFractionTokenModule / ThanksToken) working — same handler still creates them
- [ ] Sepolia dev deploy with #467 testnet addresses — needs `pnpm --filter subgraph deploy:sepolia`
- [ ] Frontend `pnpm --filter frontend codegen` — depends on Sepolia/Base subgraph being redeployed first (codegen pulls schema from Goldsky)

## Follow-ups (deferred)
- Goldsky deploy of the new schema (sepolia/base)
- Frontend Quest queries in `pkgs/frontend/hooks/` — left for a follow-up since the generated GraphQL types only exist after deploy

## Test plan
- [x] `pnpm --filter subgraph codegen` (sepolia)
- [x] `pnpm --filter subgraph build` (sepolia)
- [x] `pnpm --filter subgraph codegen && pnpm --filter subgraph build` (base)
- [ ] `pnpm --filter subgraph deploy:sepolia` and run the 18 contract scenarios from PR #467 against the live subgraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)