### PR TITLE
feat(frontend): design tokens & atomic primitives (#426)

### DIFF
--- a/pkgs/frontend/app/components/common/CommonButton.tsx
+++ b/pkgs/frontend/app/components/common/CommonButton.tsx
@@ -11,8 +11,11 @@ import { cn } from "~/lib/utils";
 
 type ShadcnSize = NonNullable<VariantProps<typeof buttonVariants>["size"]>;
 
+// Map legacy chakra-style sizes onto the Toban button sizes defined in
+// `components/ui/button.tsx`. Once all callers migrate to the new design
+// system, this shim and its consumers can be retired together (#427/#428).
 const sizeMap: Record<string, ShadcnSize> = {
-  md: "default",
+  xs: "sm",
   xl: "lg",
 };
 
@@ -28,7 +31,7 @@ interface CommonButtonProps
   fontWeight?: string | number;
   borderRadius?: string | number;
   rounded?: string | number;
-  size?: ShadcnSize | "md" | "xl";
+  size?: ShadcnSize | "xs" | "xl";
   /** Render the button as a <label> via asChild — used for file-input wrappers. */
   as?: "button" | "label";
 }

--- a/pkgs/frontend/app/components/ui/avatar.stories.tsx
+++ b/pkgs/frontend/app/components/ui/avatar.stories.tsx
@@ -1,0 +1,72 @@
+import type { Story } from "@ladle/react";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarImage,
+} from "./avatar";
+
+export default {
+  title: "UI / Avatar",
+};
+
+const seeds = ["ひらやま", "homma", "前田陽太", "genks", "ryoma", "yuki"];
+
+export const Default: Story = () => (
+  <div className="flex items-center gap-4">
+    <Avatar size="sm">
+      <AvatarFallback seed="ひらやま" />
+    </Avatar>
+    <Avatar>
+      <AvatarFallback seed="ひらやま" />
+    </Avatar>
+    <Avatar size="lg">
+      <AvatarFallback seed="ひらやま" />
+    </Avatar>
+    <Avatar size="xl">
+      <AvatarFallback seed="ひらやま" />
+    </Avatar>
+  </div>
+);
+
+export const SeedColors: Story = () => (
+  <div className="flex flex-wrap gap-3">
+    {seeds.map((seed) => (
+      <div key={seed} className="flex flex-col items-center gap-1">
+        <Avatar size="lg">
+          <AvatarFallback seed={seed} />
+        </Avatar>
+        <span className="text-xs text-text-secondary">{seed}</span>
+      </div>
+    ))}
+  </div>
+);
+
+export const WithImage: Story = () => (
+  <div className="flex items-center gap-4">
+    <Avatar size="lg">
+      <AvatarImage
+        src="https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?w=200"
+        alt="member"
+      />
+      <AvatarFallback seed="member" />
+    </Avatar>
+    <Avatar size="lg">
+      {/* broken src exercises the fallback path */}
+      <AvatarImage src="/missing.png" alt="missing" />
+      <AvatarFallback seed="Tanaka" />
+    </Avatar>
+  </div>
+);
+
+export const Group: Story = () => (
+  <AvatarGroup data-size="default">
+    {seeds.slice(0, 3).map((seed) => (
+      <Avatar key={seed}>
+        <AvatarFallback seed={seed} />
+      </Avatar>
+    ))}
+    <AvatarGroupCount>+4</AvatarGroupCount>
+  </AvatarGroup>
+);

--- a/pkgs/frontend/app/components/ui/avatar.tsx
+++ b/pkgs/frontend/app/components/ui/avatar.tsx
@@ -3,19 +3,44 @@ import type * as React from "react";
 
 import { cn } from "~/lib/utils";
 
+// Toban deterministic palette — avatar fallback colour derived from a seed
+// string (typically the member's name), mirroring `primitives.jsx:108-126`.
+const SEED_PALETTE = [
+  "#F5B82E",
+  "#65C98A",
+  "#5DADEC",
+  "#D6B995",
+  "#E48F4F",
+  "#B696E0",
+  "#E48ABF",
+] as const;
+
+function seedColor(seed: string): string {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) {
+    h = (h * 31 + seed.charCodeAt(i)) >>> 0;
+  }
+  return SEED_PALETTE[h % SEED_PALETTE.length];
+}
+
+function seedInitials(seed: string): string {
+  const cleaned = seed.replace(/[^a-zA-Z぀-ヿ一-鿿]/g, "");
+  return cleaned.slice(0, 2).toUpperCase() || "?";
+}
+
 function Avatar({
   className,
   size = "default",
   ...props
 }: React.ComponentProps<typeof AvatarPrimitive.Root> & {
-  size?: "default" | "sm" | "lg";
+  size?: "default" | "sm" | "lg" | "xl";
 }) {
   return (
     <AvatarPrimitive.Root
       data-slot="avatar"
       data-size={size}
       className={cn(
-        "group/avatar relative flex size-8 shrink-0 overflow-hidden rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
+        "group/avatar relative flex size-9 shrink-0 select-none overflow-hidden rounded-full font-bold text-white data-[size=lg]:size-12 data-[size=sm]:size-7 data-[size=xl]:size-16",
         className,
       )}
       {...props}
@@ -30,25 +55,42 @@ function AvatarImage({
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
-      className={cn("aspect-square size-full", className)}
+      className={cn("aspect-square size-full object-cover", className)}
       {...props}
     />
   );
 }
 
+interface AvatarFallbackProps
+  extends React.ComponentProps<typeof AvatarPrimitive.Fallback> {
+  /** Optional seed string used to pick a deterministic background colour and
+   *  initials when no `children` are supplied. */
+  seed?: string;
+}
+
 function AvatarFallback({
   className,
+  seed,
+  children,
+  style,
   ...props
-}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+}: AvatarFallbackProps) {
+  const bg = seed ? seedColor(seed) : undefined;
+  const fallbackText =
+    children ?? (seed ? seedInitials(seed) : undefined) ?? "?";
   return (
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
       className={cn(
-        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        "flex size-full items-center justify-center rounded-full text-[15px] tracking-tight group-data-[size=lg]/avatar:text-xl group-data-[size=sm]/avatar:text-xs group-data-[size=xl]/avatar:text-2xl",
+        seed ? "text-white" : "bg-muted font-medium text-muted-foreground",
         className,
       )}
+      style={bg ? { backgroundColor: bg, ...style } : style}
       {...props}
-    />
+    >
+      {fallbackText}
+    </AvatarPrimitive.Fallback>
   );
 }
 
@@ -61,6 +103,7 @@ function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
         "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
         "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
         "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        "group-data-[size=xl]/avatar:size-4 group-data-[size=xl]/avatar:[&>svg]:size-3",
         className,
       )}
       {...props}
@@ -89,7 +132,7 @@ function AvatarGroupCount({
     <div
       data-slot="avatar-group-count"
       className={cn(
-        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        "relative flex size-9 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-12 group-has-data-[size=sm]/avatar-group:size-7 group-has-data-[size=xl]/avatar-group:size-16 [&>svg]:size-4",
         className,
       )}
       {...props}
@@ -104,4 +147,6 @@ export {
   AvatarBadge,
   AvatarGroup,
   AvatarGroupCount,
+  seedColor,
+  seedInitials,
 };

--- a/pkgs/frontend/app/components/ui/badge.stories.tsx
+++ b/pkgs/frontend/app/components/ui/badge.stories.tsx
@@ -1,0 +1,35 @@
+import type { Story } from "@ladle/react";
+import { Badge } from "./badge";
+import { Icon } from "./icon";
+
+export default {
+  title: "UI / Badge",
+};
+
+export const Kinds: Story = () => (
+  <div className="flex flex-wrap items-center gap-3">
+    <Badge kind="member">メンバー</Badge>
+    <Badge kind="lead">当番リード</Badge>
+    <Badge kind="supporter">サポーター</Badge>
+    <Badge kind="role">ロール</Badge>
+    <Badge kind="info">お知らせ</Badge>
+    <Badge kind="danger">期限切れ</Badge>
+  </div>
+);
+
+export const WithIcon: Story = () => (
+  <div className="flex flex-wrap items-center gap-3">
+    <Badge kind="member">
+      <Icon name="check" />
+      参加済み
+    </Badge>
+    <Badge kind="info">
+      <Icon name="bell" />
+      通知あり
+    </Badge>
+    <Badge kind="danger">
+      <Icon name="shield" />
+      要確認
+    </Badge>
+  </div>
+);

--- a/pkgs/frontend/app/components/ui/badge.tsx
+++ b/pkgs/frontend/app/components/ui/badge.tsx
@@ -4,31 +4,32 @@ import type * as React from "react";
 
 import { cn } from "~/lib/utils";
 
+// Toban status badges. The bg/fg pairs are not in the brand palette because
+// they're status-specific (e.g. green for member, blue for info). Using
+// arbitrary Tailwind values keeps them inline with the design source rather
+// than promoting six more tokens that no other component reads.
 const badgeVariants = cva(
-  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2.5 py-0.5 text-xs font-semibold whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:ring-ring/40 [&>svg]:pointer-events-none [&>svg]:size-3",
   {
     variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
-        secondary:
-          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
-        destructive:
-          "bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
-        outline:
-          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      kind: {
+        member: "bg-[#E5F5EC] text-[#2F8B58]",
+        lead: "bg-primary-soft text-[#A07310]",
+        supporter: "bg-[#E8E2D4] text-[#7A5A2E]",
+        role: "bg-[#F2EAD9] text-[#7A5A2E]",
+        danger: "bg-[#FBE5E2] text-[#B5382C]",
+        info: "bg-[#E2F0FB] text-[#2870A8]",
       },
     },
     defaultVariants: {
-      variant: "default",
+      kind: "member",
     },
   },
 );
 
 function Badge({
   className,
-  variant = "default",
+  kind,
   asChild = false,
   ...props
 }: React.ComponentProps<"span"> &
@@ -38,8 +39,8 @@ function Badge({
   return (
     <Comp
       data-slot="badge"
-      data-variant={variant}
-      className={cn(badgeVariants({ variant }), className)}
+      data-kind={kind ?? "member"}
+      className={cn(badgeVariants({ kind }), className)}
       {...props}
     />
   );

--- a/pkgs/frontend/app/components/ui/button.stories.tsx
+++ b/pkgs/frontend/app/components/ui/button.stories.tsx
@@ -1,30 +1,79 @@
 import type { Story } from "@ladle/react";
 import { Button } from "./button";
+import { Icon } from "./icon";
 
 export default {
   title: "UI / Button",
 };
 
-export const Default: Story = () => <Button>Click me</Button>;
+export const Default: Story = () => <Button>はじめる</Button>;
 
 export const Variants: Story = () => (
   <div className="flex flex-wrap items-center gap-3">
-    <Button>Default</Button>
+    <Button variant="primary">Primary</Button>
+    <Button variant="soft">Soft</Button>
     <Button variant="secondary">Secondary</Button>
-    <Button variant="outline">Outline</Button>
     <Button variant="ghost">Ghost</Button>
-    <Button variant="destructive">Destructive</Button>
-    <Button variant="link">Link</Button>
+    <Button variant="danger">Danger</Button>
+    <Button variant="dark">Dark</Button>
   </div>
 );
 
 export const Sizes: Story = () => (
-  <div className="flex items-center gap-3">
-    <Button size="xs">XS</Button>
-    <Button size="sm">SM</Button>
-    <Button size="default">Default</Button>
-    <Button size="lg">LG</Button>
+  <div className="flex flex-col items-start gap-3">
+    <div className="flex items-center gap-3">
+      <Button size="sm">Small</Button>
+      <Button size="md">Medium</Button>
+      <Button size="lg">Large</Button>
+    </div>
+    <div className="flex items-center gap-3">
+      <Button size="icon-sm" aria-label="Add">
+        <Icon name="plus" size={16} />
+      </Button>
+      <Button size="icon" aria-label="Add">
+        <Icon name="plus" />
+      </Button>
+      <Button size="icon-lg" aria-label="Add">
+        <Icon name="plus" size={26} />
+      </Button>
+    </div>
   </div>
 );
 
-export const Disabled: Story = () => <Button disabled>Disabled</Button>;
+export const WithIcon: Story = () => (
+  <div className="flex flex-wrap items-center gap-3">
+    <Button>
+      <Icon name="send" size={16} />
+      サンクスを送る
+    </Button>
+    <Button variant="secondary">
+      <Icon name="plus" size={16} />
+      当番を追加
+    </Button>
+    <Button variant="dark">
+      <Icon name="qr" size={16} />
+      招待
+    </Button>
+  </div>
+);
+
+export const FullWidth: Story = () => (
+  <div className="w-80 space-y-3">
+    <Button full>確定する</Button>
+    <Button variant="secondary" full>
+      キャンセル
+    </Button>
+  </div>
+);
+
+export const Disabled: Story = () => (
+  <div className="flex flex-wrap items-center gap-3">
+    <Button disabled>Primary</Button>
+    <Button variant="secondary" disabled>
+      Secondary
+    </Button>
+    <Button variant="dark" disabled>
+      Dark
+    </Button>
+  </div>
+);

--- a/pkgs/frontend/app/components/ui/button.tsx
+++ b/pkgs/frontend/app/components/ui/button.tsx
@@ -4,44 +4,50 @@ import type * as React from "react";
 
 import { cn } from "~/lib/utils";
 
+// Toban Button — variants, sizes and shape come from the design tokens defined
+// in `app/styles/globals.css`. The full-pill radius and 48 px default height
+// are intentional brand cues: every primary CTA in the prototype is round.
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 select-none items-center justify-center gap-2 rounded-full font-semibold whitespace-nowrap outline-none transition-[transform,background-color,color,box-shadow] active:scale-[0.98] focus-visible:ring-[3px] focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-60 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
-        outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        primary:
+          "bg-primary text-text-primary shadow-1 hover:brightness-[0.97] disabled:bg-[#F0E7CB] disabled:text-[#B0A179] disabled:opacity-100 disabled:shadow-none",
+        soft: "bg-primary-soft text-[#7A5A2E] hover:brightness-[0.97]",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          "border border-border bg-surface text-text-primary hover:bg-bg",
+        ghost: "bg-transparent text-text-secondary hover:bg-primary-soft/60",
+        danger:
+          "border border-border bg-surface text-danger hover:bg-[#FBE5E2]",
+        dark: "bg-text-primary text-white hover:brightness-110",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-8",
-        "icon-lg": "size-10",
+        sm: "h-9 px-[14px] text-sm",
+        md: "h-12 px-5 text-[15px]",
+        lg: "h-14 px-6 text-base",
+        "icon-sm": "size-9 px-0",
+        icon: "size-12 px-0",
+        "icon-lg": "size-14 px-0",
+      },
+      full: {
+        true: "w-full",
+        false: "",
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: "primary",
+      size: "md",
+      full: false,
     },
   },
 );
 
 function Button({
   className,
-  variant = "default",
-  size = "default",
+  variant,
+  size,
+  full,
   asChild = false,
   ...props
 }: React.ComponentProps<"button"> &
@@ -53,9 +59,9 @@ function Button({
   return (
     <Comp
       data-slot="button"
-      data-variant={variant}
-      data-size={size}
-      className={cn(buttonVariants({ variant, size, className }))}
+      data-variant={variant ?? "primary"}
+      data-size={size ?? "md"}
+      className={cn(buttonVariants({ variant, size, full, className }))}
       {...props}
     />
   );

--- a/pkgs/frontend/app/components/ui/card.stories.tsx
+++ b/pkgs/frontend/app/components/ui/card.stories.tsx
@@ -1,0 +1,75 @@
+import type { Story } from "@ladle/react";
+import { Avatar, AvatarFallback } from "./avatar";
+import { Badge } from "./badge";
+import { Button } from "./button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "./card";
+import { Icon } from "./icon";
+
+export default {
+  title: "UI / Card",
+};
+
+export const Default: Story = () => (
+  <Card className="w-80">
+    <CardHeader>
+      <CardTitle>今週の当番</CardTitle>
+      <CardDescription>残り 3 日</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <p className="text-sm text-text-secondary">
+        ゴミ出し / 共有エリアの清掃 / 来客対応 を担当します。
+      </p>
+    </CardContent>
+    <CardFooter>
+      <Button variant="soft" full>
+        詳細を見る
+      </Button>
+    </CardFooter>
+  </Card>
+);
+
+export const WithAction: Story = () => (
+  <Card className="w-80">
+    <CardHeader>
+      <CardTitle>分配ルール</CardTitle>
+      <CardDescription>毎月 1 日 自動実行</CardDescription>
+      <CardAction>
+        <Button variant="ghost" size="icon-sm" aria-label="編集">
+          <Icon name="edit" size={16} />
+        </Button>
+      </CardAction>
+    </CardHeader>
+    <CardContent className="flex items-center gap-3">
+      <Avatar>
+        <AvatarFallback seed="ひらやま" />
+      </Avatar>
+      <div className="text-sm">
+        <div className="font-semibold">ひらやま</div>
+        <div className="text-text-secondary">42% / 全体</div>
+      </div>
+      <Badge kind="lead" className="ml-auto">
+        当番リード
+      </Badge>
+    </CardContent>
+  </Card>
+);
+
+export const Compact: Story = () => (
+  <Card className="w-72 gap-3 py-4">
+    <CardContent className="flex items-center gap-3 px-4">
+      <Icon name="sparkle" className="text-primary" />
+      <div className="flex-1 text-sm">
+        <div className="font-semibold">サンクスが届きました</div>
+        <div className="text-text-secondary">homma さんから 10 THX</div>
+      </div>
+    </CardContent>
+  </Card>
+);

--- a/pkgs/frontend/app/components/ui/card.tsx
+++ b/pkgs/frontend/app/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        "flex flex-col gap-6 rounded-md border bg-card py-6 text-card-foreground shadow-1",
         className,
       )}
       {...props}

--- a/pkgs/frontend/app/components/ui/checkbox.stories.tsx
+++ b/pkgs/frontend/app/components/ui/checkbox.stories.tsx
@@ -1,0 +1,22 @@
+import type { Story } from "@ladle/react";
+import { Checkbox } from "./checkbox";
+
+export default {
+  title: "UI / Checkbox",
+};
+
+export const Default: Story = () => (
+  <div className="flex items-center gap-3">
+    <Checkbox defaultChecked />
+    <Checkbox />
+    <Checkbox disabled />
+    <Checkbox disabled defaultChecked />
+  </div>
+);
+
+export const Labelled: Story = () => (
+  <div className="flex items-center gap-2 text-sm font-medium">
+    <Checkbox id="terms" defaultChecked />
+    <label htmlFor="terms">利用規約に同意する</label>
+  </div>
+);

--- a/pkgs/frontend/app/components/ui/dialog.tsx
+++ b/pkgs/frontend/app/components/ui/dialog.tsx
@@ -111,7 +111,7 @@ function DialogFooter({
       {children}
       {showCloseButton && (
         <DialogPrimitive.Close asChild>
-          <Button variant="outline">Close</Button>
+          <Button variant="secondary">Close</Button>
         </DialogPrimitive.Close>
       )}
     </div>

--- a/pkgs/frontend/app/components/ui/icon.stories.tsx
+++ b/pkgs/frontend/app/components/ui/icon.stories.tsx
@@ -1,0 +1,49 @@
+import type { Story } from "@ladle/react";
+import { Icon, type IconName, iconRegistry } from "./icon";
+
+export default {
+  title: "UI / Icon",
+};
+
+const names = Object.keys(iconRegistry) as IconName[];
+
+export const Catalog: Story = () => (
+  <div className="grid grid-cols-4 gap-4 text-text-secondary sm:grid-cols-6">
+    {names.map((name) => (
+      <div
+        key={name}
+        className="flex flex-col items-center gap-2 rounded-md border bg-surface p-3"
+      >
+        <Icon name={name} className="text-text-primary" />
+        <span className="text-[11px] text-text-secondary">{name}</span>
+      </div>
+    ))}
+  </div>
+);
+
+export const Sizes: Story = () => (
+  <div className="flex items-center gap-4 text-text-primary">
+    <Icon name="bell" size={14} />
+    <Icon name="bell" size={18} />
+    <Icon name="bell" size={22} />
+    <Icon name="bell" size={28} />
+    <Icon name="bell" size={36} />
+  </div>
+);
+
+export const InContext: Story = () => (
+  <div className="space-y-3 text-text-primary">
+    <div className="flex items-center gap-2">
+      <Icon name="search" className="text-text-secondary" />
+      <span>メンバーを検索</span>
+    </div>
+    <div className="flex items-center gap-2">
+      <Icon name="check" className="text-[color:var(--color-contrib)]" />
+      <span>完了</span>
+    </div>
+    <div className="flex items-center gap-2">
+      <Icon name="shield" className="text-danger" />
+      <span>要確認</span>
+    </div>
+  </div>
+);

--- a/pkgs/frontend/app/components/ui/icon.tsx
+++ b/pkgs/frontend/app/components/ui/icon.tsx
@@ -1,0 +1,92 @@
+import type * as React from "react";
+import type { IconType } from "react-icons";
+import {
+  LuArrowRight,
+  LuBell,
+  LuChartPie,
+  LuCheck,
+  LuChevronDown,
+  LuChevronLeft,
+  LuChevronRight,
+  LuCopy,
+  LuHeart,
+  LuHouse,
+  LuLogOut,
+  LuPencil,
+  LuPlus,
+  LuQrCode,
+  LuSearch,
+  LuSend,
+  LuSettings,
+  LuShield,
+  LuSparkles,
+  LuUser,
+  LuUserCog,
+  LuUserPlus,
+  LuUsers,
+  LuWallet,
+  LuX,
+} from "react-icons/lu";
+
+import { cn } from "~/lib/utils";
+
+// Curated alias map. The keys mirror the icon names used in the design source
+// (`docs/design/handoff/project/primitives.jsx:6-37`); the values come from
+// `react-icons/lu` so we stay aligned with the Lucide vocabulary the rest of
+// the shadcn-derived primitives already depend on.
+//
+// Add new icons here as design needs grow rather than scattering raw imports
+// across the app — that way Storybook/Ladle catalogs every icon the design
+// system supports in one place.
+const iconRegistry = {
+  home: LuHouse,
+  duty: LuUserCog,
+  split: LuChartPie,
+  members: LuUsers,
+  wallet: LuWallet,
+  bell: LuBell,
+  search: LuSearch,
+  plus: LuPlus,
+  edit: LuPencil,
+  gear: LuSettings,
+  send: LuSend,
+  check: LuCheck,
+  "chevron-right": LuChevronRight,
+  "chevron-left": LuChevronLeft,
+  "chevron-down": LuChevronDown,
+  close: LuX,
+  "arrow-right": LuArrowRight,
+  sparkle: LuSparkles,
+  heart: LuHeart,
+  shield: LuShield,
+  user: LuUser,
+  invite: LuUserPlus,
+  copy: LuCopy,
+  logout: LuLogOut,
+  qr: LuQrCode,
+  pie: LuChartPie,
+} as const satisfies Record<string, IconType>;
+
+type IconName = keyof typeof iconRegistry;
+
+interface IconProps extends Omit<React.SVGAttributes<SVGElement>, "color"> {
+  name: IconName;
+  /** Pixel size — defaults to 22 to match the design source. */
+  size?: number | string;
+}
+
+function Icon({ name, size = 22, className, ...rest }: IconProps) {
+  const Cmp = iconRegistry[name];
+  return (
+    <Cmp
+      data-slot="icon"
+      data-name={name}
+      size={size}
+      className={cn("shrink-0", className)}
+      {...rest}
+    />
+  );
+}
+
+export { Icon, iconRegistry };
+export type { IconName, IconProps };

--- a/pkgs/frontend/app/components/ui/input.stories.tsx
+++ b/pkgs/frontend/app/components/ui/input.stories.tsx
@@ -1,0 +1,32 @@
+import type { Story } from "@ladle/react";
+import { Icon } from "./icon";
+import { Input } from "./input";
+
+export default {
+  title: "UI / Input",
+};
+
+export const Default: Story = () => (
+  <div className="w-80 space-y-3">
+    <Input placeholder="ワークスペース名" />
+  </div>
+);
+
+export const WithIcon: Story = () => (
+  <div className="w-80 space-y-3">
+    <Input icon={<Icon name="search" />} placeholder="メンバーを検索" />
+    <Input icon={<Icon name="user" />} placeholder="ユーザー名" />
+  </div>
+);
+
+export const States: Story = () => (
+  <div className="w-80 space-y-3">
+    <Input placeholder="フォーカス時に確認" />
+    <Input
+      placeholder="エラー状態"
+      aria-invalid="true"
+      defaultValue="invalid"
+    />
+    <Input placeholder="無効化" disabled defaultValue="disabled" />
+  </div>
+);

--- a/pkgs/frontend/app/components/ui/input.tsx
+++ b/pkgs/frontend/app/components/ui/input.tsx
@@ -2,20 +2,43 @@ import type * as React from "react";
 
 import { cn } from "~/lib/utils";
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+const baseInputClass =
+  "h-12 w-full min-w-0 rounded-sm border border-input bg-surface px-3.5 text-[15px] outline-none transition-[color,box-shadow] selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/40 aria-invalid:border-destructive aria-invalid:ring-destructive/20";
+
+interface InputProps extends React.ComponentProps<"input"> {
+  icon?: React.ReactNode;
+}
+
+function Input({ className, type, icon, ...props }: InputProps) {
+  if (icon) {
+    return (
+      <div
+        data-slot="input-group"
+        className={cn(
+          "flex h-12 w-full items-center gap-2 rounded-sm border border-input bg-surface px-3.5 transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/40 aria-invalid:border-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-[18px] [&_svg:not([class*='text-'])]:text-text-secondary",
+          className,
+        )}
+      >
+        {icon}
+        <input
+          type={type}
+          data-slot="input"
+          className="h-full w-full min-w-0 flex-1 border-0 bg-transparent p-0 text-[15px] outline-none placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+          {...props}
+        />
+      </div>
+    );
+  }
+
   return (
     <input
       type={type}
       data-slot="input"
-      className={cn(
-        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
-        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
-        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
-        className,
-      )}
+      className={cn(baseInputClass, className)}
       {...props}
     />
   );
 }
 
 export { Input };
+export type { InputProps };

--- a/pkgs/frontend/app/components/ui/radio-group.stories.tsx
+++ b/pkgs/frontend/app/components/ui/radio-group.stories.tsx
@@ -1,0 +1,36 @@
+import type { Story } from "@ladle/react";
+import { RadioGroup, RadioGroupItem } from "./radio-group";
+
+export default {
+  title: "UI / RadioGroup",
+};
+
+const options = [
+  { value: "weekly", label: "毎週" },
+  { value: "biweekly", label: "隔週" },
+  { value: "monthly", label: "毎月" },
+] as const;
+
+export const Default: Story = () => (
+  <RadioGroup defaultValue="weekly" className="text-sm">
+    {options.map((opt) => (
+      <div key={opt.value} className="flex items-center gap-2">
+        <RadioGroupItem id={`freq-${opt.value}`} value={opt.value} />
+        <label htmlFor={`freq-${opt.value}`}>{opt.label}</label>
+      </div>
+    ))}
+  </RadioGroup>
+);
+
+export const Disabled: Story = () => (
+  <RadioGroup defaultValue="b" className="text-sm">
+    <div className="flex items-center gap-2">
+      <RadioGroupItem id="disabled-a" value="a" disabled />
+      <label htmlFor="disabled-a">無効化</label>
+    </div>
+    <div className="flex items-center gap-2">
+      <RadioGroupItem id="disabled-b" value="b" disabled />
+      <label htmlFor="disabled-b">無効化（選択中）</label>
+    </div>
+  </RadioGroup>
+);

--- a/pkgs/frontend/app/components/ui/skeleton.stories.tsx
+++ b/pkgs/frontend/app/components/ui/skeleton.stories.tsx
@@ -1,0 +1,24 @@
+import type { Story } from "@ladle/react";
+import { Skeleton } from "./skeleton";
+
+export default {
+  title: "UI / Skeleton",
+};
+
+export const Default: Story = () => (
+  <div className="w-80 space-y-3">
+    <Skeleton className="h-12 w-full" />
+    <Skeleton className="h-4 w-2/3" />
+    <Skeleton className="h-4 w-1/2" />
+  </div>
+);
+
+export const Card: Story = () => (
+  <div className="flex w-80 items-center gap-3 rounded-md border bg-surface p-4 shadow-1">
+    <Skeleton className="size-12 rounded-full" />
+    <div className="flex-1 space-y-2">
+      <Skeleton className="h-4 w-3/4" />
+      <Skeleton className="h-3 w-1/2" />
+    </div>
+  </div>
+);

--- a/pkgs/frontend/app/components/ui/switch.stories.tsx
+++ b/pkgs/frontend/app/components/ui/switch.stories.tsx
@@ -1,0 +1,29 @@
+import type { Story } from "@ladle/react";
+import { Switch } from "./switch";
+
+export default {
+  title: "UI / Switch",
+};
+
+export const Default: Story = () => (
+  <div className="flex items-center gap-3">
+    <Switch defaultChecked />
+    <Switch />
+    <Switch disabled />
+    <Switch disabled defaultChecked />
+  </div>
+);
+
+export const Sizes: Story = () => (
+  <div className="flex items-center gap-3">
+    <Switch size="sm" defaultChecked />
+    <Switch size="default" defaultChecked />
+  </div>
+);
+
+export const Labelled: Story = () => (
+  <div className="flex items-center gap-3 text-sm font-medium">
+    <Switch id="notify" defaultChecked />
+    <label htmlFor="notify">サンクスを送信したら通知する</label>
+  </div>
+);

--- a/pkgs/frontend/app/components/ui/textarea.stories.tsx
+++ b/pkgs/frontend/app/components/ui/textarea.stories.tsx
@@ -1,0 +1,33 @@
+import type { Story } from "@ladle/react";
+import { Icon } from "./icon";
+import { Textarea } from "./textarea";
+
+export default {
+  title: "UI / Textarea",
+};
+
+export const Default: Story = () => (
+  <div className="w-80 space-y-3">
+    <Textarea placeholder="メッセージを入力" />
+  </div>
+);
+
+export const WithIcon: Story = () => (
+  <div className="w-80 space-y-3">
+    <Textarea
+      icon={<Icon name="edit" />}
+      placeholder="ありがとうのメッセージを書く"
+    />
+  </div>
+);
+
+export const States: Story = () => (
+  <div className="w-80 space-y-3">
+    <Textarea
+      placeholder="エラー状態"
+      aria-invalid="true"
+      defaultValue="invalid"
+    />
+    <Textarea placeholder="無効化" disabled defaultValue="disabled" />
+  </div>
+);

--- a/pkgs/frontend/app/components/ui/textarea.tsx
+++ b/pkgs/frontend/app/components/ui/textarea.tsx
@@ -2,17 +2,41 @@ import type * as React from "react";
 
 import { cn } from "~/lib/utils";
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+interface TextareaProps extends React.ComponentProps<"textarea"> {
+  icon?: React.ReactNode;
+}
+
+const baseTextareaClass =
+  "field-sizing-content flex min-h-24 w-full rounded-sm border border-input bg-surface px-3.5 py-3 text-[15px] outline-none transition-[color,box-shadow] placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/40 aria-invalid:border-destructive aria-invalid:ring-destructive/20";
+
+function Textarea({ className, icon, ...props }: TextareaProps) {
+  if (icon) {
+    return (
+      <div
+        data-slot="textarea-group"
+        className={cn(
+          "flex min-h-24 w-full items-start gap-2 rounded-sm border border-input bg-surface px-3.5 py-3 transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/40 aria-invalid:border-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-[18px] [&_svg:not([class*='text-'])]:text-text-secondary",
+          className,
+        )}
+      >
+        <span className="pt-0.5">{icon}</span>
+        <textarea
+          data-slot="textarea"
+          className="field-sizing-content min-h-[1.5rem] w-full flex-1 resize-none border-0 bg-transparent p-0 text-[15px] outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          {...props}
+        />
+      </div>
+    );
+  }
+
   return (
     <textarea
       data-slot="textarea"
-      className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
-        className,
-      )}
+      className={cn(baseTextareaClass, className)}
       {...props}
     />
   );
 }
 
 export { Textarea };
+export type { TextareaProps };

--- a/pkgs/frontend/app/root.tsx
+++ b/pkgs/frontend/app/root.tsx
@@ -13,6 +13,16 @@ import { Header } from "./components/Header";
 import { PWAUpdater } from "./components/PWAUpdater";
 import { SmartWalletLoading } from "./components/SmartWalletLoading";
 import { SwitchNetwork } from "./components/SwitchNetwork";
+// Self-host the brand fonts (Issue #426). Inter carries Latin numerals/labels
+// and Noto Sans JP covers Japanese copy — both are referenced by --font-sans.
+import "@fontsource/inter/400.css";
+import "@fontsource/inter/500.css";
+import "@fontsource/inter/600.css";
+import "@fontsource/inter/700.css";
+import "@fontsource/noto-sans-jp/400.css";
+import "@fontsource/noto-sans-jp/500.css";
+import "@fontsource/noto-sans-jp/700.css";
+
 // Tailwind v4 + design tokens. Imported here so every route inherits them.
 import "./styles/globals.css";
 

--- a/pkgs/frontend/app/styles/globals.css
+++ b/pkgs/frontend/app/styles/globals.css
@@ -1,6 +1,15 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+/* Tailwind v4 auto-detects sources by walking the project from this file
+ * outward. That works for the React Router dev/build pipelines but Ladle
+ * runs through a separate Vite config and only finds the bare entry, so
+ * utility classes used inside components/stories get pruned away. Listing
+ * them explicitly keeps both pipelines in sync. Paths are relative to this
+ * CSS file (`app/styles/globals.css`). */
+@source "../**/*.{ts,tsx,js,jsx}";
+@source "../../.ladle/**/*.{ts,tsx,js,jsx}";
+
 @custom-variant dark (&:is(.dark *));
 
 /* ============================================================================


### PR DESCRIPTION
Closes #426 (Phase 2-1 — design system 1/3).

## Summary

Re-styles the shadcn primitives seeded in #478 to match the Toban design tokens defined in `app/styles/globals.css`, adds the missing `Icon` wrapper, and ships Ladle stories for every primitive so the catalog matches the spec in #426. Also fixes the Tailwind v4 content-detection issue that left Ladle without our utility classes.

### Primitives (`app/components/ui/`)

- **Button** — 6 Toban variants (`primary` / `soft` / `secondary` / `ghost` / `danger` / `dark`) × 3 sizes (`sm` / `md` / `lg`) plus `icon-sm` / `icon` / `icon-lg`, all on a pill-radius base, with a `full` prop.
- **Card** — `rounded-md` + `shadow-1`. The accent left-edge bar is intentionally absent (matches the design feedback in `docs/design/handoff/chats/chat1.md`).
- **Badge** — 6 status kinds (`member` / `lead` / `supporter` / `role` / `info` / `danger`).
- **Input / Textarea** — optional leading `icon` prop and 48 px default height on the inline group.
- **Avatar** — deterministic seed → palette colour with initials fallback, plus an `xl` size.
- **Icon** — new `react-icons/lu` wrapper that mirrors the design source's icon names (matches the project's react-icons-only convention).
- Dialog footer's example button → `secondary` (the only call-site of the old `outline` variant).
- `CommonButton` size-shim updated to map the legacy chakra `xs` / `xl` onto the new Toban sizes.

### Tokens / fonts

- `globals.css`: tokens were already in place from #478. Added `@source` directives so Tailwind v4 picks up the same utility classes under both pipelines (the React Router dev/build worked but Ladle's separate Vite was generating only ~19 utility classes — the visible "no styles applied" symptom).
- `root.tsx`: self-host **Inter** + **Noto Sans JP** via `@fontsource` so the `--font-sans` token resolves at runtime in the actual app.

### Ladle stories

`*.stories.tsx` added (or updated) for: Button, Card, Avatar, Badge, Input, Textarea, Icon, Skeleton, Switch, Checkbox, RadioGroup. `pnpm ladle:build` produces a 286-class CSS bundle and all stories render with tokens applied.

## Test plan

- [x] `pnpm --filter frontend typecheck`
- [x] `pnpm --filter frontend lint` — no new errors in touched files (66 pre-existing repo errors unchanged)
- [x] `pnpm --filter frontend ladle:build`
- [ ] `pnpm --filter frontend ladle` — visually walk every story to confirm the tokens are applied
- [ ] `pnpm --filter frontend dev` — confirm the existing app still renders (`CommonButton` size-shim, dialog footer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)