### PR TITLE
feat(frontend): responsive layout shell (#428)

### DIFF
--- a/pkgs/frontend/app/components/layout/AppHeader.stories.tsx
+++ b/pkgs/frontend/app/components/layout/AppHeader.stories.tsx
@@ -1,0 +1,24 @@
+import type { Story } from "@ladle/react";
+import { AppHeader } from "./AppHeader";
+
+export default {
+  title: "Layout / AppHeader",
+};
+
+export const Default: Story = () => (
+  <div className="w-[420px] border-b bg-bg">
+    <AppHeader workspaceName="ひがしのシェアハウス" />
+  </div>
+);
+
+export const WithNotifications: Story = () => (
+  <div className="w-[420px] border-b bg-bg">
+    <AppHeader workspaceName="ひがしのシェアハウス" hasNotifications />
+  </div>
+);
+
+export const LongName: Story = () => (
+  <div className="w-[420px] border-b bg-bg">
+    <AppHeader workspaceName="ふじのもり・季節のあつまり 2026 春の章" />
+  </div>
+);

--- a/pkgs/frontend/app/components/layout/AppHeader.tsx
+++ b/pkgs/frontend/app/components/layout/AppHeader.tsx
@@ -1,0 +1,75 @@
+import type * as React from "react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import { Button } from "~/components/ui/button";
+import { Icon } from "~/components/ui/icon";
+import { cn } from "~/lib/utils";
+
+interface AppHeaderProps extends React.ComponentProps<"header"> {
+  /** Workspace name shown inside the switcher pill. */
+  workspaceName: string;
+  /** Optional avatar source for the workspace icon. */
+  workspaceImageUrl?: string;
+  /** Called when the user taps the workspace pill (open the switcher Sheet). */
+  onWorkspacePress?: () => void;
+  /** Show a small dot on the bell icon. */
+  hasNotifications?: boolean;
+  /** Called when the user taps the bell. */
+  onNotificationsPress?: () => void;
+  /** Optional trailing slot (extra icon buttons / user avatar dropdown). */
+  right?: React.ReactNode;
+}
+
+// Toban mobile AppHeader — workspace switcher pill + notification bell.
+// Mirrors `docs/design/handoff/project/screens.jsx:91-117`.
+function AppHeader({
+  workspaceName,
+  workspaceImageUrl,
+  onWorkspacePress,
+  hasNotifications,
+  onNotificationsPress,
+  right,
+  className,
+  ...rest
+}: AppHeaderProps) {
+  return (
+    <header
+      data-slot="app-header"
+      className={cn("flex items-center gap-2.5 px-4 pt-3.5 pb-2", className)}
+      {...rest}
+    >
+      <button
+        type="button"
+        onClick={onWorkspacePress}
+        className="flex min-w-0 flex-1 items-center gap-2 rounded-full border border-border bg-surface py-1.5 pr-2.5 pl-1.5 text-left transition-colors hover:bg-bg"
+      >
+        <Avatar size="sm" data-size="sm">
+          {workspaceImageUrl && (
+            <AvatarImage src={workspaceImageUrl} alt={workspaceName} />
+          )}
+          <AvatarFallback seed={workspaceName} />
+        </Avatar>
+        <span className="flex-1 truncate text-sm font-bold text-text-primary">
+          {workspaceName}
+        </span>
+        <Icon name="chevron-down" size={16} className="text-text-secondary" />
+      </button>
+      <Button
+        size="icon"
+        variant="secondary"
+        aria-label="通知"
+        onClick={onNotificationsPress}
+        className="relative size-10"
+      >
+        <Icon name="bell" size={20} />
+        {hasNotifications && (
+          <span className="absolute top-1.5 right-1.5 size-2 rounded-full border-2 border-surface bg-danger" />
+        )}
+      </Button>
+      {right}
+    </header>
+  );
+}
+
+export { AppHeader };
+export type { AppHeaderProps };

--- a/pkgs/frontend/app/components/layout/AppShell.stories.tsx
+++ b/pkgs/frontend/app/components/layout/AppShell.stories.tsx
@@ -1,0 +1,127 @@
+import type { Story } from "@ladle/react";
+import { useState } from "react";
+import { Row } from "~/components/composite/row";
+import { SectionLabel } from "~/components/composite/section-label";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Icon } from "~/components/ui/icon";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "~/components/ui/sheet";
+import { AppShell } from "./AppShell";
+import { PageContainer } from "./PageContainer";
+
+export default {
+  title: "Layout / AppShell",
+};
+
+const SAMPLE_USER = {
+  name: "ryoma",
+  subtitle: "0xab12...c45f",
+};
+
+const sampleHomeContent = (
+  <PageContainer className="py-4 md:py-6">
+    <SectionLabel>あなたの当番</SectionLabel>
+    <Card className="mb-3">
+      <CardHeader>
+        <CardTitle>ゴミ出し</CardTitle>
+      </CardHeader>
+      <CardContent>残り 3 日</CardContent>
+    </Card>
+    <SectionLabel>最近のアクティビティ</SectionLabel>
+    <div className="rounded-md border bg-surface">
+      <Row title="homma さんから 10 THX" subtitle="2 時間前" />
+      <Row title="genks さんから 5 THX" subtitle="昨日" />
+    </div>
+  </PageContainer>
+);
+
+export const Responsive: Story = () => {
+  const [active, setActive] = useState("home");
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <AppShell
+        workspace={{ name: "ひがしのシェアハウス" }}
+        active={active}
+        onNavigate={setActive}
+        hasNotifications
+        user={SAMPLE_USER}
+        topBar={{
+          title:
+            {
+              home: "ホーム",
+              duties: "当番",
+              splits: "分配",
+              members: "メンバー",
+              wallet: "ウォレット",
+            }[active] ?? "Toban",
+          subtitle: "Phase 2-3 デモ",
+          searchPlaceholder: "メンバーを検索",
+          primaryAction: {
+            label: "サンクスを送る",
+            icon: <Icon name="send" size={14} />,
+          },
+        }}
+      >
+        <div className="min-h-[480px]">{sampleHomeContent}</div>
+      </AppShell>
+    </div>
+  );
+};
+
+export const WithWorkspaceSwitcher: Story = () => {
+  const [active, setActive] = useState("home");
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <AppShell
+        workspace={{ name: "ひがしのシェアハウス" }}
+        active={active}
+        onNavigate={setActive}
+        onWorkspacePress={() => setOpen(true)}
+        user={SAMPLE_USER}
+        topBar={{
+          title: "ホーム",
+          primaryAction: {
+            label: "サンクスを送る",
+            icon: <Icon name="send" size={14} />,
+          },
+        }}
+      >
+        <div className="min-h-[480px]">{sampleHomeContent}</div>
+      </AppShell>
+      {/* Mobile uses Sheet (bottom). On desktop you'd swap to a Popover
+         anchored to the Sidebar workspace button — see #428. */}
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent side="bottom">
+          <SheetHeader>
+            <SheetTitle>ひがしのシェアハウス</SheetTitle>
+          </SheetHeader>
+          <div className="px-4 pb-4">
+            <Row
+              left={<Icon name="members" />}
+              title="ワークスペースを切り替え"
+              subtitle="2 件"
+              onClick={() => setOpen(false)}
+            />
+            <Row
+              left={<Icon name="invite" />}
+              title="メンバーを招待"
+              subtitle="リンクをコピーして共有"
+              onClick={() => setOpen(false)}
+            />
+            <Row
+              left={<Icon name="gear" />}
+              title="ワークスペース設定"
+              subtitle="名前・参加・機能設定"
+              onClick={() => setOpen(false)}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+};

--- a/pkgs/frontend/app/components/layout/AppShell.tsx
+++ b/pkgs/frontend/app/components/layout/AppShell.tsx
@@ -1,0 +1,107 @@
+import type * as React from "react";
+
+import { cn } from "~/lib/utils";
+import { AppHeader, type AppHeaderProps } from "./AppHeader";
+import { BottomNav, type BottomNavProps } from "./BottomNav";
+import { Sidebar, type SidebarProps } from "./Sidebar";
+import { TopBar, type TopBarProps } from "./TopBar";
+
+interface AppShellProps extends React.ComponentProps<"div"> {
+  /** Workspace metadata shared between AppHeader (mobile) and Sidebar (desktop). */
+  workspace: {
+    name: string;
+    imageUrl?: string;
+  };
+  /** Active nav key — e.g. "home" / "duties" / "splits" / "members" / "wallet". */
+  active: string;
+  /** Called from BottomNav (mobile) and Sidebar (desktop). */
+  onNavigate: (key: string) => void;
+  /** Called when the user opens the workspace switcher (Sheet/Popover). */
+  onWorkspacePress?: () => void;
+  /** TopBar / AppHeader shared inputs. */
+  hasNotifications?: boolean;
+  onNotificationsPress?: () => void;
+  /** Sidebar user footer. */
+  user?: SidebarProps["user"];
+  /** Per-page TopBar inputs. Title is required to render the desktop TopBar. */
+  topBar?: Omit<TopBarProps, "onNotificationsPress" | "hasNotifications">;
+  /** Trailing slot for the AppHeader (e.g. the legacy account dropdown). */
+  appHeaderRight?: AppHeaderProps["right"];
+  /** Optional override of the BottomNav items list. */
+  navItems?: BottomNavProps["items"];
+  /** When true, the desktop main column drops the TopBar (master-detail pages). */
+  hideTopBar?: boolean;
+}
+
+// Responsive shell — switches between mobile (AppHeader + BottomNav) and
+// desktop (Sidebar + TopBar) at the `md:` breakpoint. The desktop sidebar
+// is built with `hidden md:flex`, so we render both sets and let CSS pick;
+// no JS media-query is needed and SSR stays consistent.
+function AppShell({
+  workspace,
+  active,
+  onNavigate,
+  onWorkspacePress,
+  hasNotifications,
+  onNotificationsPress,
+  user,
+  topBar,
+  appHeaderRight,
+  navItems,
+  hideTopBar,
+  className,
+  children,
+  ...rest
+}: AppShellProps) {
+  return (
+    <div
+      data-slot="app-shell"
+      className={cn("flex min-h-dvh flex-col md:flex-row", className)}
+      {...rest}
+    >
+      {/* Desktop: persistent sidebar (hidden under md). */}
+      <Sidebar
+        workspaceName={workspace.name}
+        workspaceImageUrl={workspace.imageUrl}
+        onWorkspacePress={onWorkspacePress}
+        active={active}
+        onNavigate={onNavigate}
+        items={navItems}
+        user={user}
+      />
+
+      {/* Mobile: header at top, bottom nav at bottom. */}
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="md:hidden">
+          <AppHeader
+            workspaceName={workspace.name}
+            workspaceImageUrl={workspace.imageUrl}
+            onWorkspacePress={onWorkspacePress}
+            hasNotifications={hasNotifications}
+            onNotificationsPress={onNotificationsPress}
+            right={appHeaderRight}
+          />
+        </div>
+
+        {!hideTopBar && topBar && (
+          <div className="hidden md:block">
+            <TopBar
+              {...topBar}
+              hasNotifications={hasNotifications}
+              onNotificationsPress={onNotificationsPress}
+            />
+          </div>
+        )}
+
+        <main className="flex-1 overflow-x-hidden">{children}</main>
+
+        <div className="md:hidden">
+          <BottomNav active={active} onChange={onNavigate} items={navItems} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { AppShell };
+export type { AppShellProps };

--- a/pkgs/frontend/app/components/layout/BottomNav.stories.tsx
+++ b/pkgs/frontend/app/components/layout/BottomNav.stories.tsx
@@ -1,0 +1,29 @@
+import type { Story } from "@ladle/react";
+import { useState } from "react";
+import { BottomNav } from "./BottomNav";
+
+export default {
+  title: "Layout / BottomNav",
+};
+
+export const Interactive: Story = () => {
+  const [active, setActive] = useState("home");
+  return (
+    <div className="w-[420px] border-x">
+      <div className="bg-bg p-6 text-center text-sm text-text-secondary">
+        現在: <strong>{active}</strong>
+      </div>
+      <BottomNav active={active} onChange={setActive} />
+    </div>
+  );
+};
+
+export const EachActiveState: Story = () => (
+  <div className="space-y-3">
+    {["home", "duties", "splits", "members", "wallet"].map((key) => (
+      <div key={key} className="w-[420px] border-x">
+        <BottomNav active={key} onChange={() => {}} />
+      </div>
+    ))}
+  </div>
+);

--- a/pkgs/frontend/app/components/layout/BottomNav.tsx
+++ b/pkgs/frontend/app/components/layout/BottomNav.tsx
@@ -1,0 +1,86 @@
+import type * as React from "react";
+
+import { Icon, type IconName } from "~/components/ui/icon";
+import { cn } from "~/lib/utils";
+
+interface BottomNavItem {
+  key: string;
+  label: string;
+  icon: IconName;
+}
+
+const DEFAULT_ITEMS: ReadonlyArray<BottomNavItem> = [
+  { key: "home", label: "ホーム", icon: "home" },
+  { key: "duties", label: "当番", icon: "duty" },
+  { key: "splits", label: "分配", icon: "split" },
+  { key: "members", label: "メンバー", icon: "members" },
+  { key: "wallet", label: "ウォレット", icon: "wallet" },
+];
+
+interface BottomNavProps extends Omit<React.ComponentProps<"nav">, "onChange"> {
+  active: string;
+  onChange: (key: string) => void;
+  items?: ReadonlyArray<BottomNavItem>;
+}
+
+// Toban mobile BottomNav — 5-tab bar with a primary-soft pill behind the
+// active item. Mirrors `docs/design/handoff/project/primitives.jsx:234-273`.
+function BottomNav({
+  active,
+  onChange,
+  items = DEFAULT_ITEMS,
+  className,
+  ...rest
+}: BottomNavProps) {
+  return (
+    <nav
+      data-slot="bottom-nav"
+      className={cn(
+        "flex justify-around border-t bg-surface px-2 pt-2 pb-[calc(0.875rem+env(safe-area-inset-bottom))]",
+        className,
+      )}
+      {...rest}
+    >
+      {items.map((it) => {
+        const isActive = it.key === active;
+        return (
+          <button
+            key={it.key}
+            type="button"
+            onClick={() => onChange(it.key)}
+            aria-label={it.label}
+            data-active={isActive ? "" : undefined}
+            className={cn(
+              "flex flex-1 flex-col items-center gap-1 py-1.5",
+              isActive ? "text-primary" : "text-text-secondary",
+            )}
+          >
+            <span
+              className={cn(
+                "flex h-7 w-11 items-center justify-center rounded-full transition-colors",
+                isActive ? "bg-primary-soft" : "bg-transparent",
+              )}
+            >
+              <Icon
+                name={it.icon}
+                size={20}
+                className={isActive ? "text-[#A07310]" : "text-text-secondary"}
+              />
+            </span>
+            <span
+              className={cn(
+                "text-[10px]",
+                isActive ? "font-bold" : "font-medium",
+              )}
+            >
+              {it.label}
+            </span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+export { BottomNav, DEFAULT_ITEMS as DEFAULT_BOTTOM_NAV_ITEMS };
+export type { BottomNavProps, BottomNavItem };

--- a/pkgs/frontend/app/components/layout/MasterDetailLayout.stories.tsx
+++ b/pkgs/frontend/app/components/layout/MasterDetailLayout.stories.tsx
@@ -1,0 +1,67 @@
+import type { Story } from "@ladle/react";
+import { useState } from "react";
+import { Avatar, AvatarFallback } from "~/components/ui/avatar";
+import { Card, CardContent } from "~/components/ui/card";
+import { MasterDetailLayout } from "./MasterDetailLayout";
+
+const duties = [
+  { id: "trash", name: "ゴミ出し", assignee: "ひらやま" },
+  { id: "cleanup", name: "共有部清掃", assignee: "homma" },
+  { id: "stock", name: "備品補充", assignee: undefined },
+];
+
+export default {
+  title: "Layout / MasterDetailLayout",
+};
+
+export const Default: Story = () => {
+  const [selected, setSelected] = useState<string>("trash");
+  const duty = duties.find((d) => d.id === selected);
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <MasterDetailLayout
+        master={
+          <div className="flex flex-col gap-1.5 p-3">
+            {duties.map((d) => {
+              const active = d.id === selected;
+              return (
+                <button
+                  key={d.id}
+                  type="button"
+                  onClick={() => setSelected(d.id)}
+                  className={`flex items-center gap-3 rounded-sm px-3 py-3 text-left transition-colors ${
+                    active
+                      ? "bg-surface shadow-1"
+                      : "bg-transparent hover:bg-surface/50"
+                  }`}
+                >
+                  <Avatar size="sm">
+                    <AvatarFallback seed={d.name} />
+                  </Avatar>
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-bold">{d.name}</div>
+                    <div className="text-[11px] text-text-secondary">
+                      {d.assignee ?? "担当者を募集中"}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        }
+        detail={
+          <div className="space-y-4">
+            <h2 className="text-2xl font-bold">{duty?.name}</h2>
+            <Card>
+              <CardContent>
+                <p className="text-sm text-text-secondary">
+                  詳細パネルにはここで担当者・分配・メンバー一覧などを並べます。
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        }
+      />
+    </div>
+  );
+};

--- a/pkgs/frontend/app/components/layout/MasterDetailLayout.tsx
+++ b/pkgs/frontend/app/components/layout/MasterDetailLayout.tsx
@@ -1,0 +1,37 @@
+import type * as React from "react";
+
+import { cn } from "~/lib/utils";
+
+interface MasterDetailLayoutProps extends React.ComponentProps<"div"> {
+  /** The 320 px master list panel (left). */
+  master: React.ReactNode;
+  /** The flexible detail panel (right). */
+  detail: React.ReactNode;
+}
+
+// Toban desktop MasterDetailLayout — fixed-width master + fluid detail.
+// Mirrors `docs/design/handoff/project/desktop.jsx:354-426`. Designed to
+// sit *under* the 72 px TopBar, so it claims the rest of the viewport.
+function MasterDetailLayout({
+  master,
+  detail,
+  className,
+  ...rest
+}: MasterDetailLayoutProps) {
+  return (
+    <div
+      data-slot="master-detail"
+      className={cn(
+        "grid h-[calc(100dvh-72px)] grid-cols-[320px_1fr]",
+        className,
+      )}
+      {...rest}
+    >
+      <aside className="overflow-auto border-r bg-bg">{master}</aside>
+      <section className="overflow-auto p-7">{detail}</section>
+    </div>
+  );
+}
+
+export { MasterDetailLayout };
+export type { MasterDetailLayoutProps };

--- a/pkgs/frontend/app/components/layout/PageContainer.stories.tsx
+++ b/pkgs/frontend/app/components/layout/PageContainer.stories.tsx
@@ -1,0 +1,15 @@
+import type { Story } from "@ladle/react";
+import { PageContainer } from "./PageContainer";
+
+export default {
+  title: "Layout / PageContainer",
+};
+
+export const Default: Story = () => (
+  <PageContainer>
+    <div className="rounded-md border bg-surface p-4 text-sm">
+      モバイルでは <code>px-4</code>、デスクトップでは{" "}
+      <code>max-w-screen-xl mx-auto px-6</code> を適用します。
+    </div>
+  </PageContainer>
+);

--- a/pkgs/frontend/app/components/layout/PageContainer.tsx
+++ b/pkgs/frontend/app/components/layout/PageContainer.tsx
@@ -1,0 +1,18 @@
+import type * as React from "react";
+
+import { cn } from "~/lib/utils";
+
+// Toban PageContainer — unified horizontal padding + max-width for any page
+// that doesn't use a `MasterDetailLayout`. Mobile: 16 px gutter; desktop:
+// 24 px gutter inside a centred 1280 px column.
+function PageContainer({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="page-container"
+      className={cn("mx-auto w-full max-w-screen-xl px-4 md:px-6", className)}
+      {...props}
+    />
+  );
+}
+
+export { PageContainer };

--- a/pkgs/frontend/app/components/layout/ScreenHeader.stories.tsx
+++ b/pkgs/frontend/app/components/layout/ScreenHeader.stories.tsx
@@ -1,0 +1,44 @@
+import type { Story } from "@ladle/react";
+import { Button } from "~/components/ui/button";
+import { Icon } from "~/components/ui/icon";
+import { ScreenHeader } from "./ScreenHeader";
+
+export default {
+  title: "Layout / ScreenHeader",
+};
+
+export const Default: Story = () => (
+  <div className="w-[420px] border-b bg-bg">
+    <ScreenHeader title="当番の詳細" onBack={() => {}} />
+  </div>
+);
+
+export const WithSubtitle: Story = () => (
+  <div className="w-[420px] border-b bg-bg">
+    <ScreenHeader
+      title="ゴミ出し"
+      subtitle="毎週月曜・木曜・日曜"
+      onBack={() => {}}
+    />
+  </div>
+);
+
+export const WithRightSlot: Story = () => (
+  <div className="w-[420px] border-b bg-bg">
+    <ScreenHeader
+      title="ワークスペース設定"
+      onBack={() => {}}
+      right={
+        <Button size="icon-sm" variant="ghost" aria-label="編集">
+          <Icon name="edit" size={18} />
+        </Button>
+      }
+    />
+  </div>
+);
+
+export const NoBack: Story = () => (
+  <div className="w-[420px] border-b bg-bg">
+    <ScreenHeader title="お知らせ" />
+  </div>
+);

--- a/pkgs/frontend/app/components/layout/ScreenHeader.tsx
+++ b/pkgs/frontend/app/components/layout/ScreenHeader.tsx
@@ -1,0 +1,59 @@
+import type * as React from "react";
+
+import { Button } from "~/components/ui/button";
+import { Icon } from "~/components/ui/icon";
+import { cn } from "~/lib/utils";
+
+interface ScreenHeaderProps
+  extends Omit<React.ComponentProps<"header">, "title"> {
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  /** Render a back chevron and call this when pressed. */
+  onBack?: () => void;
+  /** Trailing slot — usually icon buttons or a dropdown trigger. */
+  right?: React.ReactNode;
+}
+
+// Toban mobile ScreenHeader — sub-page header with back button, title,
+// optional subtitle, and a trailing slot. Mirrors
+// `docs/design/handoff/project/primitives.jsx:212-231`.
+function ScreenHeader({
+  title,
+  subtitle,
+  onBack,
+  right,
+  className,
+  ...rest
+}: ScreenHeaderProps) {
+  return (
+    <header
+      data-slot="screen-header"
+      className={cn("flex items-center gap-2 bg-bg px-4 pt-2 pb-3", className)}
+      {...rest}
+    >
+      {onBack && (
+        <Button
+          size="icon"
+          variant="ghost"
+          aria-label="戻る"
+          onClick={onBack}
+          className="-ml-2 size-9"
+        >
+          <Icon name="chevron-left" size={22} className="text-text-primary" />
+        </Button>
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[17px] font-bold text-text-primary">
+          {title}
+        </div>
+        {subtitle && (
+          <div className="truncate text-xs text-text-secondary">{subtitle}</div>
+        )}
+      </div>
+      {right}
+    </header>
+  );
+}
+
+export { ScreenHeader };
+export type { ScreenHeaderProps };

--- a/pkgs/frontend/app/components/layout/Sidebar.stories.tsx
+++ b/pkgs/frontend/app/components/layout/Sidebar.stories.tsx
@@ -1,0 +1,43 @@
+import type { Story } from "@ladle/react";
+import { useState } from "react";
+import { Sidebar } from "./Sidebar";
+
+export default {
+  title: "Layout / Sidebar",
+};
+
+export const Default: Story = () => {
+  const [active, setActive] = useState("home");
+  return (
+    <div className="flex h-[640px] overflow-hidden rounded-md border bg-surface">
+      {/* Sidebar hides under md breakpoint; force visible inside the story
+         frame by removing the responsive guard via wrapper width (Ladle is
+         on a desktop viewport by default). */}
+      <Sidebar
+        workspaceName="ひがしのシェアハウス"
+        active={active}
+        onNavigate={setActive}
+        user={{
+          name: "ryoma",
+          subtitle: "0xab12...c45f",
+        }}
+      />
+      <div className="flex flex-1 items-center justify-center text-sm text-text-secondary">
+        現在: {active}
+      </div>
+    </div>
+  );
+};
+
+export const WithoutUser: Story = () => (
+  <div className="flex h-[480px] overflow-hidden rounded-md border bg-surface">
+    <Sidebar
+      workspaceName="新規ワークスペース"
+      active="home"
+      onNavigate={() => {}}
+    />
+    <div className="flex flex-1 items-center justify-center text-sm text-text-secondary">
+      ユーザー情報なし
+    </div>
+  </div>
+);

--- a/pkgs/frontend/app/components/layout/Sidebar.tsx
+++ b/pkgs/frontend/app/components/layout/Sidebar.tsx
@@ -1,0 +1,147 @@
+import type * as React from "react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import { Button } from "~/components/ui/button";
+import { Icon } from "~/components/ui/icon";
+import { cn } from "~/lib/utils";
+import { type BottomNavItem, DEFAULT_BOTTOM_NAV_ITEMS } from "./BottomNav";
+
+interface SidebarUser {
+  name: string;
+  /** Wallet address or short identifier shown under the name. */
+  subtitle?: string;
+  imageUrl?: string;
+}
+
+interface SidebarProps extends React.ComponentProps<"aside"> {
+  workspaceName: string;
+  workspaceImageUrl?: string;
+  onWorkspacePress?: () => void;
+  active: string;
+  onNavigate: (key: string) => void;
+  items?: ReadonlyArray<BottomNavItem>;
+  user?: SidebarUser;
+  onSettingsPress?: () => void;
+}
+
+// Toban desktop Sidebar — 260 px column with brand mark, workspace
+// switcher, primary nav, and a user footer.
+// Mirrors `docs/design/handoff/project/desktop.jsx:56-125`.
+function Sidebar({
+  workspaceName,
+  workspaceImageUrl,
+  onWorkspacePress,
+  active,
+  onNavigate,
+  items = DEFAULT_BOTTOM_NAV_ITEMS,
+  user,
+  onSettingsPress,
+  className,
+  ...rest
+}: SidebarProps) {
+  return (
+    <aside
+      data-slot="sidebar"
+      className={cn(
+        "hidden h-screen w-[260px] shrink-0 flex-col border-r bg-bg md:flex",
+        className,
+      )}
+      {...rest}
+    >
+      <div className="flex items-center gap-2.5 border-b px-4 pt-5 pb-3.5">
+        <span className="inline-flex size-8 items-center justify-center rounded-md bg-text-primary text-base font-extrabold text-[#FFD668]">
+          と
+        </span>
+        <div>
+          <div className="text-[15px] font-bold text-text-primary">Toban</div>
+          <div className="text-[11px] text-text-secondary">
+            あたたかい当番帳
+          </div>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onWorkspacePress}
+        className="mx-3 mt-3.5 mb-1.5 flex items-center gap-2.5 rounded-sm border bg-surface px-3 py-2.5 text-left transition-colors hover:bg-bg"
+      >
+        <Avatar size="sm" className="rounded-md">
+          {workspaceImageUrl && (
+            <AvatarImage src={workspaceImageUrl} alt={workspaceName} />
+          )}
+          <AvatarFallback seed={workspaceName} className="rounded-md" />
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="text-[11px] font-semibold tracking-wide text-text-secondary">
+            WORKSPACE
+          </div>
+          <div className="truncate text-[13px] font-bold text-text-primary">
+            {workspaceName}
+          </div>
+        </div>
+        <Icon name="chevron-down" size={14} className="text-text-secondary" />
+      </button>
+
+      <nav className="flex flex-col gap-0.5 px-2 py-3">
+        {items.map((it) => {
+          const isActive = it.key === active;
+          return (
+            <button
+              key={it.key}
+              type="button"
+              onClick={() => onNavigate(it.key)}
+              data-active={isActive ? "" : undefined}
+              className={cn(
+                "flex items-center gap-3 rounded-sm px-3 py-2.5 text-left text-sm transition-colors",
+                isActive
+                  ? "bg-primary-soft font-bold text-[#7A5A2E]"
+                  : "font-medium text-text-primary hover:bg-bg",
+              )}
+            >
+              <Icon
+                name={it.icon}
+                size={18}
+                className={isActive ? "text-primary" : "text-text-secondary"}
+              />
+              <span>{it.label}</span>
+            </button>
+          );
+        })}
+      </nav>
+
+      {user && (
+        <div className="mt-auto border-t p-3">
+          <div className="flex items-center gap-2.5">
+            <Avatar>
+              {user.imageUrl && (
+                <AvatarImage src={user.imageUrl} alt={user.name} />
+              )}
+              <AvatarFallback seed={user.name} />
+            </Avatar>
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-[13px] font-bold text-text-primary">
+                {user.name}
+              </div>
+              {user.subtitle && (
+                <div className="truncate font-mono text-[11px] text-text-secondary">
+                  {user.subtitle}
+                </div>
+              )}
+            </div>
+            <Button
+              size="icon-sm"
+              variant="ghost"
+              aria-label="設定"
+              onClick={onSettingsPress}
+            >
+              <Icon name="gear" size={16} />
+            </Button>
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+}
+
+export { Sidebar };
+export type { SidebarProps, SidebarUser };

--- a/pkgs/frontend/app/components/layout/TopBar.stories.tsx
+++ b/pkgs/frontend/app/components/layout/TopBar.stories.tsx
@@ -1,0 +1,47 @@
+import type { Story } from "@ladle/react";
+import { useState } from "react";
+import { Icon } from "~/components/ui/icon";
+import { TopBar } from "./TopBar";
+
+export default {
+  title: "Layout / TopBar",
+};
+
+export const Default: Story = () => (
+  <div className="rounded-md border bg-surface">
+    <TopBar
+      title="ホーム"
+      subtitle="今週の活動"
+      hasNotifications
+      primaryAction={{
+        label: "サンクスを送る",
+        icon: <Icon name="send" size={14} />,
+      }}
+    />
+  </div>
+);
+
+export const WithSearch: Story = () => {
+  const [q, setQ] = useState("");
+  return (
+    <div className="rounded-md border bg-surface">
+      <TopBar
+        title="メンバー"
+        subtitle={`検索結果 ${q ? "1" : "9"} 件`}
+        searchPlaceholder="メンバーを検索"
+        searchValue={q}
+        onSearchChange={setQ}
+        primaryAction={{
+          label: "招待",
+          icon: <Icon name="invite" size={14} />,
+        }}
+      />
+    </div>
+  );
+};
+
+export const WithoutCta: Story = () => (
+  <div className="rounded-md border bg-surface">
+    <TopBar title="設定" subtitle="ワークスペース全体の設定" />
+  </div>
+);

--- a/pkgs/frontend/app/components/layout/TopBar.tsx
+++ b/pkgs/frontend/app/components/layout/TopBar.tsx
@@ -1,0 +1,96 @@
+import type * as React from "react";
+
+import { Button } from "~/components/ui/button";
+import { Icon } from "~/components/ui/icon";
+import { cn } from "~/lib/utils";
+
+interface TopBarProps extends Omit<React.ComponentProps<"header">, "title"> {
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  /** Optional placeholder for the search pill. Hides search if undefined. */
+  searchPlaceholder?: string;
+  searchValue?: string;
+  onSearchChange?: (next: string) => void;
+  onNotificationsPress?: () => void;
+  hasNotifications?: boolean;
+  /** Trailing slot before the primary CTA. */
+  right?: React.ReactNode;
+  /** Primary CTA — e.g. "サンクスを送る". Hidden when omitted. */
+  primaryAction?: {
+    label: React.ReactNode;
+    onClick?: () => void;
+    icon?: React.ReactNode;
+  };
+}
+
+// Toban desktop TopBar — page title, search pill, bell and a primary CTA.
+// Mirrors `docs/design/handoff/project/desktop.jsx:134-155`.
+function TopBar({
+  title,
+  subtitle,
+  searchPlaceholder,
+  searchValue,
+  onSearchChange,
+  onNotificationsPress,
+  hasNotifications,
+  right,
+  primaryAction,
+  className,
+  ...rest
+}: TopBarProps) {
+  return (
+    <header
+      data-slot="top-bar"
+      className={cn(
+        "flex h-[72px] items-center gap-4 border-b bg-surface px-7",
+        className,
+      )}
+      {...rest}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[22px] font-bold tracking-tight text-text-primary">
+          {title}
+        </div>
+        {subtitle && (
+          <div className="mt-0.5 truncate text-xs text-text-secondary">
+            {subtitle}
+          </div>
+        )}
+      </div>
+      {searchPlaceholder !== undefined && (
+        <div className="flex w-[280px] items-center gap-2 rounded-full bg-bg px-3.5 py-2">
+          <Icon name="search" size={16} className="text-text-secondary" />
+          <input
+            type="search"
+            placeholder={searchPlaceholder}
+            value={searchValue}
+            onChange={(e) => onSearchChange?.(e.target.value)}
+            className="w-full border-0 bg-transparent text-[13px] outline-none placeholder:text-text-secondary"
+          />
+        </div>
+      )}
+      <Button
+        size="icon"
+        variant="ghost"
+        aria-label="通知"
+        onClick={onNotificationsPress}
+        className="relative size-10"
+      >
+        <Icon name="bell" size={18} className="text-text-secondary" />
+        {hasNotifications && (
+          <span className="absolute top-2 right-2 size-2 rounded-full border-2 border-surface bg-danger" />
+        )}
+      </Button>
+      {right}
+      {primaryAction && (
+        <Button onClick={primaryAction.onClick}>
+          {primaryAction.icon}
+          {primaryAction.label}
+        </Button>
+      )}
+    </header>
+  );
+}
+
+export { TopBar };
+export type { TopBarProps };


### PR DESCRIPTION
Closes #428 (Phase 2-3 — design system 3/3).

## Summary

Adds the responsive **AppShell** plus the eight layout primitives that compose it. All ship as pure presentational components under `app/components/layout/`, parameterised through props so consumers can wire data later without touching the shells.

### Mobile

| Component | Reference |
|---|---|
| `AppHeader` | `screens.jsx:91-117` — workspace pill + notification bell |
| `BottomNav` | `primitives.jsx:234-273` — 5-tab bar with `primary-soft` pill behind the active item |
| `ScreenHeader` | `primitives.jsx:212-231` — back button + title/subtitle + trailing slot |

### Desktop

| Component | Reference |
|---|---|
| `Sidebar` | `desktop.jsx:56-125` — 260 px column with brand mark, workspace switcher, primary nav, user footer |
| `TopBar` | `desktop.jsx:134-155` — title/subtitle + search pill + bell + primary CTA |
| `MasterDetailLayout` | `desktop.jsx:354-426` — `320px 1fr` grid under a 72 px TopBar |

### Common

- **`PageContainer`** — `max-w-screen-xl mx-auto px-4 md:px-6` for non-master-detail pages.
- **`AppShell`** — orchestrates the others. Switches between AppHeader+BottomNav (mobile) and Sidebar+TopBar (desktop) at the `md:` breakpoint via CSS-only `hidden md:*` guards, so SSR stays consistent without a `useMediaQuery` hook.

### Stories

`*.stories.tsx` added for every layout component plus an interactive **AppShell** story that shows active-route switching and a Sheet-based workspace switcher menu (mobile). Resize the Ladle viewport across the 768 px boundary to see the layout swap.

## Notes & follow-up

- The legacy `<Header />` in `app/root.tsx` is **left in place for this issue**. Wiring AppShell into the live route tree (and migrating the chakra-shim account/logout dropdown into AppShell's `appHeaderRight` slot) is intentionally deferred so the existing auth flows aren't disturbed mid-design-system migration. AppShell's prop surface is already shaped for that follow-up.
- Workspace switcher acceptance criterion is demonstrated in the AppShell story (Sheet on mobile). The desktop Popover variant is sketched in the story comments and will land alongside the root.tsx integration above.

## Test plan

- [x] `pnpm --filter frontend typecheck`
- [x] `pnpm --filter frontend ladle:build`
- [x] Lefthook pre-commit (Biome check / format / type-check) green
- [ ] `pnpm --filter frontend ladle` — resize across `md:` (768 px) to confirm AppHeader+BottomNav ↔ Sidebar+TopBar swap; click through BottomNav active states; open the workspace switcher Sheet from the AppShell story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)