### PR TITLE
feat(frontend): Heading/Typography primitives and migrate renewed surfaces

### DIFF
--- a/pkgs/frontend/app/components/composite/auth-hero.tsx
+++ b/pkgs/frontend/app/components/composite/auth-hero.tsx
@@ -1,5 +1,7 @@
 import type * as React from "react";
 
+import { Heading } from "~/components/ui/heading";
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 interface AuthHeroProps extends Omit<React.ComponentProps<"div">, "title"> {
@@ -34,18 +36,13 @@ function AuthHero({
       )}
       {...rest}
     >
-      <h1
-        className={cn(
-          "font-extrabold leading-tight text-text-primary",
-          "text-[26px] sm:text-3xl md:text-4xl",
-        )}
-      >
+      <Heading variant="hero" level={1}>
         {title}
-      </h1>
+      </Heading>
       {description && (
-        <p className="max-w-md text-sm leading-relaxed text-text-secondary md:text-[15px]">
+        <Typography variant="bodySm" tone="secondary" className="max-w-md">
           {description}
-        </p>
+        </Typography>
       )}
       {children}
     </div>

--- a/pkgs/frontend/app/components/composite/divider.stories.tsx
+++ b/pkgs/frontend/app/components/composite/divider.stories.tsx
@@ -1,4 +1,5 @@
 import type { Story } from "@ladle/react";
+import { Typography } from "../ui/typography";
 import { Divider } from "./divider";
 
 export default {
@@ -7,16 +8,24 @@ export default {
 
 export const Default: Story = () => (
   <div className="w-80 rounded-md border bg-surface px-4 py-2">
-    <p className="py-2 text-sm">上のセクション</p>
+    <Typography variant="bodySm" className="py-2">
+      上のセクション
+    </Typography>
     <Divider />
-    <p className="py-2 text-sm">下のセクション</p>
+    <Typography variant="bodySm" className="py-2">
+      下のセクション
+    </Typography>
   </div>
 );
 
 export const Inset: Story = () => (
   <div className="w-80 rounded-md border bg-surface">
-    <p className="px-4 py-3 text-sm">アバターの右で揃える行</p>
+    <Typography variant="bodySm" className="px-4 py-3">
+      アバターの右で揃える行
+    </Typography>
     <Divider inset={16} />
-    <p className="px-4 py-3 text-sm">次の行</p>
+    <Typography variant="bodySm" className="px-4 py-3">
+      次の行
+    </Typography>
   </div>
 );

--- a/pkgs/frontend/app/components/composite/empty-state.tsx
+++ b/pkgs/frontend/app/components/composite/empty-state.tsx
@@ -1,5 +1,7 @@
 import type * as React from "react";
 
+import { Heading } from "~/components/ui/heading";
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 interface EmptyStateProps extends Omit<React.ComponentProps<"div">, "title"> {
@@ -33,11 +35,18 @@ function EmptyState({
           {icon}
         </div>
       )}
-      <div className="text-[15px] font-bold text-text-primary">{title}</div>
+      <Heading variant="h5" level={2}>
+        {title}
+      </Heading>
       {body && (
-        <div className="mt-1.5 text-[13px] leading-relaxed text-text-secondary">
+        <Typography
+          as="div"
+          variant="bodySm"
+          tone="secondary"
+          className="mt-1.5"
+        >
           {body}
-        </div>
+        </Typography>
       )}
       {action && <div className="mt-5 flex justify-center">{action}</div>}
     </div>

--- a/pkgs/frontend/app/components/composite/field-label.tsx
+++ b/pkgs/frontend/app/components/composite/field-label.tsx
@@ -1,6 +1,7 @@
 import type * as React from "react";
 
 import { Label } from "~/components/ui/label";
+import { typographyVariants } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 // Toban FieldLabel — small uppercase-ish caption above a form control.
@@ -15,7 +16,8 @@ function FieldLabel({
     <Label
       data-slot="field-label"
       className={cn(
-        "mb-2 block text-xs font-bold tracking-[0.03em] text-text-secondary",
+        typographyVariants({ variant: "label" }),
+        "mb-2 block",
         className,
       )}
       {...props}

--- a/pkgs/frontend/app/components/composite/next-step-card.tsx
+++ b/pkgs/frontend/app/components/composite/next-step-card.tsx
@@ -1,6 +1,7 @@
 import type * as React from "react";
 
 import { Icon, type IconName } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 interface NextStepCardProps
@@ -37,9 +38,14 @@ function NextStepCard({
       >
         <Icon name={icon} size={16} />
       </span>
-      <span className="flex-1 text-sm font-semibold text-text-primary">
+      <Typography
+        as="span"
+        variant="bodySm"
+        weight="semibold"
+        className="flex-1"
+      >
         {label}
-      </span>
+      </Typography>
       <Icon
         name="chevron-right"
         size={16}

--- a/pkgs/frontend/app/components/composite/row.tsx
+++ b/pkgs/frontend/app/components/composite/row.tsx
@@ -1,5 +1,6 @@
 import type * as React from "react";
 
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 interface RowProps extends Omit<React.ComponentProps<"div">, "title"> {
@@ -51,13 +52,24 @@ function Row({
     >
       {left}
       <div className="min-w-0 flex-1">
-        <div className="text-[15px] font-semibold leading-tight text-text-primary">
+        <Typography
+          as="div"
+          variant="body"
+          weight="semibold"
+          className="leading-tight"
+        >
           {title}
-        </div>
+        </Typography>
         {subtitle && (
-          <div className="mt-0.5 truncate text-xs leading-tight text-text-secondary">
+          <Typography
+            as="div"
+            variant="caption"
+            tone="secondary"
+            truncate
+            className="mt-0.5"
+          >
             {subtitle}
-          </div>
+          </Typography>
         )}
       </div>
       {right}

--- a/pkgs/frontend/app/components/composite/section-label.tsx
+++ b/pkgs/frontend/app/components/composite/section-label.tsx
@@ -1,5 +1,6 @@
 import type * as React from "react";
 
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 // Toban SectionLabel — small caps caption that introduces a section
@@ -7,12 +8,11 @@ import { cn } from "~/lib/utils";
 // `docs/design/handoff/project/screens.jsx:87-89`.
 function SectionLabel({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div
+    <Typography
+      as="div"
+      variant="label"
       data-slot="section-label"
-      className={cn(
-        "px-5 pt-1 pb-2 text-xs font-bold tracking-[0.04em] text-text-secondary",
-        className,
-      )}
+      className={cn("px-5 pt-1 pb-2", className)}
       {...props}
     />
   );

--- a/pkgs/frontend/app/components/composite/stat-card.tsx
+++ b/pkgs/frontend/app/components/composite/stat-card.tsx
@@ -1,6 +1,7 @@
 import type * as React from "react";
 
 import { Card } from "~/components/ui/card";
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 interface StatCardProps extends React.ComponentProps<typeof Card> {
@@ -39,31 +40,47 @@ function StatCard({
       )}
       {...rest}
     >
-      <div className="px-4 text-[11px] font-semibold text-text-secondary">
+      <Typography
+        as="div"
+        variant="micro"
+        tone="secondary"
+        weight="semibold"
+        className="px-4"
+      >
         {label}
-      </div>
+      </Typography>
       <div
         className={cn(
           "mt-1 flex items-baseline gap-1.5 px-4",
           isWide ? "justify-start" : "justify-center",
         )}
       >
-        <span
-          className={cn(
-            "font-extrabold tracking-tight text-text-primary",
-            isWide ? "text-[32px] leading-none" : "text-[26px] leading-none",
-          )}
+        <Typography
+          as="span"
+          variant={isWide ? "statLg" : "statMd"}
           style={accent ? { color: accent } : undefined}
         >
           {value}
-        </span>
+        </Typography>
         {unit && (
-          <span className="text-xs font-bold text-text-secondary">{unit}</span>
+          <Typography
+            as="span"
+            variant="caption"
+            tone="secondary"
+            weight="bold"
+          >
+            {unit}
+          </Typography>
         )}
         {delta && (
-          <span className="ml-auto rounded-full bg-[#E5F5EC] px-2 py-0.5 text-[11px] font-bold text-[#2F8B58]">
+          <Typography
+            as="span"
+            variant="micro"
+            weight="bold"
+            className="ml-auto rounded-full bg-[#E5F5EC] px-2 py-0.5 text-[#2F8B58]"
+          >
             {delta}
-          </span>
+          </Typography>
         )}
       </div>
     </Card>

--- a/pkgs/frontend/app/components/composite/summary-row.tsx
+++ b/pkgs/frontend/app/components/composite/summary-row.tsx
@@ -1,5 +1,6 @@
 import type * as React from "react";
 
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 interface SummaryRowProps extends React.ComponentProps<"div"> {
@@ -19,10 +20,22 @@ function SummaryRow({ label, value, className, ...rest }: SummaryRowProps) {
       )}
       {...rest}
     >
-      <span className="text-xs font-semibold text-text-secondary">{label}</span>
-      <span className="inline-flex items-center text-right text-sm font-semibold text-text-primary">
+      <Typography
+        as="span"
+        variant="caption"
+        tone="secondary"
+        weight="semibold"
+      >
+        {label}
+      </Typography>
+      <Typography
+        as="span"
+        variant="bodySm"
+        weight="semibold"
+        className="inline-flex items-center text-right"
+      >
         {value}
-      </span>
+      </Typography>
     </div>
   );
 }

--- a/pkgs/frontend/app/components/composite/toggle-row.tsx
+++ b/pkgs/frontend/app/components/composite/toggle-row.tsx
@@ -2,6 +2,7 @@ import { useId } from "react";
 import type * as React from "react";
 
 import { Switch } from "~/components/ui/switch";
+import { Typography, typographyVariants } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 interface ToggleRowProps extends React.ComponentProps<"div"> {
@@ -38,14 +39,22 @@ function ToggleRow({
       <div className="min-w-0 flex-1">
         <label
           htmlFor={id}
-          className="block text-sm font-semibold text-text-primary"
+          className={cn(
+            typographyVariants({ variant: "bodySm", weight: "semibold" }),
+            "block",
+          )}
         >
           {label}
         </label>
         {sub && (
-          <div className="mt-0.5 text-[11px] leading-snug text-text-secondary">
+          <Typography
+            as="div"
+            variant="micro"
+            tone="secondary"
+            className="mt-0.5 leading-snug"
+          >
             {sub}
-          </div>
+          </Typography>
         )}
       </div>
       <Switch

--- a/pkgs/frontend/app/components/composite/weight-bar.tsx
+++ b/pkgs/frontend/app/components/composite/weight-bar.tsx
@@ -1,5 +1,6 @@
 import type * as React from "react";
 
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 interface WeightBarProps extends React.ComponentProps<"div"> {
@@ -22,11 +23,19 @@ function WeightBar({
   const clamped = Math.max(0, Math.min(100, pct));
   return (
     <div data-slot="weight-bar" className={cn("w-full", className)} {...rest}>
-      <div className="mb-1.5 flex items-baseline justify-between text-[13px]">
-        <span className="font-semibold text-text-primary">{label}</span>
-        <span className="font-bold tabular-nums" style={{ color }}>
+      <div className="mb-1.5 flex items-baseline justify-between">
+        <Typography as="span" variant="bodySm" weight="semibold">
+          {label}
+        </Typography>
+        <Typography
+          as="span"
+          variant="bodySm"
+          weight="bold"
+          className="tabular-nums"
+          style={{ color }}
+        >
           {clamped}%
-        </span>
+        </Typography>
       </div>
       <div className="h-2 w-full overflow-hidden rounded-xs bg-[#F0EBE0]">
         <div

--- a/pkgs/frontend/app/components/composite/workspace-card.tsx
+++ b/pkgs/frontend/app/components/composite/workspace-card.tsx
@@ -2,6 +2,7 @@ import type * as React from "react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Badge } from "~/components/ui/badge";
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 interface WorkspaceCardProps
@@ -58,20 +59,38 @@ function WorkspaceCard({
         <AvatarFallback seed={seed} className="rounded-md" />
       </Avatar>
       <div className="min-w-0 flex-1">
-        <div className="truncate text-base font-bold text-text-primary">
+        <Typography
+          as="div"
+          variant="body"
+          weight="bold"
+          truncate
+          className="leading-tight"
+        >
           {name}
-        </div>
+        </Typography>
         {description && (
-          <div className="mt-0.5 truncate text-xs text-text-secondary">
+          <Typography
+            as="div"
+            variant="caption"
+            tone="secondary"
+            truncate
+            className="mt-0.5"
+          >
             {description}
-          </div>
+          </Typography>
         )}
         {hasMeta && (
-          <div className="mt-1.5 truncate text-[11px] text-text-secondary">
+          <Typography
+            as="div"
+            variant="micro"
+            tone="secondary"
+            truncate
+            className="mt-1.5"
+          >
             {typeof members === "number" && <span>{members}人</span>}
             {typeof members === "number" && lastActive && <span> ・ </span>}
             {lastActive && <span>最近の活動: {lastActive}</span>}
-          </div>
+          </Typography>
         )}
       </div>
       {current && <Badge kind="member">現在</Badge>}

--- a/pkgs/frontend/app/components/layout/AccountMenu.tsx
+++ b/pkgs/frontend/app/components/layout/AccountMenu.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu";
 import { Icon } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 interface AccountMenuProps {
@@ -142,13 +143,13 @@ function AccountMenu({ variant = "compact", className }: AccountMenuProps) {
           <AvatarFallback seed={displayName} />
         </Avatar>
         <div className="min-w-0 flex-1">
-          <div className="truncate text-[13px] font-bold text-text-primary">
+          <Typography as="div" variant="bodySm" weight="bold" truncate>
             {displayName}
-          </div>
+          </Typography>
           {subtitle && (
-            <div className="truncate font-mono text-[11px] text-text-secondary">
+            <Typography as="div" variant="mono" tone="secondary" truncate>
               {subtitle}
-            </div>
+            </Typography>
           )}
         </div>
         <Icon name="chevron-down" size={14} className="text-text-secondary" />
@@ -178,18 +179,18 @@ function AccountMenu({ variant = "compact", className }: AccountMenuProps) {
         className="min-w-56 rounded-md"
       >
         <DropdownMenuLabel className="flex flex-col gap-0.5 py-2">
-          <span className="text-[13px] font-bold text-text-primary">
+          <Typography as="span" variant="bodySm" weight="bold">
             {displayName}
-          </span>
+          </Typography>
           {identity.name && identity.domain && (
-            <span className="text-[11px] text-text-secondary">
+            <Typography as="span" variant="micro" tone="secondary">
               {identity.name}.{identity.domain}
-            </span>
+            </Typography>
           )}
           {identity.address && (
-            <span className="font-mono text-[11px] text-text-secondary">
+            <Typography as="span" variant="mono" tone="secondary">
               {abbreviateAddress(identity.address)}
-            </span>
+            </Typography>
           )}
         </DropdownMenuLabel>
         <DropdownMenuSeparator />

--- a/pkgs/frontend/app/components/layout/AppHeader.tsx
+++ b/pkgs/frontend/app/components/layout/AppHeader.tsx
@@ -3,6 +3,7 @@ import type * as React from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
 import { Icon } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 interface AppHeaderProps extends React.ComponentProps<"header"> {
@@ -49,9 +50,15 @@ function AppHeader({
           )}
           <AvatarFallback seed={workspaceName} />
         </Avatar>
-        <span className="flex-1 truncate text-sm font-bold text-text-primary">
+        <Typography
+          as="span"
+          variant="bodySm"
+          weight="bold"
+          truncate
+          className="flex-1"
+        >
           {workspaceName}
-        </span>
+        </Typography>
         <Icon name="chevron-down" size={16} className="text-text-secondary" />
       </button>
       <Button

--- a/pkgs/frontend/app/components/layout/MasterDetailLayout.stories.tsx
+++ b/pkgs/frontend/app/components/layout/MasterDetailLayout.stories.tsx
@@ -2,6 +2,8 @@ import type { Story } from "@ladle/react";
 import { useState } from "react";
 import { Avatar, AvatarFallback } from "~/components/ui/avatar";
 import { Card, CardContent } from "~/components/ui/card";
+import { Heading } from "~/components/ui/heading";
+import { Typography } from "~/components/ui/typography";
 import { MasterDetailLayout } from "./MasterDetailLayout";
 
 const duties = [
@@ -39,10 +41,17 @@ export const Default: Story = () => {
                     <AvatarFallback seed={d.name} />
                   </Avatar>
                   <div className="min-w-0 flex-1">
-                    <div className="truncate text-sm font-bold">{d.name}</div>
-                    <div className="text-[11px] text-text-secondary">
+                    <Typography
+                      as="div"
+                      variant="bodySm"
+                      weight="bold"
+                      truncate
+                    >
+                      {d.name}
+                    </Typography>
+                    <Typography as="div" variant="micro" tone="secondary">
                       {d.assignee ?? "担当者を募集中"}
-                    </div>
+                    </Typography>
                   </div>
                 </button>
               );
@@ -51,12 +60,14 @@ export const Default: Story = () => {
         }
         detail={
           <div className="space-y-4">
-            <h2 className="text-2xl font-bold">{duty?.name}</h2>
+            <Heading variant="h2" level={2}>
+              {duty?.name}
+            </Heading>
             <Card>
               <CardContent>
-                <p className="text-sm text-text-secondary">
+                <Typography variant="bodySm" tone="secondary">
                   詳細パネルにはここで担当者・分配・メンバー一覧などを並べます。
-                </p>
+                </Typography>
               </CardContent>
             </Card>
           </div>

--- a/pkgs/frontend/app/components/layout/ScreenHeader.tsx
+++ b/pkgs/frontend/app/components/layout/ScreenHeader.tsx
@@ -1,7 +1,9 @@
 import type * as React from "react";
 
 import { Button } from "~/components/ui/button";
+import { Heading } from "~/components/ui/heading";
 import { Icon } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 interface ScreenHeaderProps
@@ -43,11 +45,13 @@ function ScreenHeader({
         </Button>
       )}
       <div className="min-w-0 flex-1">
-        <div className="truncate text-[17px] font-bold text-text-primary">
+        <Heading variant="h4" className="truncate">
           {title}
-        </div>
+        </Heading>
         {subtitle && (
-          <div className="truncate text-xs text-text-secondary">{subtitle}</div>
+          <Typography variant="caption" tone="secondary" truncate>
+            {subtitle}
+          </Typography>
         )}
       </div>
       {right}

--- a/pkgs/frontend/app/components/layout/Sidebar.tsx
+++ b/pkgs/frontend/app/components/layout/Sidebar.tsx
@@ -3,6 +3,7 @@ import type * as React from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
 import { Icon } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 import { type BottomNavItem, DEFAULT_BOTTOM_NAV_ITEMS } from "./BottomNav";
 
@@ -53,10 +54,17 @@ function Sidebar({
           と
         </span>
         <div>
-          <div className="text-[15px] font-bold text-text-primary">Toban</div>
-          <div className="text-[11px] text-text-secondary">
+          <Typography
+            as="div"
+            variant="body"
+            weight="bold"
+            className="leading-tight"
+          >
+            Toban
+          </Typography>
+          <Typography as="div" variant="micro" tone="secondary">
             あたたかい当番帳
-          </div>
+          </Typography>
         </div>
       </div>
 
@@ -72,12 +80,18 @@ function Sidebar({
           <AvatarFallback seed={workspaceName} className="rounded-md" />
         </Avatar>
         <div className="min-w-0 flex-1">
-          <div className="text-[11px] font-semibold tracking-wide text-text-secondary">
+          <Typography
+            as="div"
+            variant="micro"
+            tone="secondary"
+            weight="semibold"
+            className="tracking-wide"
+          >
             WORKSPACE
-          </div>
-          <div className="truncate text-[13px] font-bold text-text-primary">
+          </Typography>
+          <Typography as="div" variant="bodySm" weight="bold" truncate>
             {workspaceName}
-          </div>
+          </Typography>
         </div>
         <Icon name="chevron-down" size={14} className="text-text-secondary" />
       </button>
@@ -119,13 +133,13 @@ function Sidebar({
               <AvatarFallback seed={user.name} />
             </Avatar>
             <div className="min-w-0 flex-1">
-              <div className="truncate text-[13px] font-bold text-text-primary">
+              <Typography as="div" variant="bodySm" weight="bold" truncate>
                 {user.name}
-              </div>
+              </Typography>
               {user.subtitle && (
-                <div className="truncate font-mono text-[11px] text-text-secondary">
+                <Typography as="div" variant="mono" tone="secondary" truncate>
                   {user.subtitle}
-                </div>
+                </Typography>
               )}
             </div>
             <Button

--- a/pkgs/frontend/app/components/layout/TopBar.tsx
+++ b/pkgs/frontend/app/components/layout/TopBar.tsx
@@ -1,7 +1,9 @@
 import type * as React from "react";
 
 import { Button } from "~/components/ui/button";
+import { Heading } from "~/components/ui/heading";
 import { Icon } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 interface TopBarProps extends Omit<React.ComponentProps<"header">, "title"> {
@@ -48,13 +50,18 @@ function TopBar({
       {...rest}
     >
       <div className="min-w-0 flex-1">
-        <div className="truncate text-[22px] font-bold tracking-tight text-text-primary">
+        <Heading variant="h2" className="truncate">
           {title}
-        </div>
+        </Heading>
         {subtitle && (
-          <div className="mt-0.5 truncate text-xs text-text-secondary">
+          <Typography
+            variant="caption"
+            tone="secondary"
+            truncate
+            className="mt-0.5"
+          >
             {subtitle}
-          </div>
+          </Typography>
         )}
       </div>
       {searchPlaceholder !== undefined && (

--- a/pkgs/frontend/app/components/layout/WorkspaceSwitcherMenu.tsx
+++ b/pkgs/frontend/app/components/layout/WorkspaceSwitcherMenu.tsx
@@ -13,6 +13,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "~/components/ui/sheet";
+import { Typography } from "~/components/ui/typography";
 
 interface WorkspaceSwitcherMenuProps {
   /** Controlled open state — same value drives both Sheet (mobile) and
@@ -113,9 +114,15 @@ function WorkspaceSwitcherMenu({
             sideOffset={8}
             className="w-[280px] p-0"
           >
-            <div className="border-b px-4 py-3 text-[13px] font-bold text-text-primary">
+            <Typography
+              as="div"
+              variant="bodySm"
+              weight="bold"
+              truncate
+              className="border-b px-4 py-3"
+            >
               {workspaceName}
-            </div>
+            </Typography>
             {items}
           </PopoverContent>
         </Popover>

--- a/pkgs/frontend/app/components/ui/heading.stories.tsx
+++ b/pkgs/frontend/app/components/ui/heading.stories.tsx
@@ -1,0 +1,51 @@
+import type { Story } from "@ladle/react";
+import { Heading } from "./heading";
+
+export default {
+  title: "UI / Heading",
+};
+
+export const Variants: Story = () => (
+  <div className="flex flex-col gap-6">
+    <Heading variant="display" level={1}>
+      display — あたたかい当番帳
+    </Heading>
+    <Heading variant="hero" level={1}>
+      hero — 認証画面ヒーロー
+    </Heading>
+    <Heading variant="h1" level={2}>
+      h1 — LP セクション見出し
+    </Heading>
+    <Heading variant="h2">h2 — ページタイトル</Heading>
+    <Heading variant="h3">h3 — 大きめカード見出し</Heading>
+    <Heading variant="h4">h4 — 中カード見出し</Heading>
+    <Heading variant="h5">h5 — ScreenHeader タイトル</Heading>
+    <Heading variant="h6">h6 — 行 / EmptyState タイトル</Heading>
+    <Heading variant="eyebrow">eyebrow — あなたの当番</Heading>
+  </div>
+);
+
+export const Tones: Story = () => (
+  <div className="flex flex-col gap-3">
+    <Heading variant="h3" tone="primary">
+      Primary トーン
+    </Heading>
+    <Heading variant="h3" tone="secondary">
+      Secondary トーン
+    </Heading>
+    <Heading variant="h3" tone="danger">
+      Danger トーン
+    </Heading>
+  </div>
+);
+
+export const SemanticOverride: Story = () => (
+  <div className="flex flex-col gap-3">
+    <Heading variant="display" level={1}>
+      level=1 / variant=display
+    </Heading>
+    <Heading variant="h6" level={2}>
+      level=2 / variant=h6（カード内タイトル）
+    </Heading>
+  </div>
+);

--- a/pkgs/frontend/app/components/ui/heading.tsx
+++ b/pkgs/frontend/app/components/ui/heading.tsx
@@ -1,0 +1,104 @@
+import { type VariantProps, cva } from "class-variance-authority";
+import { Slot } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "~/lib/utils";
+
+// Toban Heading primitive. Variant carries the full visual scale (font
+// size + weight + line-height + tracking) so call sites never reach for
+// `text-*` Tailwind utilities. `level` controls the semantic level used
+// for the rendered element and document outline. The variant ladder is
+// derived from the renewed surfaces (LP / auth / workspace list / app
+// chrome); each variant maps 1:1 to a recurring visual role rather than
+// to a pixel size so the underlying scale can shift in `globals.css`
+// without touching call sites. See issue #491.
+const headingVariants = cva("tracking-tight text-text-primary", {
+  variants: {
+    variant: {
+      // Landing-page hero.
+      display: "text-[clamp(34px,7vw,62px)] font-black leading-[1.15]",
+      // Auth hero (login / signup) — sits between display and h1.
+      hero: "text-[26px] font-extrabold leading-tight sm:text-3xl md:text-4xl",
+      // LP section title.
+      h1: "text-[clamp(28px,4vw,44px)] font-black leading-[1.18]",
+      // App page title (workspace list / home / desktop TopBar).
+      h2: "text-[22px] font-extrabold leading-tight md:text-[24px]",
+      // Section heading / large card title (LP Principle / Feature / Step).
+      h3: "text-[20px] font-extrabold leading-snug md:text-[22px]",
+      // Use-case card / sub-section heading.
+      h4: "text-lg font-extrabold leading-snug",
+      // ScreenHeader title / smaller in-card title.
+      h5: "text-[17px] font-bold leading-snug",
+      // Row title / EmptyState title / very-tight in-card heading.
+      h6: "text-[15px] font-bold leading-tight",
+      // Eyebrow / footer column heading — small bold caption that
+      // introduces a section. No implicit uppercase so JP copy renders
+      // naturally; add `uppercase` via className for English eyebrows.
+      eyebrow: "text-xs font-bold tracking-[0.04em] text-text-secondary",
+    },
+    tone: {
+      primary: "text-text-primary",
+      secondary: "text-text-secondary",
+      danger: "text-danger",
+    },
+  },
+  defaultVariants: {
+    variant: "h2",
+  },
+});
+
+type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+// Map a visual variant to a sensible default semantic level. Callers can
+// still override with `level` when the document outline needs to diverge
+// from the visual hierarchy.
+const defaultLevelForVariant: Record<
+  NonNullable<VariantProps<typeof headingVariants>["variant"]>,
+  HeadingLevel
+> = {
+  display: 1,
+  hero: 1,
+  h1: 1,
+  h2: 2,
+  h3: 3,
+  h4: 4,
+  h5: 5,
+  h6: 6,
+  eyebrow: 6,
+};
+
+interface HeadingProps
+  extends Omit<React.ComponentProps<"h2">, "color">,
+    VariantProps<typeof headingVariants> {
+  /** Semantic heading level for a11y. Defaults to the variant's natural level. */
+  level?: HeadingLevel;
+  /** Render via Radix Slot so the parent passes its own element. */
+  asChild?: boolean;
+}
+
+function Heading({
+  className,
+  variant,
+  tone,
+  level,
+  asChild = false,
+  ...props
+}: HeadingProps) {
+  const resolvedVariant = variant ?? "h2";
+  const resolvedLevel = level ?? defaultLevelForVariant[resolvedVariant];
+  const Comp = asChild
+    ? Slot.Root
+    : (`h${resolvedLevel}` as "h1" | "h2" | "h3" | "h4" | "h5" | "h6");
+
+  return (
+    <Comp
+      data-slot="heading"
+      data-variant={resolvedVariant}
+      className={cn(headingVariants({ variant, tone }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Heading, headingVariants };
+export type { HeadingProps, HeadingLevel };

--- a/pkgs/frontend/app/components/ui/typography.stories.tsx
+++ b/pkgs/frontend/app/components/ui/typography.stories.tsx
@@ -1,0 +1,61 @@
+import type { Story } from "@ladle/react";
+import { Typography } from "./typography";
+
+export default {
+  title: "UI / Typography",
+};
+
+export const Variants: Story = () => (
+  <div className="flex flex-col gap-4">
+    <Typography variant="display">
+      display — LP の強調パラグラフ。流動サイズ。
+    </Typography>
+    <Typography variant="lead">
+      lead — ランディングやページのイントロ本文。少し大きめのボディ。
+    </Typography>
+    <Typography variant="body">
+      body — 通常本文。標準的なボディサイズ（15px）。
+    </Typography>
+    <Typography variant="bodySm" tone="secondary">
+      bodySm — カード説明や補足本文。
+    </Typography>
+    <Typography variant="caption" tone="secondary">
+      caption — 1 行キャプション・メタ情報
+    </Typography>
+    <Typography variant="micro" tone="secondary">
+      micro — 最小ラベル
+    </Typography>
+    <Typography variant="label" as="span">
+      label
+    </Typography>
+    <Typography variant="mono" tone="secondary">
+      0x1234…abcd
+    </Typography>
+  </div>
+);
+
+export const Tones: Story = () => (
+  <div className="flex flex-col gap-2">
+    <Typography tone="primary">primary トーン</Typography>
+    <Typography tone="secondary">secondary トーン</Typography>
+    <Typography tone="danger">danger トーン</Typography>
+    <Typography tone="success">success トーン</Typography>
+  </div>
+);
+
+export const Weights: Story = () => (
+  <div className="flex flex-col gap-2">
+    <Typography weight="regular">regular ウェイト</Typography>
+    <Typography weight="medium">medium ウェイト</Typography>
+    <Typography weight="semibold">semibold ウェイト</Typography>
+    <Typography weight="bold">bold ウェイト</Typography>
+  </div>
+);
+
+export const Truncate: Story = () => (
+  <div className="max-w-[200px]">
+    <Typography truncate>
+      長いテキストは省略される — 0x1234567890abcdef1234567890abcdef12345678
+    </Typography>
+  </div>
+);

--- a/pkgs/frontend/app/components/ui/typography.tsx
+++ b/pkgs/frontend/app/components/ui/typography.tsx
@@ -1,0 +1,97 @@
+import { type VariantProps, cva } from "class-variance-authority";
+import { Slot } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "~/lib/utils";
+
+// Toban Typography primitive. Variant carries the full visual scale
+// (font size + line-height) so call sites never reach for `text-*`
+// Tailwind utilities. `tone` controls colour, `weight` lets a caller
+// bump weight without leaving the variant. Sizes were derived from the
+// renewed surfaces; the 14px / `text-sm` slot collapses into `bodySm`
+// (13px) on purpose — we don't want two adjacent compact-body variants.
+const typographyVariants = cva("", {
+  variants: {
+    variant: {
+      // LP marketing emphasis paragraph — fluid between body and h1.
+      display: "text-[clamp(22px,3.4vw,40px)] font-extrabold leading-[1.45]",
+      // Numeric stat display — wide (desktop) StatCard.
+      statLg: "text-[32px] font-extrabold leading-none tracking-tight",
+      // Numeric stat display — compact (mobile) StatCard.
+      statMd: "text-[26px] font-extrabold leading-none tracking-tight",
+      // LP / page intro body — slightly larger than `body`.
+      lead: "text-base font-medium leading-relaxed md:text-[17px]",
+      // Default running body copy.
+      body: "text-[15px] leading-relaxed",
+      // Compact body — card descriptions, secondary copy. Absorbs
+      // `text-sm` callers too.
+      bodySm: "text-[13px] leading-relaxed",
+      // One-liner caption / meta line.
+      caption: "text-xs leading-tight",
+      // Smallest readable size for counters / disclaimers.
+      micro: "text-[11px] leading-tight",
+      // Form-control / section label (compact bold caption).
+      label: "text-xs font-bold tracking-[0.03em] text-text-secondary",
+      // Mono-spaced address / hash.
+      mono: "font-mono text-[11px] leading-tight",
+    },
+    tone: {
+      primary: "text-text-primary",
+      secondary: "text-text-secondary",
+      muted: "text-text-secondary",
+      danger: "text-danger",
+      success: "text-[#2F8B58]",
+    },
+    weight: {
+      regular: "font-normal",
+      medium: "font-medium",
+      semibold: "font-semibold",
+      bold: "font-bold",
+    },
+    truncate: {
+      true: "truncate",
+    },
+  },
+  defaultVariants: {
+    variant: "body",
+    tone: "primary",
+  },
+});
+
+type TypographyElement = "p" | "span" | "div";
+
+interface TypographyProps
+  extends Omit<React.ComponentProps<"p">, "color">,
+    VariantProps<typeof typographyVariants> {
+  /** HTML element to render. Defaults to `p`. */
+  as?: TypographyElement;
+  /** Render via Radix Slot so the parent passes its own element. */
+  asChild?: boolean;
+}
+
+function Typography({
+  className,
+  variant,
+  tone,
+  weight,
+  truncate,
+  as = "p",
+  asChild = false,
+  ...props
+}: TypographyProps) {
+  const Comp = asChild ? Slot.Root : as;
+  return (
+    <Comp
+      data-slot="typography"
+      data-variant={variant ?? "body"}
+      className={cn(
+        typographyVariants({ variant, tone, weight, truncate }),
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Typography, typographyVariants };
+export type { TypographyProps };

--- a/pkgs/frontend/app/routes/_index.tsx
+++ b/pkgs/frontend/app/routes/_index.tsx
@@ -13,6 +13,8 @@ import {
 import { Link } from "react-router";
 
 import { Button } from "~/components/ui/button";
+import { Heading } from "~/components/ui/heading";
+import { Typography } from "~/components/ui/typography";
 
 // Brand quadrant colours — the four-tone identity from the Toban logo. Reused
 // across the LP for decorative accents (pills, feature cards, corner nodes).
@@ -197,15 +199,23 @@ function HeroCentered() {
       data-lp-root
       className="relative mx-auto max-w-[1200px] px-5 pt-14 pb-20 text-center md:px-7 md:pt-20 md:pb-28"
     >
-      <h1 className="mx-auto text-balance font-black leading-[1.3] tracking-tight text-text-primary text-[clamp(34px,7vw,62px)] md:max-w-4xl">
+      <Heading
+        variant="display"
+        level={1}
+        className="mx-auto text-balance leading-[1.3] md:max-w-4xl"
+      >
         <span style={{ color: ACCENT.orange }}>貢献してくれる人</span>に報いて、
         <br className="hidden sm:inline" />
         <span style={{ color: ACCENT.teal }}>長く続く活動</span>をつくる。
-      </h1>
-      <p className="mx-auto mt-6 max-w-2xl text-balance text-base font-medium leading-relaxed text-text-secondary md:text-[17px]">
+      </Heading>
+      <Typography
+        variant="lead"
+        tone="secondary"
+        className="mx-auto mt-6 max-w-2xl text-balance"
+      >
         みんなの貢献を記録し、報酬として届ける。Toban
         は、動いた人が正しく報われるコミュニティをブロックチェーンで支えるアプリです。
-      </p>
+      </Typography>
 
       <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
         <Link to="/login">
@@ -538,7 +548,7 @@ function PhilosophySection() {
         <SectionEyebrow color="var(--color-text-primary)">
           OUR PHILOSOPHY
         </SectionEyebrow>
-        <p className="text-balance font-extrabold leading-[1.45] tracking-tight text-text-primary text-[clamp(22px,3.4vw,40px)]">
+        <Typography variant="display" className="text-balance">
           コミュニティには、
           {/* hide sp */}
           <br className="hidden sm:inline" />
@@ -557,7 +567,7 @@ function PhilosophySection() {
             <span style={{ color: ACCENT.teal }}>やってくれた人を報いる</span>
           </Highlight>
           仕組みをつくります。
-        </p>
+        </Typography>
 
         <div className="mt-12 grid gap-8 border-t border-border pt-12 md:mt-14 md:grid-cols-3 md:pt-14">
           <Principle
@@ -604,10 +614,12 @@ function Principle({
       <div className="mb-3 text-[13px] font-bold tracking-[0.12em] text-text-secondary">
         PRINCIPLE {number}
       </div>
-      <h3 className="mb-3 text-xl font-extrabold tracking-tight text-text-primary md:text-[22px]">
+      <Heading variant="h3" className="mb-3">
         {title}
-      </h3>
-      <p className="text-sm leading-[1.7] text-text-secondary">{body}</p>
+      </Heading>
+      <Typography variant="bodySm" tone="secondary" className="leading-[1.7]">
+        {body}
+      </Typography>
     </div>
   );
 }
@@ -679,15 +691,19 @@ function FeaturesSection() {
       className="mx-auto max-w-[1200px] px-5 py-20 md:px-7 md:py-28"
     >
       <SectionEyebrow color={ACCENT.orange}>FEATURES</SectionEyebrow>
-      <h2 className="mb-4 text-balance font-black leading-[1.18] tracking-tight text-text-primary text-[clamp(28px,4vw,44px)]">
+      <Heading variant="h1" level={2} className="mb-4 text-balance">
         <span style={{ color: ACCENT.orange }}>ふたつの記録方法</span>
         を組み合わせて、
         <br className="hidden sm:inline" />
         <span style={{ color: ACCENT.teal }}>可視化と分配</span>をします
-      </h2>
-      <p className="mb-12 text-balance text-base text-text-secondary md:text-[17px]">
+      </Heading>
+      <Typography
+        variant="lead"
+        tone="secondary"
+        className="mb-12 text-balance"
+      >
         サンクストークンと当番クエスト、2つの方法で貢献を記録し、そのままブロックチェーンで可視化と分配につなげる。
-      </p>
+      </Typography>
 
       <FeatureGroup label="ふたつの記録方法">
         <div className="grid gap-5 sm:grid-cols-2">
@@ -766,14 +782,12 @@ function FeatureCard({
           >
             {label}
           </div>
-          <h3 className="text-[20px] font-extrabold leading-tight tracking-tight text-text-primary md:text-[22px]">
-            {title}
-          </h3>
+          <Heading variant="h3">{title}</Heading>
         </div>
       </div>
-      <p className="mb-4 text-[15px] leading-relaxed text-text-secondary">
+      <Typography variant="body" tone="secondary" className="mb-4">
         {desc}
-      </p>
+      </Typography>
       <ul className="m-0 flex flex-col gap-1.5 p-0 text-[13px] font-semibold text-text-primary">
         {items.map((it) => (
           <li key={it} className="flex items-center gap-2">
@@ -803,11 +817,11 @@ function StepsSection() {
     >
       <div className="mx-auto max-w-[1200px] px-5 py-20 md:px-7 md:py-28">
         <SectionEyebrow color={ACCENT.blue}>HOW IT WORKS</SectionEyebrow>
-        <h2 className="mb-4 text-balance font-black leading-[1.18] tracking-tight text-text-primary text-[clamp(28px,4vw,44px)]">
+        <Heading variant="h1" level={2} className="mb-4 text-balance">
           3ステップで、
           <br className="hidden sm:inline" />
           <span style={{ color: ACCENT.orange }}>循環</span>がはじまる。
-        </h2>
+        </Heading>
         <div className="grid gap-5 md:grid-cols-3">
           <Step
             number="01"
@@ -857,10 +871,12 @@ function Step({
       >
         STEP {number}
       </div>
-      <h3 className="mb-3 text-2xl font-black tracking-tight text-text-primary">
+      <Heading variant="h2" className="mb-3 font-black">
         <span style={{ color }}>{title}</span>
-      </h3>
-      <p className="m-0 text-sm text-text-secondary">{body}</p>
+      </Heading>
+      <Typography variant="bodySm" tone="secondary" className="m-0">
+        {body}
+      </Typography>
       <div className="mt-5 flex h-32 items-center justify-center overflow-hidden rounded-md bg-bg md:h-36">
         {visual}
       </div>
@@ -1061,14 +1077,18 @@ function UseCasesSection() {
       className="mx-auto max-w-[1200px] px-5 py-20 md:px-7 md:py-28"
     >
       <SectionEyebrow color={ACCENT.teal}>USE CASES</SectionEyebrow>
-      <h2 className="mb-4 text-balance font-black leading-[1.18] tracking-tight text-text-primary text-[clamp(28px,4vw,44px)]">
+      <Heading variant="h1" level={2} className="mb-4 text-balance">
         あらゆるコミュニティの
         <br className="hidden sm:inline" />
         <span style={{ color: ACCENT.orange }}>貢献が報われる</span>。
-      </h2>
-      <p className="mb-12 text-balance text-base text-text-secondary md:text-[17px]">
+      </Heading>
+      <Typography
+        variant="lead"
+        tone="secondary"
+        className="mb-12 text-balance"
+      >
         OSSコミュニティから地域の団体まで。Tobanはコミュニティの形に合わせて使えます。
-      </p>
+      </Typography>
       <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
         {CASES.map((c) => (
           <UseCaseCard key={c.title} {...c} />
@@ -1108,12 +1128,10 @@ function UseCaseCard({
         >
           {tag}
         </span>
-        <h4 className="text-lg font-extrabold leading-snug tracking-tight text-text-primary">
-          {title}
-        </h4>
-        <p className="text-[13px] leading-relaxed text-text-secondary">
+        <Heading variant="h4">{title}</Heading>
+        <Typography variant="bodySm" tone="secondary">
           {body}
-        </p>
+        </Typography>
       </div>
     </div>
   );
@@ -1133,9 +1151,13 @@ function SiteFooter() {
             <BrandMark className="h-8 w-8" />
             Toban
           </Link>
-          <p className="mt-3 mb-5 max-w-xs text-[13px] text-text-secondary">
+          <Typography
+            variant="bodySm"
+            tone="secondary"
+            className="mt-3 mb-5 max-w-xs"
+          >
             貢献してくれる人に報いて、長く続く活動をつくる。
-          </p>
+          </Typography>
           <div className="flex gap-2.5">
             <SocialLink href={FOOTER_LINKS.github} label="GitHub">
               <LuGithub size={16} aria-hidden />
@@ -1206,9 +1228,13 @@ function FooterColumn({
 }) {
   return (
     <div>
-      <h5 className="mb-3 text-[12px] font-extrabold tracking-[0.12em] text-text-secondary uppercase">
+      <Heading
+        variant="eyebrow"
+        level={5}
+        className="mb-3 tracking-[0.12em] uppercase"
+      >
         {title}
-      </h5>
+      </Heading>
       <ul className="m-0 flex list-none flex-col gap-2.5 p-0">
         {links.map((link) => {
           const linkClassName =

--- a/pkgs/frontend/app/routes/login.tsx
+++ b/pkgs/frontend/app/routes/login.tsx
@@ -8,6 +8,7 @@ import { AuthLayout } from "~/components/layout/AuthLayout";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
 import { Icon } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
 
 const Login: FC = () => {
   const navigate = useNavigate();
@@ -89,18 +90,30 @@ const Login: FC = () => {
                 <Icon name="mail" size={18} />
                 メール / SNS で続ける
               </Button>
-              <p className="mt-1 text-center text-xs text-text-secondary">
+              <Typography
+                variant="caption"
+                tone="secondary"
+                className="mt-1 text-center"
+              >
                 Privy が安全なウォレットを自動で作成します
-              </p>
+              </Typography>
             </>
           ) : (
             <>
-              <p className="text-center text-sm font-bold text-text-primary">
+              <Typography
+                variant="bodySm"
+                weight="bold"
+                className="text-center"
+              >
                 ウォレットに接続しています
-              </p>
-              <p className="text-center text-xs text-text-secondary">
+              </Typography>
+              <Typography
+                variant="caption"
+                tone="secondary"
+                className="text-center"
+              >
                 自動でワークスペースに移動します。問題が起きた場合はサインアウトしてやり直してください。
-              </p>
+              </Typography>
               <Button
                 variant="secondary"
                 size="lg"

--- a/pkgs/frontend/app/routes/workspace._index.tsx
+++ b/pkgs/frontend/app/routes/workspace._index.tsx
@@ -16,8 +16,10 @@ import { SectionLabel } from "~/components/composite/section-label";
 import { WorkspaceCard } from "~/components/composite/workspace-card";
 import { PageContainer } from "~/components/layout/PageContainer";
 import { Button } from "~/components/ui/button";
+import { Heading } from "~/components/ui/heading";
 import { Icon } from "~/components/ui/icon";
 import { Input } from "~/components/ui/input";
+import { Typography } from "~/components/ui/typography";
 import { useWorkspaceStore } from "~/stores/workspace";
 
 type Workspace = {
@@ -185,13 +187,13 @@ const Workspace: FC = () => {
       {/* Greeting + page title — mirrors `screens.jsx:1149-1152`. */}
       <header className="px-1">
         {greetingName && (
-          <p className="text-[13px] text-text-secondary">
+          <Typography variant="bodySm" tone="secondary">
             こんにちは、{greetingName} さん
-          </p>
+          </Typography>
         )}
-        <h1 className="mt-0.5 text-2xl font-extrabold tracking-tight text-text-primary">
+        <Heading variant="h2" level={1} className="mt-0.5">
           ワークスペース
-        </h1>
+        </Heading>
       </header>
 
       <Input


### PR DESCRIPTION
## Summary

- Add `Heading` and `Typography` primitives under `app/components/ui/` (with Ladle stories) so every renewed surface declares font size via a variant instead of inline `text-[…]` classes.
- Route every `<h*>` / `<p>` in the renewed `composite/`, `layout/`, and routes (`_index`, `login`, `signup` via `AuthHero`, `workspace._index`, `workspace.new` via `AuthHero` / shared components) through the new primitives. Font-size Tailwind classes on the migrated call sites are gone.

Closes #491.

## Notes

- The home page (`$treeId._index.tsx`) is currently still the old Chakra version on `main`; the renewed copy is WIP on #433 and will pick up these primitives as part of that PR. Everything else in scope of #491 is covered here.
- Variant scale was derived from the renewed surfaces (handoff + actual usage). Adjacent sizes are intentionally consolidated (e.g. `text-sm` 14px collapses into `bodySm` 13px) — that's the point.
- Lefthook (biome + frontend typecheck) is green; only pre-existing warning is the unused suppression in `field.tsx` from #426.

## Test plan

- [ ] Browse Ladle: confirm `UI / Heading` and `UI / Typography` stories render the full variant ladder.
- [ ] `pnpm frontend dev` and visually verify landing (`/`), login (`/login`), signup (`/signup`), workspace list (`/workspace`), workspace create (`/workspace/new`) — copy hierarchy should be unchanged.
- [ ] Spot-check composite Ladle stories (Row, EmptyState, StatCard, SummaryRow, ToggleRow, WeightBar, WorkspaceCard, SectionLabel, FieldLabel).
- [ ] Confirm `AppHeader`, `ScreenHeader`, `TopBar`, `Sidebar`, `AccountMenu`, `WorkspaceSwitcherMenu` render correctly across mobile + desktop breakpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)