### PR TITLE
feat(frontend): renew workspace home with design system (#433)

### DIFF
--- a/pkgs/frontend/CLAUDE.md
+++ b/pkgs/frontend/CLAUDE.md
@@ -19,7 +19,7 @@ Guidance for the Toban web app. The repo-root `CLAUDE.md` covers monorepo-wide c
 
 `app/components/ui/`, `app/components/composite/`, and `app/components/layout/` together **are** the design system. Routes/pages should be assembled from these — do not introduce new ad-hoc layout/typography/styling at the page level.
 
-- **`app/components/ui/`** — shadcn-vendored primitives (`new-york` style): `button`, `card`, `dialog`, `dropdown-menu`, `input`, `textarea`, `tabs`, `sheet`, `popover`, `tooltip`, `avatar`, `badge`, `checkbox`, `switch`, `radio-group`, `skeleton`, `sonner`, `field`, `label`, `menu`, `icon`. These are the lowest level — keep them close to upstream shadcn so future updates merge cleanly. Edit only when a token/variant change is needed; otherwise build *on top* in `composite/`.
+- **`app/components/ui/`** — shadcn-vendored primitives (`new-york` style): `button`, `card`, `dialog`, `dropdown-menu`, `input`, `textarea`, `tabs`, `sheet`, `popover`, `tooltip`, `avatar`, `badge`, `checkbox`, `switch`, `radio-group`, `skeleton`, `sonner`, `field`, `label`, `menu`, `icon`, plus the Toban-specific `heading` and `typography` (see Typography section below). These are the lowest level — keep them close to upstream shadcn so future updates merge cleanly. Edit only when a token/variant change is needed; otherwise build *on top* in `composite/`.
 - **`app/components/composite/`** — Toban-specific patterns built from primitives: `chip`, `divider`, `empty-state`, `field-label`, `row`, `section-label`, `segmented`, `stat-card`, `step-bar`, `summary-row`, `toggle-row`, `weight-bar`. Use these for any list-row / form-row / status-card shape that already exists.
 - **`app/components/layout/`** — page chrome: `AppShell`, `AppHeader`, `TopBar`, `BottomNav`, `Sidebar`, `PageContainer`, `ScreenHeader`, `MasterDetailLayout`. Routes should wrap their content in these instead of hand-rolling headers/containers.
 
@@ -32,6 +32,17 @@ Workflow when building a route:
 5. Every new `ui/` or `composite/` component ships with a `*.stories.tsx` next to it (Ladle previews them).
 
 Domain components (`app/components/{assistcredit,roles,splits,thankstoken,...}/`) are allowed to compose `composite/` + `ui/` for feature-specific UIs; they are **not** the design system and should not be reached for from unrelated features.
+
+## Typography — `Heading` and `Typography` primitives
+
+All headings and running text on renewed surfaces go through `app/components/ui/heading.tsx` and `app/components/ui/typography.tsx` (issue #491). **Don't reach for `text-*` / `font-*` / `tracking-*` / `leading-*` Tailwind utilities on `<h*>`/`<p>`/`<span>`/`<div>` text nodes** — pick the right `variant` instead. The variants exist so the type scale lives in one place and trivially follows token changes in `globals.css`.
+
+- `Heading variant="…"` for headings. Variant carries the full visual scale; `level={1..6}` controls the semantic element. Variants: `display` (LP hero), `hero` (auth hero), `h1` (LP section title), `h2` (app page title), `h3` (section / card title), `h4` / `h5` / `h6` (progressively tighter card-internal titles), `eyebrow` (small-caps section caption). Decouple visual size from semantic level when needed: `<Heading variant="h2" level={1}>` for a page title that's visually h2 but the page's H1 in document outline.
+- `Typography variant="…"` for body / caption / numeric stat text. Variants: `display`, `statLg` / `statMd` (numeric stat displays), `lead`, `body`, `bodySm`, `caption`, `micro`, `label`, `mono`. Use `tone` (`primary` / `secondary` / `muted` / `danger` / `success`) for colour, `weight` to bump weight without leaving the variant, `truncate` for single-line ellipsis, and `as` (`p` / `span` / `div`) when the default `<p>` is wrong (e.g. inline copy).
+- The 13 px and 14 px sizes collapse into `bodySm` on purpose — don't reintroduce a near-duplicate adjacent slot.
+- Need a one-off literal px (40 px / 56 px hero numeric on the home screen, for instance)? Compose `variant="statLg"` with a `className="text-[40px]"` override so the call site still declares "this is a stat display" rather than re-deriving the full scale.
+- When wrapping a `<Link>` so it inherits Typography styles, use `<Typography asChild as="span" variant="caption" tone="secondary"><Link …/></Typography>` — Radix `Slot.Root` passes the classes onto the link.
+- Composite-level wrappers (`SectionLabel`, `FieldLabel`, etc.) already consume Typography internally; reach for those when the role is named ("section label"). Reach for the raw primitive when no composite fits.
 
 ## Icons — react-icons only
 

--- a/pkgs/frontend/app/components/composite/stat-card.tsx
+++ b/pkgs/frontend/app/components/composite/stat-card.tsx
@@ -14,6 +14,8 @@ interface StatCardProps extends React.ComponentProps<typeof Card> {
   delta?: React.ReactNode;
   /** "compact" matches the mobile spec; "wide" matches the desktop spec. */
   size?: "compact" | "wide";
+  /** Override className for the numeric value Typography (e.g. step the size down). */
+  valueClassName?: string;
 }
 
 // Toban StatCard — label + large numeric value + unit, with an optional
@@ -26,6 +28,7 @@ function StatCard({
   accent,
   delta,
   size = "compact",
+  valueClassName,
   className,
   ...rest
 }: StatCardProps) {
@@ -58,6 +61,7 @@ function StatCard({
         <Typography
           as="span"
           variant={isWide ? "statLg" : "statMd"}
+          className={valueClassName}
           style={accent ? { color: accent } : undefined}
         >
           {value}

--- a/pkgs/frontend/app/components/layout/AppHeader.stories.tsx
+++ b/pkgs/frontend/app/components/layout/AppHeader.stories.tsx
@@ -11,12 +11,6 @@ export const Default: Story = () => (
   </div>
 );
 
-export const WithNotifications: Story = () => (
-  <div className="w-[420px] border-b bg-bg">
-    <AppHeader workspaceName="ひがしのシェアハウス" hasNotifications />
-  </div>
-);
-
 export const LongName: Story = () => (
   <div className="w-[420px] border-b bg-bg">
     <AppHeader workspaceName="ふじのもり・季節のあつまり 2026 春の章" />

--- a/pkgs/frontend/app/components/layout/AppHeader.tsx
+++ b/pkgs/frontend/app/components/layout/AppHeader.tsx
@@ -1,7 +1,6 @@
 import type * as React from "react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
-import { Button } from "~/components/ui/button";
 import { Icon } from "~/components/ui/icon";
 import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
@@ -13,22 +12,16 @@ interface AppHeaderProps extends React.ComponentProps<"header"> {
   workspaceImageUrl?: string;
   /** Called when the user taps the workspace pill (open the switcher Sheet). */
   onWorkspacePress?: () => void;
-  /** Show a small dot on the bell icon. */
-  hasNotifications?: boolean;
-  /** Called when the user taps the bell. */
-  onNotificationsPress?: () => void;
   /** Optional trailing slot (extra icon buttons / user avatar dropdown). */
   right?: React.ReactNode;
 }
 
-// Toban mobile AppHeader — workspace switcher pill + notification bell.
+// Toban mobile AppHeader — workspace switcher pill plus a trailing slot.
 // Mirrors `docs/design/handoff/project/screens.jsx:91-117`.
 function AppHeader({
   workspaceName,
   workspaceImageUrl,
   onWorkspacePress,
-  hasNotifications,
-  onNotificationsPress,
   right,
   className,
   ...rest
@@ -61,18 +54,6 @@ function AppHeader({
         </Typography>
         <Icon name="chevron-down" size={16} className="text-text-secondary" />
       </button>
-      <Button
-        size="icon"
-        variant="secondary"
-        aria-label="通知"
-        onClick={onNotificationsPress}
-        className="relative size-10"
-      >
-        <Icon name="bell" size={20} />
-        {hasNotifications && (
-          <span className="absolute top-1.5 right-1.5 size-2 rounded-full border-2 border-surface bg-danger" />
-        )}
-      </Button>
       {right}
     </header>
   );

--- a/pkgs/frontend/app/components/layout/AppShell.stories.tsx
+++ b/pkgs/frontend/app/components/layout/AppShell.stories.tsx
@@ -17,11 +17,6 @@ export default {
   title: "Layout / AppShell",
 };
 
-const SAMPLE_USER = {
-  name: "ryoma",
-  subtitle: "0xab12...c45f",
-};
-
 const sampleHomeContent = (
   <PageContainer className="py-4 md:py-6">
     <SectionLabel>あなたの当番</SectionLabel>
@@ -47,24 +42,6 @@ export const Responsive: Story = () => {
         workspace={{ name: "ひがしのシェアハウス" }}
         active={active}
         onNavigate={setActive}
-        hasNotifications
-        user={SAMPLE_USER}
-        topBar={{
-          title:
-            {
-              home: "ホーム",
-              duties: "当番",
-              splits: "分配",
-              members: "メンバー",
-              wallet: "ウォレット",
-            }[active] ?? "Toban",
-          subtitle: "Phase 2-3 デモ",
-          searchPlaceholder: "メンバーを検索",
-          primaryAction: {
-            label: "サンクスを送る",
-            icon: <Icon name="send" size={14} />,
-          },
-        }}
       >
         <div className="min-h-[480px]">{sampleHomeContent}</div>
       </AppShell>
@@ -82,14 +59,6 @@ export const WithWorkspaceSwitcher: Story = () => {
         active={active}
         onNavigate={setActive}
         onWorkspacePress={() => setOpen(true)}
-        user={SAMPLE_USER}
-        topBar={{
-          title: "ホーム",
-          primaryAction: {
-            label: "サンクスを送る",
-            icon: <Icon name="send" size={14} />,
-          },
-        }}
       >
         <div className="min-h-[480px]">{sampleHomeContent}</div>
       </AppShell>

--- a/pkgs/frontend/app/components/layout/AppShell.tsx
+++ b/pkgs/frontend/app/components/layout/AppShell.tsx
@@ -3,8 +3,7 @@ import type * as React from "react";
 import { cn } from "~/lib/utils";
 import { AppHeader, type AppHeaderProps } from "./AppHeader";
 import { BottomNav, type BottomNavProps } from "./BottomNav";
-import { Sidebar, type SidebarProps } from "./Sidebar";
-import { TopBar, type TopBarProps } from "./TopBar";
+import { Sidebar } from "./Sidebar";
 
 interface AppShellProps extends React.ComponentProps<"div"> {
   /** Workspace metadata shared between AppHeader (mobile) and Sidebar (desktop). */
@@ -18,23 +17,14 @@ interface AppShellProps extends React.ComponentProps<"div"> {
   onNavigate: (key: string) => void;
   /** Called when the user opens the workspace switcher (Sheet/Popover). */
   onWorkspacePress?: () => void;
-  /** TopBar / AppHeader shared inputs. */
-  hasNotifications?: boolean;
-  onNotificationsPress?: () => void;
-  /** Sidebar user footer. */
-  user?: SidebarProps["user"];
-  /** Per-page TopBar inputs. Title is required to render the desktop TopBar. */
-  topBar?: Omit<TopBarProps, "onNotificationsPress" | "hasNotifications">;
   /** Trailing slot for the AppHeader (e.g. the legacy account dropdown). */
   appHeaderRight?: AppHeaderProps["right"];
   /** Optional override of the BottomNav items list. */
   navItems?: BottomNavProps["items"];
-  /** When true, the desktop main column drops the TopBar (master-detail pages). */
-  hideTopBar?: boolean;
 }
 
 // Responsive shell — switches between mobile (AppHeader + BottomNav) and
-// desktop (Sidebar + TopBar) at the `md:` breakpoint. The desktop sidebar
+// desktop (Sidebar only) at the `md:` breakpoint. The desktop sidebar
 // is built with `hidden md:flex`, so we render both sets and let CSS pick;
 // no JS media-query is needed and SSR stays consistent.
 function AppShell({
@@ -42,13 +32,8 @@ function AppShell({
   active,
   onNavigate,
   onWorkspacePress,
-  hasNotifications,
-  onNotificationsPress,
-  user,
-  topBar,
   appHeaderRight,
   navItems,
-  hideTopBar,
   className,
   children,
   ...rest
@@ -56,7 +41,10 @@ function AppShell({
   return (
     <div
       data-slot="app-shell"
-      className={cn("flex min-h-dvh flex-col md:flex-row", className)}
+      className={cn(
+        "flex h-dvh flex-col overflow-hidden md:flex-row",
+        className,
+      )}
       {...rest}
     >
       {/* Desktop: persistent sidebar (hidden under md). */}
@@ -67,33 +55,22 @@ function AppShell({
         active={active}
         onNavigate={onNavigate}
         items={navItems}
-        user={user}
       />
 
       {/* Mobile: header at top, bottom nav at bottom. */}
-      <div className="flex min-w-0 flex-1 flex-col">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
         <div className="md:hidden">
           <AppHeader
             workspaceName={workspace.name}
             workspaceImageUrl={workspace.imageUrl}
             onWorkspacePress={onWorkspacePress}
-            hasNotifications={hasNotifications}
-            onNotificationsPress={onNotificationsPress}
             right={appHeaderRight}
           />
         </div>
 
-        {!hideTopBar && topBar && (
-          <div className="hidden md:block">
-            <TopBar
-              {...topBar}
-              hasNotifications={hasNotifications}
-              onNotificationsPress={onNotificationsPress}
-            />
-          </div>
-        )}
-
-        <main className="flex-1 overflow-x-hidden">{children}</main>
+        <main className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
+          {children}
+        </main>
 
         <div className="md:hidden">
           <BottomNav active={active} onChange={onNavigate} items={navItems} />

--- a/pkgs/frontend/app/components/layout/AppShellLayout.tsx
+++ b/pkgs/frontend/app/components/layout/AppShellLayout.tsx
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { useActiveWalletIdentity } from "hooks/useENS";
 import { useTreeInfo } from "hooks/useHats";
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -11,25 +10,16 @@ import {
 } from "react-router";
 import type { HatsDetailSchama } from "types/hats";
 import { ipfs2https } from "utils/ipfs";
-import { abbreviateAddress } from "utils/wallet";
 import { AccountMenu } from "./AccountMenu";
 import { AppShell } from "./AppShell";
 import { WorkspaceSwitcherMenu } from "./WorkspaceSwitcherMenu";
 
-// Per-route TopBar inputs are declared via React Router v7's `handle` export.
-// Pages opt in by exporting `export const handle: AppShellHandle = { ... }`.
+// Per-route AppShell inputs are declared via React Router v7's `handle`
+// export. Pages opt in by exporting `export const handle: AppShellHandle = {…}`.
 // The wrapper reads the deepest match's handle so nested routes win.
 interface AppShellHandle {
   /** Bottom-nav / Sidebar active key (`home` / `duties` / `splits` / ...). */
   active?: string;
-  /** Per-page TopBar title (desktop). Falls back to the workspace name. */
-  topBarTitle?: React.ReactNode;
-  /** Per-page TopBar subtitle (desktop). */
-  topBarSubtitle?: React.ReactNode;
-  /** Optional search pill placeholder. Hides search if undefined. */
-  topBarSearchPlaceholder?: string;
-  /** Skip the desktop TopBar entirely (master-detail pages). */
-  hideTopBar?: boolean;
 }
 
 // Only the `/{treeId}/...` routes get wrapped with AppShell. These segments
@@ -78,7 +68,6 @@ function ShellView({ treeId }: ShellViewProps) {
   const location = useLocation();
   const matches = useMatches();
   const treeInfo = useTreeInfo(Number(treeId));
-  const { identity } = useActiveWalletIdentity();
   const [workspaceName, setWorkspaceName] = useState<string>();
   const [switcherOpen, setSwitcherOpen] = useState(false);
 
@@ -147,19 +136,6 @@ function ShellView({ treeId }: ShellViewProps) {
     }
   };
 
-  const userName = identity?.name ?? identity?.address;
-  const user = userName
-    ? {
-        name: userName,
-        subtitle: identity?.address
-          ? abbreviateAddress(identity.address)
-          : undefined,
-        imageUrl: identity?.text_records?.avatar
-          ? ipfs2https(identity.text_records.avatar)
-          : undefined,
-      }
-    : undefined;
-
   const displayWorkspaceName = workspaceName ?? "Toban";
 
   return (
@@ -172,14 +148,7 @@ function ShellView({ treeId }: ShellViewProps) {
         active={active}
         onNavigate={handleNavigate}
         onWorkspacePress={() => setSwitcherOpen(true)}
-        user={user}
-        topBar={{
-          title: handle.topBarTitle ?? displayWorkspaceName,
-          subtitle: handle.topBarSubtitle,
-          searchPlaceholder: handle.topBarSearchPlaceholder,
-        }}
         appHeaderRight={<AccountMenu variant="compact" />}
-        hideTopBar={handle.hideTopBar}
       >
         <Outlet />
       </AppShell>

--- a/pkgs/frontend/app/components/layout/Sidebar.stories.tsx
+++ b/pkgs/frontend/app/components/layout/Sidebar.stories.tsx
@@ -6,6 +6,9 @@ export default {
   title: "Layout / Sidebar",
 };
 
+// The Sidebar's account header is driven by `AccountMenu`, which reads
+// Privy + ENS at runtime — Ladle previews fall back to the Login-button
+// state. Behavioural verification lives in the Cypress E2E suite.
 export const Default: Story = () => {
   const [active, setActive] = useState("home");
   return (
@@ -17,10 +20,6 @@ export const Default: Story = () => {
         workspaceName="ひがしのシェアハウス"
         active={active}
         onNavigate={setActive}
-        user={{
-          name: "ryoma",
-          subtitle: "0xab12...c45f",
-        }}
       />
       <div className="flex flex-1 items-center justify-center text-sm text-text-secondary">
         現在: {active}
@@ -28,16 +27,3 @@ export const Default: Story = () => {
     </div>
   );
 };
-
-export const WithoutUser: Story = () => (
-  <div className="flex h-[480px] overflow-hidden rounded-md border bg-surface">
-    <Sidebar
-      workspaceName="新規ワークスペース"
-      active="home"
-      onNavigate={() => {}}
-    />
-    <div className="flex flex-1 items-center justify-center text-sm text-text-secondary">
-      ユーザー情報なし
-    </div>
-  </div>
-);

--- a/pkgs/frontend/app/components/layout/Sidebar.tsx
+++ b/pkgs/frontend/app/components/layout/Sidebar.tsx
@@ -1,18 +1,11 @@
 import type * as React from "react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
-import { Button } from "~/components/ui/button";
 import { Icon } from "~/components/ui/icon";
 import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
+import { AccountMenu } from "./AccountMenu";
 import { type BottomNavItem, DEFAULT_BOTTOM_NAV_ITEMS } from "./BottomNav";
-
-interface SidebarUser {
-  name: string;
-  /** Wallet address or short identifier shown under the name. */
-  subtitle?: string;
-  imageUrl?: string;
-}
 
 interface SidebarProps extends React.ComponentProps<"aside"> {
   workspaceName: string;
@@ -21,12 +14,10 @@ interface SidebarProps extends React.ComponentProps<"aside"> {
   active: string;
   onNavigate: (key: string) => void;
   items?: ReadonlyArray<BottomNavItem>;
-  user?: SidebarUser;
-  onSettingsPress?: () => void;
 }
 
-// Toban desktop Sidebar — 260 px column with brand mark, workspace
-// switcher, primary nav, and a user footer.
+// Toban desktop Sidebar — 260 px column with account header (or Login
+// button when signed-out), workspace switcher, and primary nav.
 // Mirrors `docs/design/handoff/project/desktop.jsx:56-125`.
 function Sidebar({
   workspaceName,
@@ -35,8 +26,6 @@ function Sidebar({
   active,
   onNavigate,
   items = DEFAULT_BOTTOM_NAV_ITEMS,
-  user,
-  onSettingsPress,
   className,
   ...rest
 }: SidebarProps) {
@@ -49,23 +38,8 @@ function Sidebar({
       )}
       {...rest}
     >
-      <div className="flex items-center gap-2.5 border-b px-4 pt-5 pb-3.5">
-        <span className="inline-flex size-8 items-center justify-center rounded-md bg-text-primary text-base font-extrabold text-[#FFD668]">
-          と
-        </span>
-        <div>
-          <Typography
-            as="div"
-            variant="body"
-            weight="bold"
-            className="leading-tight"
-          >
-            Toban
-          </Typography>
-          <Typography as="div" variant="micro" tone="secondary">
-            あたたかい当番帳
-          </Typography>
-        </div>
+      <div className="border-b p-3">
+        <AccountMenu variant="inline" className="w-full px-3 py-2.5" />
       </div>
 
       <button
@@ -122,40 +96,9 @@ function Sidebar({
           );
         })}
       </nav>
-
-      {user && (
-        <div className="mt-auto border-t p-3">
-          <div className="flex items-center gap-2.5">
-            <Avatar>
-              {user.imageUrl && (
-                <AvatarImage src={user.imageUrl} alt={user.name} />
-              )}
-              <AvatarFallback seed={user.name} />
-            </Avatar>
-            <div className="min-w-0 flex-1">
-              <Typography as="div" variant="bodySm" weight="bold" truncate>
-                {user.name}
-              </Typography>
-              {user.subtitle && (
-                <Typography as="div" variant="mono" tone="secondary" truncate>
-                  {user.subtitle}
-                </Typography>
-              )}
-            </div>
-            <Button
-              size="icon-sm"
-              variant="ghost"
-              aria-label="設定"
-              onClick={onSettingsPress}
-            >
-              <Icon name="gear" size={16} />
-            </Button>
-          </div>
-        </div>
-      )}
     </aside>
   );
 }
 
 export { Sidebar };
-export type { SidebarProps, SidebarUser };
+export type { SidebarProps };

--- a/pkgs/frontend/app/components/layout/TopBar.stories.tsx
+++ b/pkgs/frontend/app/components/layout/TopBar.stories.tsx
@@ -12,7 +12,6 @@ export const Default: Story = () => (
     <TopBar
       title="ホーム"
       subtitle="今週の活動"
-      hasNotifications
       primaryAction={{
         label: "サンクスを送る",
         icon: <Icon name="send" size={14} />,

--- a/pkgs/frontend/app/components/layout/TopBar.tsx
+++ b/pkgs/frontend/app/components/layout/TopBar.tsx
@@ -7,14 +7,12 @@ import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 interface TopBarProps extends Omit<React.ComponentProps<"header">, "title"> {
-  title: React.ReactNode;
+  title?: React.ReactNode;
   subtitle?: React.ReactNode;
   /** Optional placeholder for the search pill. Hides search if undefined. */
   searchPlaceholder?: string;
   searchValue?: string;
   onSearchChange?: (next: string) => void;
-  onNotificationsPress?: () => void;
-  hasNotifications?: boolean;
   /** Trailing slot before the primary CTA. */
   right?: React.ReactNode;
   /** Primary CTA — e.g. "サンクスを送る". Hidden when omitted. */
@@ -25,7 +23,7 @@ interface TopBarProps extends Omit<React.ComponentProps<"header">, "title"> {
   };
 }
 
-// Toban desktop TopBar — page title, search pill, bell and a primary CTA.
+// Toban desktop TopBar — page title (optional), search pill, and a primary CTA.
 // Mirrors `docs/design/handoff/project/desktop.jsx:134-155`.
 function TopBar({
   title,
@@ -33,8 +31,6 @@ function TopBar({
   searchPlaceholder,
   searchValue,
   onSearchChange,
-  onNotificationsPress,
-  hasNotifications,
   right,
   primaryAction,
   className,
@@ -50,9 +46,11 @@ function TopBar({
       {...rest}
     >
       <div className="min-w-0 flex-1">
-        <Heading variant="h2" className="truncate">
-          {title}
-        </Heading>
+        {title && (
+          <Heading variant="h2" className="truncate">
+            {title}
+          </Heading>
+        )}
         {subtitle && (
           <Typography
             variant="caption"
@@ -76,18 +74,6 @@ function TopBar({
           />
         </div>
       )}
-      <Button
-        size="icon"
-        variant="ghost"
-        aria-label="通知"
-        onClick={onNotificationsPress}
-        className="relative size-10"
-      >
-        <Icon name="bell" size={18} className="text-text-secondary" />
-        {hasNotifications && (
-          <span className="absolute top-2 right-2 size-2 rounded-full border-2 border-surface bg-danger" />
-        )}
-      </Button>
       {right}
       {primaryAction && (
         <Button onClick={primaryAction.onClick}>

--- a/pkgs/frontend/app/components/layout/WorkspaceSwitcherMenu.tsx
+++ b/pkgs/frontend/app/components/layout/WorkspaceSwitcherMenu.tsx
@@ -1,4 +1,4 @@
-import type * as React from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Row } from "~/components/composite/row";
 import { Icon } from "~/components/ui/icon";
@@ -31,11 +31,14 @@ interface WorkspaceSwitcherMenuProps {
 }
 
 // Toban Workspace Switcher menu.
-// - Mobile (`md:hidden`): bottom Sheet anchored to the AppHeader pill.
-// - Desktop (`hidden md:block`): Popover anchored near the Sidebar workspace
-//   button via a `PopoverAnchor` positioned at the top-left of the viewport
-//   (matches the design source `desktop.jsx:72-101`).
+// - Mobile (`<md`): bottom Sheet anchored to the AppHeader pill.
+// - Desktop (`>=md`): Popover anchored near the Sidebar workspace button via
+//   a `PopoverAnchor` positioned at the top-left of the viewport (matches the
+//   design source `desktop.jsx:72-101`).
 // Both surfaces render the same three actions (switch / invite / settings).
+// Only one primitive is mounted per viewport — both Popover and Sheet portal
+// to the body, so a CSS-only `md:hidden` gate would let both open at once
+// and their focus traps would fight (the Sheet flashed shut).
 function WorkspaceSwitcherMenu({
   open,
   onOpenChange,
@@ -44,6 +47,16 @@ function WorkspaceSwitcherMenu({
   onOpenSettings,
   inviteLink,
 }: WorkspaceSwitcherMenuProps) {
+  const [isDesktop, setIsDesktop] = useState<boolean | null>(null);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mq = window.matchMedia("(min-width: 768px)");
+    setIsDesktop(mq.matches);
+    const onChange = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
   const handleInvite = async () => {
     const link =
       inviteLink ?? (typeof window !== "undefined" ? window.location.href : "");
@@ -65,7 +78,7 @@ function WorkspaceSwitcherMenu({
     onOpenChange(false);
   };
 
-  const items: React.ReactNode = (
+  const items: ReactNode = (
     <div className="flex flex-col">
       <Row
         left={<Icon name="members" />}
@@ -94,52 +107,53 @@ function WorkspaceSwitcherMenu({
     </div>
   );
 
-  return (
-    <>
-      {/* Desktop — Popover anchored to a fixed point near the Sidebar's
-          workspace button. The anchor is rendered as a 1x1 invisible div so
-          Radix has something to position against without us having to thread
-          a ref through the Sidebar primitive. */}
-      <div className="hidden md:block">
-        <Popover open={open} onOpenChange={onOpenChange}>
-          <PopoverAnchor asChild>
-            <div
-              aria-hidden
-              className="pointer-events-none fixed top-[88px] left-[260px] size-px"
-            />
-          </PopoverAnchor>
-          <PopoverContent
-            align="start"
-            side="right"
-            sideOffset={8}
-            className="w-[280px] p-0"
-          >
-            <Typography
-              as="div"
-              variant="bodySm"
-              weight="bold"
-              truncate
-              className="border-b px-4 py-3"
-            >
-              {workspaceName}
-            </Typography>
-            {items}
-          </PopoverContent>
-        </Popover>
-      </div>
+  // First paint (SSR + pre-effect client render): render nothing. The menu is
+  // only meaningful once the user opens it — by then `isDesktop` is resolved.
+  if (isDesktop === null) return null;
 
-      {/* Mobile — bottom Sheet. */}
-      <div className="md:hidden">
-        <Sheet open={open} onOpenChange={onOpenChange}>
-          <SheetContent side="bottom">
-            <SheetHeader>
-              <SheetTitle>{workspaceName}</SheetTitle>
-            </SheetHeader>
-            <div className="px-1 pb-2">{items}</div>
-          </SheetContent>
-        </Sheet>
-      </div>
-    </>
+  if (isDesktop) {
+    return (
+      // Desktop — Popover anchored to a fixed point near the Sidebar's
+      // workspace button. The anchor is a 1x1 invisible div so Radix has
+      // something to position against without threading a ref through the
+      // Sidebar primitive.
+      <Popover open={open} onOpenChange={onOpenChange}>
+        <PopoverAnchor asChild>
+          <div
+            aria-hidden
+            className="pointer-events-none fixed top-[88px] left-[260px] size-px"
+          />
+        </PopoverAnchor>
+        <PopoverContent
+          align="start"
+          side="right"
+          sideOffset={8}
+          className="w-[280px] p-0"
+        >
+          <Typography
+            as="div"
+            variant="bodySm"
+            weight="bold"
+            truncate
+            className="border-b px-4 py-3"
+          >
+            {workspaceName}
+          </Typography>
+          {items}
+        </PopoverContent>
+      </Popover>
+    );
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom">
+        <SheetHeader>
+          <SheetTitle>{workspaceName}</SheetTitle>
+        </SheetHeader>
+        <div className="px-1 pb-2">{items}</div>
+      </SheetContent>
+    </Sheet>
   );
 }
 

--- a/pkgs/frontend/app/components/ui/sheet.tsx
+++ b/pkgs/frontend/app/components/ui/sheet.tsx
@@ -86,7 +86,7 @@ function SheetContent({
           side === "top" &&
             "inset-x-0 top-0 h-auto rounded-b-md border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
           side === "bottom" &&
-            "inset-x-0 bottom-0 max-h-[88dvh] gap-2 rounded-t-lg border-t pb-7 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+            "inset-x-0 bottom-0 max-h-[88dvh] gap-2 rounded-t-lg pb-7 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
           className,
         )}
         {...props}

--- a/pkgs/frontend/app/routes/$treeId._index.tsx
+++ b/pkgs/frontend/app/routes/$treeId._index.tsx
@@ -174,6 +174,11 @@ const WorkspaceHome: FC = () => {
       Math.floor(Number(formatEther(BigInt(receivedBalance)))).toLocaleString(),
     [receivedBalance],
   );
+  // Mock: workspace join day. `HatsTimeFrameModule.getWoreTime(wearer, hatId)`
+  // exists per-hat on-chain (see ThanksToken.mintableAmount), but no
+  // subgraph entity / aggregation hook surfaces a per-workspace join time.
+  // Tracked in issue #493.
+  const daysSinceJoin = 45;
 
   const activityItems = useMemo<ActivityItem[]>(() => {
     const resolveName = (addr: string) =>
@@ -230,12 +235,33 @@ const WorkspaceHome: FC = () => {
 
       {/* Mobile layout — single column. */}
       <div className="flex flex-col gap-6 md:hidden">
-        <SendableMobileCard
+        <WeeklyBalanceCard
           sendableAmount={sendableAmount}
-          receivedAmount={receivedFormatted}
           deltaLabel={weeklyStats.delta}
           onSend={goSendThanks}
+          className="mx-1"
         />
+
+        <div className="grid grid-cols-3 gap-2 px-1">
+          <StatCard
+            label="受け取ったサンクス"
+            value={receivedFormatted}
+            unit="THX"
+            accent="var(--color-contrib)"
+          />
+          <StatCard
+            label="今週の貢献"
+            value={weeklyStats.myThisWeek}
+            unit="件"
+            accent="var(--color-split)"
+          />
+          <StatCard
+            label="参加して"
+            value={daysSinceJoin}
+            unit="日目"
+            accent="var(--color-role)"
+          />
+        </div>
 
         <section>
           <SectionLabel className="px-1">あなたの当番</SectionLabel>
@@ -256,6 +282,23 @@ const WorkspaceHome: FC = () => {
             <Card className="mx-1 py-6 text-center">
               <Typography variant="bodySm" tone="secondary">
                 担当中の当番はありません
+              </Typography>
+            </Card>
+          )}
+        </section>
+
+        <section>
+          <SectionLabel className="px-1">進行中のクエスト</SectionLabel>
+          {quests.length > 0 ? (
+            <div className="flex flex-col gap-2 px-1">
+              {quests.slice(0, 3).map((q) => (
+                <QuestRow key={q.id} quest={q} />
+              ))}
+            </div>
+          ) : (
+            <Card className="mx-1 py-6 text-center">
+              <Typography variant="bodySm" tone="secondary">
+                進行中のクエストはありません
               </Typography>
             </Card>
           )}
@@ -287,15 +330,6 @@ const WorkspaceHome: FC = () => {
         <div className="flex flex-col gap-5">
           <div className="grid grid-cols-3 gap-3">
             <StatCard
-              label="送れるサンクス"
-              value={sendableAmount}
-              unit="THX"
-              size="wide"
-              accent="var(--color-primary)"
-              delta={weeklyStats.delta}
-              valueClassName="text-[26px]"
-            />
-            <StatCard
               label="受け取ったサンクス"
               value={receivedFormatted}
               unit="THX"
@@ -309,6 +343,14 @@ const WorkspaceHome: FC = () => {
               unit="件"
               size="wide"
               accent="var(--color-split)"
+              valueClassName="text-[26px]"
+            />
+            <StatCard
+              label="参加して"
+              value={daysSinceJoin}
+              unit="日目"
+              size="wide"
+              accent="var(--color-role)"
               valueClassName="text-[26px]"
             />
           </div>
@@ -404,87 +446,21 @@ const SectionHeader: FC<{ title: string; actionTo?: string }> = ({
   </div>
 );
 
-interface SendableMobileCardProps {
-  sendableAmount: string;
-  receivedAmount: string;
-  deltaLabel?: string;
-  onSend: () => void;
-}
-
-const SendableMobileCard: FC<SendableMobileCardProps> = ({
-  sendableAmount,
-  receivedAmount,
-  deltaLabel,
-  onSend,
-}) => (
-  <Card className="mx-1 gap-0 overflow-hidden py-0">
-    <div className="bg-primary-soft px-[18px] py-[18px]">
-      <div className="flex items-start justify-between gap-2">
-        <div>
-          <Typography
-            as="div"
-            variant="caption"
-            weight="semibold"
-            className="text-[#7A5A2E]"
-          >
-            送れるサンクス
-          </Typography>
-          <div className="mt-1.5 flex items-baseline gap-1.5">
-            <Typography
-              as="span"
-              variant="statLg"
-              className="text-[32px] tracking-[-1px]"
-            >
-              {sendableAmount}
-            </Typography>
-            <Typography
-              as="span"
-              variant="bodySm"
-              weight="bold"
-              className="text-[#7A5A2E]"
-            >
-              THX
-            </Typography>
-          </div>
-        </div>
-        <div className="flex size-11 items-center justify-center rounded-full bg-primary text-white">
-          <Icon name="sparkle" size={22} />
-        </div>
-      </div>
-      <Typography
-        as="div"
-        variant="caption"
-        className="mt-3 flex items-baseline justify-between text-[#7A5A2E]"
-      >
-        <span>
-          受け取った:{" "}
-          <strong className="text-text-primary">{receivedAmount} THX</strong>
-        </span>
-        {deltaLabel && <span>{deltaLabel}</span>}
-      </Typography>
-    </div>
-    <div className="p-3.5">
-      <Button variant="primary" full onClick={onSend}>
-        <Icon name="send" size={18} />
-        サンクスを送る
-      </Button>
-    </div>
-  </Card>
-);
-
 interface WeeklyBalanceCardProps {
   sendableAmount: string;
   deltaLabel?: string;
   onSend: () => void;
+  className?: string;
 }
 
 const WeeklyBalanceCard: FC<WeeklyBalanceCardProps> = ({
   sendableAmount,
   deltaLabel,
   onSend,
+  className,
 }) => (
   <Card
-    className="gap-4 border-0 py-5 text-[#3D2D14]"
+    className={cn("gap-4 border-0 py-5 text-[#3D2D14]", className)}
     style={{ background: "linear-gradient(160deg, #FFD668, #F5B82E)" }}
   >
     <div className="px-5">
@@ -494,7 +470,7 @@ const WeeklyBalanceCard: FC<WeeklyBalanceCardProps> = ({
         weight="bold"
         className="opacity-70"
       >
-        今週の残高
+        送れるサンクス
       </Typography>
       <Typography
         as="div"
@@ -506,9 +482,11 @@ const WeeklyBalanceCard: FC<WeeklyBalanceCardProps> = ({
           THX
         </Typography>
       </Typography>
-      <Typography as="div" variant="caption" className="opacity-80">
-        送付可能量{deltaLabel ? ` ・ ${deltaLabel}` : ""}
-      </Typography>
+      {deltaLabel && (
+        <Typography as="div" variant="caption" className="opacity-80">
+          {deltaLabel}
+        </Typography>
+      )}
     </div>
     <div className="px-5">
       <Button

--- a/pkgs/frontend/app/routes/$treeId._index.tsx
+++ b/pkgs/frontend/app/routes/$treeId._index.tsx
@@ -23,7 +23,9 @@ import { PageContainer } from "~/components/layout/PageContainer";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
+import { Heading } from "~/components/ui/heading";
 import { Icon } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
 import { cn } from "~/lib/utils";
 
 const WEEK_SEC = 7 * 24 * 60 * 60;
@@ -213,13 +215,13 @@ const WorkspaceHome: FC = () => {
     <PageContainer className="pt-4 pb-8 md:pt-6">
       <header className="mb-4 px-1 md:mb-6">
         {greetingName && (
-          <p className="text-[13px] text-text-secondary">
+          <Typography variant="bodySm" tone="secondary">
             こんにちは、{greetingName} さん
-          </p>
+          </Typography>
         )}
-        <h1 className="mt-0.5 text-[22px] font-extrabold tracking-tight text-text-primary md:text-[24px]">
+        <Heading variant="h2" level={1} className="mt-0.5">
           今日もおつかれさまです！
-        </h1>
+        </Heading>
       </header>
 
       {/* Mobile layout — single column. */}
@@ -248,26 +250,28 @@ const WorkspaceHome: FC = () => {
             </div>
           ) : (
             <Card className="mx-1 py-6 text-center">
-              <p className="text-[13px] text-text-secondary">
+              <Typography variant="bodySm" tone="secondary">
                 担当中の当番はありません
-              </p>
+              </Typography>
             </Card>
           )}
         </section>
 
         <section>
           <div className="flex items-baseline justify-between px-1 pb-2">
-            <span className="text-xs font-bold tracking-[0.04em] text-text-secondary">
+            <Typography as="span" variant="label">
               最近のアクティビティ
-            </span>
+            </Typography>
             {treeId && (
-              <Link
-                to={`/${treeId}/history`}
-                className="inline-flex items-center gap-0.5 text-xs text-text-secondary"
-              >
-                すべて見る
-                <Icon name="chevron-right" size={12} />
-              </Link>
+              <Typography asChild as="span" variant="caption" tone="secondary">
+                <Link
+                  to={`/${treeId}/history`}
+                  className="inline-flex items-center gap-0.5"
+                >
+                  すべて見る
+                  <Icon name="chevron-right" size={12} />
+                </Link>
+              </Typography>
             )}
           </div>
           <ActivityList isLoading={isActivityLoading} items={activityItems} />
@@ -322,9 +326,9 @@ const WorkspaceHome: FC = () => {
                 ))}
               </div>
             ) : (
-              <p className="px-5 text-[13px] text-text-secondary">
+              <Typography variant="bodySm" tone="secondary" className="px-5">
                 担当中の当番はありません
-              </p>
+              </Typography>
             )}
           </Card>
 
@@ -358,9 +362,9 @@ const WorkspaceHome: FC = () => {
                   ))}
                 </div>
               ) : (
-                <p className="text-[13px] text-text-secondary">
+                <Typography variant="bodySm" tone="secondary">
                   進行中のクエストはありません
-                </p>
+                </Typography>
               )}
             </div>
           </Card>
@@ -374,10 +378,12 @@ const WorkspaceHome: FC = () => {
                     {p.icon}
                   </div>
                   <div>
-                    <div className="text-[13px] font-bold">{p.label}</div>
-                    <div className="text-[11px] text-text-secondary">
+                    <Typography as="div" variant="bodySm" weight="bold">
+                      {p.label}
+                    </Typography>
+                    <Typography as="div" variant="micro" tone="secondary">
                       {p.desc}
-                    </div>
+                    </Typography>
                   </div>
                 </li>
               ))}
@@ -402,14 +408,21 @@ const SectionHeader: FC<{ title: string; actionTo?: string }> = ({
   actionTo,
 }) => (
   <div className="flex items-center justify-between px-5">
-    <h2 className="text-[15px] font-bold text-text-primary">{title}</h2>
+    <Heading variant="h6" level={2}>
+      {title}
+    </Heading>
     {actionTo && (
-      <Link
-        to={actionTo}
-        className="text-xs font-semibold text-text-secondary hover:text-text-primary"
+      <Typography
+        asChild
+        as="span"
+        variant="caption"
+        tone="secondary"
+        weight="semibold"
       >
-        すべて見る →
-      </Link>
+        <Link to={actionTo} className="hover:text-text-primary">
+          すべて見る →
+        </Link>
+      </Typography>
     )}
   </div>
 );
@@ -431,27 +444,47 @@ const SendableMobileCard: FC<SendableMobileCardProps> = ({
     <div className="bg-primary-soft px-[18px] py-[18px]">
       <div className="flex items-start justify-between gap-2">
         <div>
-          <div className="text-xs font-semibold text-[#7A5A2E]">
+          <Typography
+            as="div"
+            variant="caption"
+            weight="semibold"
+            className="text-[#7A5A2E]"
+          >
             送れるサンクス
-          </div>
+          </Typography>
           <div className="mt-1.5 flex items-baseline gap-1.5">
-            <span className="text-[40px] font-extrabold leading-none tracking-[-1px] text-text-primary">
+            <Typography
+              as="span"
+              variant="statLg"
+              className="text-[40px] tracking-[-1px]"
+            >
               {sendableAmount}
-            </span>
-            <span className="text-sm font-bold text-[#7A5A2E]">THX</span>
+            </Typography>
+            <Typography
+              as="span"
+              variant="bodySm"
+              weight="bold"
+              className="text-[#7A5A2E]"
+            >
+              THX
+            </Typography>
           </div>
         </div>
         <div className="flex size-11 items-center justify-center rounded-full bg-primary text-white">
           <Icon name="sparkle" size={22} />
         </div>
       </div>
-      <div className="mt-3 flex items-baseline justify-between text-xs text-[#7A5A2E]">
+      <Typography
+        as="div"
+        variant="caption"
+        className="mt-3 flex items-baseline justify-between text-[#7A5A2E]"
+      >
         <span>
           受け取った:{" "}
           <strong className="text-text-primary">{receivedAmount} THX</strong>
         </span>
         {deltaLabel && <span>{deltaLabel}</span>}
-      </div>
+      </Typography>
     </div>
     <div className="p-3.5">
       <Button variant="primary" full onClick={onSend}>
@@ -478,14 +511,27 @@ const WeeklyBalanceCard: FC<WeeklyBalanceCardProps> = ({
     style={{ background: "linear-gradient(160deg, #FFD668, #F5B82E)" }}
   >
     <div className="px-5">
-      <div className="text-xs font-bold opacity-70">今週の残高</div>
-      <div className="mt-2.5 mb-1 text-[56px] font-extrabold leading-none tracking-[-2px]">
+      <Typography
+        as="div"
+        variant="caption"
+        weight="bold"
+        className="opacity-70"
+      >
+        今週の残高
+      </Typography>
+      <Typography
+        as="div"
+        variant="statLg"
+        className="mt-2.5 mb-1 text-[56px] tracking-[-2px]"
+      >
         {sendableAmount}
-        <span className="ml-1.5 text-lg opacity-80">THX</span>
-      </div>
-      <div className="text-xs opacity-80">
+        <Typography as="span" variant="body" className="ml-1.5 opacity-80">
+          THX
+        </Typography>
+      </Typography>
+      <Typography as="div" variant="caption" className="opacity-80">
         送付可能量{deltaLabel ? ` ・ ${deltaLabel}` : ""}
-      </div>
+      </Typography>
     </div>
     <div className="px-5">
       <Button
@@ -554,18 +600,25 @@ const MyDutyCard: FC<MyDutyCardProps> = ({
           )}
         </div>
         <div className="min-w-0 flex-1">
-          <div
-            className={cn(
-              "truncate font-bold text-text-primary",
-              isLg ? "text-[15px]" : "text-[13px]",
-            )}
-          >
-            {name}
-          </div>
+          {isLg ? (
+            <Heading variant="h6" level={3} className="truncate">
+              {name}
+            </Heading>
+          ) : (
+            <Typography as="div" variant="bodySm" weight="bold" truncate>
+              {name}
+            </Typography>
+          )}
           {isLg && detail?.data?.description && (
-            <div className="mt-0.5 truncate text-xs text-text-secondary">
+            <Typography
+              as="div"
+              variant="caption"
+              tone="secondary"
+              truncate
+              className="mt-0.5"
+            >
               {detail.data.description}
-            </div>
+            </Typography>
           )}
         </div>
         {isLg ? (
@@ -616,9 +669,13 @@ const ActivityList: FC<ActivityListProps> = ({
   }
   if (items.length === 0) {
     const empty = (
-      <p className="px-5 py-4 text-center text-[13px] text-text-secondary">
+      <Typography
+        variant="bodySm"
+        tone="secondary"
+        className="px-5 py-4 text-center"
+      >
         アクティビティはまだありません
-      </p>
+      </Typography>
     );
     return isFlat ? empty : <Card className="mx-1 py-6">{empty}</Card>;
   }
@@ -655,28 +712,42 @@ const ActivityRow: FC<{ item: ActivityItem }> = ({ item }) => {
         <Icon name={iconName} size={18} />
       </div>
       <div className="min-w-0 flex-1">
-        <div className="text-[13px] leading-tight text-text-primary">
+        <Typography as="div" variant="bodySm" className="leading-tight">
           <strong className="font-semibold">{item.counterpartName}</strong>
-          <span className="text-text-secondary">{counterpartLabel}</span>
-        </div>
+          <Typography as="span" variant="bodySm" tone="secondary">
+            {counterpartLabel}
+          </Typography>
+        </Typography>
         {item.message && (
-          <div className="mt-0.5 truncate text-xs leading-tight text-text-secondary">
+          <Typography
+            as="div"
+            variant="caption"
+            tone="secondary"
+            truncate
+            className="mt-0.5"
+          >
             {item.message}
-          </div>
+          </Typography>
         )}
-        <div className="mt-0.5 text-[11px] text-text-secondary">
+        <Typography
+          as="div"
+          variant="micro"
+          tone="secondary"
+          className="mt-0.5"
+        >
           {item.relativeTime}
-        </div>
+        </Typography>
       </div>
-      <div
-        className={cn(
-          "text-[13px] font-bold",
-          isSent ? "text-text-secondary" : "text-contrib",
-        )}
+      <Typography
+        as="div"
+        variant="bodySm"
+        weight="bold"
+        tone={isSent ? "secondary" : "primary"}
+        className={cn(!isSent && "text-contrib")}
       >
         {isSent ? "−" : "+"}
         {item.amount} THX
-      </div>
+      </Typography>
     </div>
   );
 };
@@ -693,19 +764,26 @@ const QuestRow: FC<{ quest: Quest }> = ({ quest }) => {
   return (
     <div className="flex flex-col gap-1.5 rounded-sm border bg-[#FBF8F1] px-3.5 py-3">
       <div className="flex items-center justify-between gap-2">
-        <div className="truncate text-[13px] font-bold">
+        <Typography as="div" variant="bodySm" weight="bold" truncate>
           Quest #{quest.questId}
-        </div>
-        <div className="text-xs font-bold text-primary">+{amount} THX</div>
+        </Typography>
+        <Typography
+          as="div"
+          variant="caption"
+          weight="bold"
+          className="text-primary"
+        >
+          +{amount} THX
+        </Typography>
       </div>
       <div className="flex items-center gap-2">
         <Badge kind={isReview ? "info" : "lead"}>
           {isReview ? "確認待ち" : "募集中"}
         </Badge>
         {quest.submitter && (
-          <span className="text-[11px] text-text-secondary">
+          <Typography as="span" variant="micro" tone="secondary">
             {abbreviateAddress(quest.submitter as `0x${string}`)}
-          </span>
+          </Typography>
         )}
       </div>
     </div>

--- a/pkgs/frontend/app/routes/$treeId._index.tsx
+++ b/pkgs/frontend/app/routes/$treeId._index.tsx
@@ -1,140 +1,713 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { useActiveWalletIdentity, useNamesByAddresses } from "hooks/useENS";
 import { useTreeInfo } from "hooks/useHats";
+import { type Quest, useQuests } from "hooks/useQuests";
 import {
   useThanksToken,
+  useThanksTokenActivity,
   useUserThanksTokenBalance,
 } from "hooks/useThanksToken";
 import { useActiveWallet } from "hooks/useWallet";
-import type { FC } from "react";
-import { FaPlus } from "react-icons/fa6";
+import type { NameData } from "namestone-sdk";
+import { type FC, Fragment, useMemo } from "react";
 import { Link, useNavigate, useParams } from "react-router";
-import { formatEther } from "viem";
-import { StickyNav } from "~/components/StickyNav";
-import {
-  Box,
-  Flex,
-  HStack,
-  Heading,
-  Text,
-  VStack,
-} from "~/components/chakra-shim";
-import { CommonButton } from "~/components/common/CommonButton";
-import { HatsListItemParser } from "~/components/common/HatsListItemParser";
-import { MyRole } from "~/components/roles/MyRole";
-import { VRole } from "~/components/roles/VRole";
-import { ThanksTokenHistory } from "~/components/thankstoken/History";
+import type { HatsDetailSchama } from "types/hats";
+import { ipfs2https } from "utils/ipfs";
+import { abbreviateAddress } from "utils/wallet";
+import { formatEther, hexToString } from "viem";
+import { Divider } from "~/components/composite/divider";
+import { SectionLabel } from "~/components/composite/section-label";
+import { StatCard } from "~/components/composite/stat-card";
+import { PageContainer } from "~/components/layout/PageContainer";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Card } from "~/components/ui/card";
+import { Icon } from "~/components/ui/icon";
+import { cn } from "~/lib/utils";
 
-const WorkspaceTop: FC = () => {
+const WEEK_SEC = 7 * 24 * 60 * 60;
+
+// Mirrors the "homma さんから / 2 時間前" cadence in the design source. Anything
+// older than five weeks falls back to a JP locale date so the row stays scannable.
+const formatRelative = (timestampSec: number, nowMs: number): string => {
+  const deltaSec = Math.max(0, Math.floor(nowMs / 1000 - timestampSec));
+  if (deltaSec < 60) return "今";
+  const min = Math.floor(deltaSec / 60);
+  if (min < 60) return `${min} 分前`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr} 時間前`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day} 日前`;
+  const week = Math.floor(day / 7);
+  if (week < 5) return `${week} 週間前`;
+  return new Date(timestampSec * 1000).toLocaleDateString("ja-JP");
+};
+
+// Resolves a Hats `details` IPFS pointer to its parsed metadata. Shares the
+// `["hats-detail", url]` cache key with `HatsListItemParser` so duty cards
+// don't refetch when the user navigates back from a role detail screen.
+const useHatDetail = (detailsUri?: string) => {
+  const httpsUri = useMemo(() => ipfs2https(detailsUri), [detailsUri]);
+  const { data } = useQuery({
+    queryKey: ["hats-detail", httpsUri],
+    queryFn: async (): Promise<HatsDetailSchama | undefined> => {
+      if (!httpsUri) return;
+      const { data } = await axios.get<HatsDetailSchama>(httpsUri);
+      return data;
+    },
+    enabled: !!httpsUri,
+    staleTime: 1000 * 60 * 60,
+  });
+  return data;
+};
+
+type Direction = "received" | "sent" | "third-party";
+
+interface ActivityItem {
+  id: string;
+  direction: Direction;
+  counterpartAddress: string;
+  counterpartName: string;
+  amount: string;
+  message?: string;
+  relativeTime: string;
+}
+
+const WorkspaceHome: FC = () => {
   const { wallet } = useActiveWallet();
   const me = wallet?.account?.address;
 
   const { treeId } = useParams();
+  const navigate = useNavigate();
+
+  const { identity } = useActiveWalletIdentity();
+  const greetingName =
+    identity?.name ||
+    (wallet?.account?.address ? abbreviateAddress(wallet.account.address) : "");
+
   const tree = useTreeInfo(Number(treeId));
+  const myDuties = useMemo(() => {
+    const meAddr = me?.toLowerCase();
+    if (!tree?.hats || !meAddr) return [];
+    return tree.hats.filter(
+      (h) =>
+        Number(h.levelAtLocalTree) >= 2 &&
+        h.wearers?.some((w) => w.id === meAddr),
+    );
+  }, [tree, me]);
+
+  const { mintableAmount } = useThanksToken(treeId || "");
+  const { balance: receivedBalance } = useUserThanksTokenBalance(treeId);
+  const { mints, isLoading: isActivityLoading } = useThanksTokenActivity(
+    treeId,
+    20,
+  );
+  const recentMints = mints?.mintThanksTokens ?? [];
+
+  const counterpartAddresses = useMemo(() => {
+    const set = new Set<string>();
+    for (const m of recentMints) {
+      if (m.from) set.add(m.from.toLowerCase());
+      if (m.to) set.add(m.to.toLowerCase());
+    }
+    return Array.from(set);
+  }, [recentMints]);
+  const { names } = useNamesByAddresses(counterpartAddresses);
+  const nameByAddress = useMemo(() => {
+    const map = new Map<string, NameData>();
+    for (const group of names) {
+      const entry = group[0];
+      if (entry?.address) {
+        map.set(entry.address.toLowerCase(), entry);
+      }
+    }
+    return map;
+  }, [names]);
+
+  // Weekly stats are derived from the same `recentMints` slice; we don't issue
+  // an extra query. Per-user activity is "this week's outgoing thanks" and the
+  // delta is a coarse "% change in workspace-wide mints vs the prior week".
+  const nowMs = Date.now();
+  const nowSec = Math.floor(nowMs / 1000);
+  const weeklyStats = useMemo(() => {
+    let workspaceThisWeek = 0;
+    let workspaceLastWeek = 0;
+    let myThisWeek = 0;
+    const meAddr = me?.toLowerCase();
+    for (const m of recentMints) {
+      const ts = Number(m.blockTimestamp);
+      if (ts >= nowSec - WEEK_SEC) {
+        workspaceThisWeek += 1;
+        if (meAddr && m.from?.toLowerCase() === meAddr) myThisWeek += 1;
+      } else if (ts >= nowSec - 2 * WEEK_SEC) {
+        workspaceLastWeek += 1;
+      }
+    }
+    let delta: string | undefined;
+    if (workspaceLastWeek > 0) {
+      const pct = Math.round(
+        ((workspaceThisWeek - workspaceLastWeek) / workspaceLastWeek) * 100,
+      );
+      if (pct > 0) delta = `+${pct}% 今週`;
+    }
+    return { workspaceThisWeek, myThisWeek, delta };
+  }, [recentMints, me, nowSec]);
+
+  const { quests } = useQuests(treeId, {
+    statuses: ["Open", "PendingReview"],
+    first: 3,
+  });
+
+  const sendableAmount = useMemo(
+    () => Number(formatEther(mintableAmount || 0n)).toLocaleString(),
+    [mintableAmount],
+  );
+  const receivedFormatted = useMemo(
+    () => Number(formatEther(BigInt(receivedBalance))).toLocaleString(),
+    [receivedBalance],
+  );
+
+  const activityItems = useMemo<ActivityItem[]>(() => {
+    return recentMints.slice(0, 4).map((m): ActivityItem => {
+      const fromAddr = m.from.toLowerCase();
+      const toAddr = m.to.toLowerCase();
+      const meAddr = me?.toLowerCase();
+      const direction: Direction = !meAddr
+        ? "third-party"
+        : toAddr === meAddr
+          ? "received"
+          : fromAddr === meAddr
+            ? "sent"
+            : "third-party";
+      const counterpartAddress = direction === "sent" ? toAddr : fromAddr;
+      const counterpart = nameByAddress.get(counterpartAddress);
+      const counterpartName =
+        counterpart?.name ||
+        abbreviateAddress(counterpartAddress as `0x${string}`);
+      let message: string | undefined;
+      try {
+        const decoded = hexToString((m.data as `0x${string}`) || "0x");
+        message = decoded.trim() || undefined;
+      } catch {
+        message = undefined;
+      }
+      return {
+        id: m.id,
+        direction,
+        counterpartAddress,
+        counterpartName,
+        amount: Number(formatEther(BigInt(m.amount))).toLocaleString(),
+        message,
+        relativeTime: formatRelative(Number(m.blockTimestamp), nowMs),
+      };
+    });
+  }, [recentMints, me, nameByAddress, nowMs]);
+
+  const goSendThanks = () => {
+    if (!treeId) return;
+    navigate(`/${treeId}/thankstoken/send`);
+  };
 
   return (
-    <>
-      <Box mb={4}>
-        <ThanksTokenSummary treeId={treeId} />
-      </Box>
+    <PageContainer className="pt-4 pb-8 md:pt-6">
+      <header className="mb-4 px-1 md:mb-6">
+        {greetingName && (
+          <p className="text-[13px] text-text-secondary">
+            こんにちは、{greetingName} さん
+          </p>
+        )}
+        <h1 className="mt-0.5 text-[22px] font-extrabold tracking-tight text-text-primary md:text-[24px]">
+          今日もおつかれさまです！
+        </h1>
+      </header>
 
-      {/* Recent activity */}
-      <Box my={8}>
-        <HStack justify="space-between" alignItems="center" pb={4}>
-          <Heading fontSize="xl">直近のアクティビティ</Heading>
-          <Link to={`/${treeId}/history`}>
-            <CommonButton size="xs" bgColor="yellow.400">
-              もっと見る
-            </CommonButton>
-          </Link>
-        </HStack>
-        {treeId && <ThanksTokenHistory limit={3} treeId={treeId} />}
-      </Box>
+      {/* Mobile layout — single column. */}
+      <div className="flex flex-col gap-6 md:hidden">
+        <SendableMobileCard
+          sendableAmount={sendableAmount}
+          receivedAmount={receivedFormatted}
+          deltaLabel={weeklyStats.delta}
+          onSend={goSendThanks}
+        />
 
-      {/* My roles */}
-      <Box my={4}>
-        <Heading py={4}>担当当番</Heading>
-        <VStack gap={3} align="stretch">
-          {tree?.hats
-            ?.filter((h) => Number(h.levelAtLocalTree) >= 2)
-            .filter((h) => h.wearers?.some((w) => w.id === me?.toLowerCase()))
-            .map((h) => (
-              <HatsListItemParser
-                key={h.id}
-                imageUri={h.imageUri}
-                detailUri={h.details}
+        <section>
+          <SectionLabel className="px-1">あなたの当番</SectionLabel>
+          {myDuties.length > 0 ? (
+            <div className="flex flex-col gap-2.5 px-1">
+              {myDuties.map((h) => (
+                <MyDutyCard
+                  key={h.id}
+                  treeId={treeId ?? ""}
+                  hatId={h.id as `0x${string}`}
+                  imageUri={h.imageUri}
+                  detailsUri={h.details}
+                  myAddress={(me ?? "0x") as `0x${string}`}
+                />
+              ))}
+            </div>
+          ) : (
+            <Card className="mx-1 py-6 text-center">
+              <p className="text-[13px] text-text-secondary">
+                担当中の当番はありません
+              </p>
+            </Card>
+          )}
+        </section>
+
+        <section>
+          <div className="flex items-baseline justify-between px-1 pb-2">
+            <span className="text-xs font-bold tracking-[0.04em] text-text-secondary">
+              最近のアクティビティ
+            </span>
+            {treeId && (
+              <Link
+                to={`/${treeId}/history`}
+                className="inline-flex items-center gap-0.5 text-xs text-text-secondary"
               >
-                <MyRole address={me} treeId={treeId} hatId={h.id} />
-              </HatsListItemParser>
-            ))}
-        </VStack>
-      </Box>
+                すべて見る
+                <Icon name="chevron-right" size={12} />
+              </Link>
+            )}
+          </div>
+          <ActivityList isLoading={isActivityLoading} items={activityItems} />
+        </section>
+      </div>
 
-      <StickyNav />
-    </>
+      {/* Desktop layout — 2fr / 1fr grid. */}
+      <div className="hidden gap-5 md:grid md:grid-cols-[2fr_1fr]">
+        <div className="flex flex-col gap-5">
+          <div className="grid grid-cols-3 gap-3">
+            <StatCard
+              label="送れるサンクス"
+              value={sendableAmount}
+              unit="THX"
+              size="wide"
+              accent="var(--color-primary)"
+              delta={weeklyStats.delta}
+            />
+            <StatCard
+              label="受け取ったサンクス"
+              value={receivedFormatted}
+              unit="THX"
+              size="wide"
+              accent="var(--color-contrib)"
+            />
+            <StatCard
+              label="今週の貢献"
+              value={weeklyStats.myThisWeek}
+              unit="件"
+              size="wide"
+              accent="var(--color-split)"
+            />
+          </div>
+
+          <Card className="gap-3 py-5">
+            <SectionHeader
+              title="あなたの当番"
+              actionTo={treeId ? `/${treeId}/role` : undefined}
+            />
+            {myDuties.length > 0 ? (
+              <div className="grid grid-cols-2 gap-2.5 px-5">
+                {myDuties.slice(0, 4).map((h) => (
+                  <MyDutyCard
+                    key={h.id}
+                    treeId={treeId ?? ""}
+                    hatId={h.id as `0x${string}`}
+                    imageUri={h.imageUri}
+                    detailsUri={h.details}
+                    myAddress={(me ?? "0x") as `0x${string}`}
+                    size="sm"
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className="px-5 text-[13px] text-text-secondary">
+                担当中の当番はありません
+              </p>
+            )}
+          </Card>
+
+          <Card className="gap-2 py-5">
+            <SectionHeader
+              title="最近のアクティビティ"
+              actionTo={treeId ? `/${treeId}/history` : undefined}
+            />
+            <ActivityList
+              isLoading={isActivityLoading}
+              items={activityItems}
+              variant="flat"
+            />
+          </Card>
+        </div>
+
+        <div className="flex flex-col gap-5">
+          <WeeklyBalanceCard
+            sendableAmount={sendableAmount}
+            deltaLabel={weeklyStats.delta}
+            onSend={goSendThanks}
+          />
+
+          <Card className="gap-3 py-5">
+            <SectionHeader title="進行中のクエスト" />
+            <div className="px-5">
+              {quests.length > 0 ? (
+                <div className="flex flex-col gap-2">
+                  {quests.slice(0, 3).map((q) => (
+                    <QuestRow key={q.id} quest={q} />
+                  ))}
+                </div>
+              ) : (
+                <p className="text-[13px] text-text-secondary">
+                  進行中のクエストはありません
+                </p>
+              )}
+            </div>
+          </Card>
+
+          <Card className="gap-3 py-5">
+            <SectionHeader title="原則" />
+            <ul className="flex flex-col gap-3 px-5">
+              {PRINCIPLES.map((p) => (
+                <li key={p.label} className="flex items-center gap-3">
+                  <div className="flex size-8 items-center justify-center rounded-xs bg-primary-soft text-sm text-[#7A5A2E]">
+                    {p.icon}
+                  </div>
+                  <div>
+                    <div className="text-[13px] font-bold">{p.label}</div>
+                    <div className="text-[11px] text-text-secondary">
+                      {p.desc}
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        </div>
+      </div>
+    </PageContainer>
   );
 };
 
-export default WorkspaceTop;
+export default WorkspaceHome;
 
-const ThanksTokenSummary: FC<{ treeId?: string }> = ({ treeId }) => {
-  const navigate = useNavigate();
-  const { balance: thanksTokenBalance } = useUserThanksTokenBalance(treeId);
-  const { mintableAmount } = useThanksToken(treeId || "");
+const PRINCIPLES = [
+  { icon: "♡", label: "Warm", desc: "やさしい人のつながり" },
+  { icon: "✺", label: "Clear", desc: "迷わないシンプルさ" },
+  { icon: "◍", label: "Community", desc: "みんなで育てる仕組み" },
+];
 
-  return (
-    <VStack align="stretch" gap={3}>
-      {/* Big rounded card */}
-      <Box
-        w="full"
-        maxW="sm"
-        mx="auto"
-        bg="white"
-        borderRadius="2xl"
-        borderWidth="2px"
-        borderColor="gray.200"
-        p={6}
-        boxShadow="sm"
+const SectionHeader: FC<{ title: string; actionTo?: string }> = ({
+  title,
+  actionTo,
+}) => (
+  <div className="flex items-center justify-between px-5">
+    <h2 className="text-[15px] font-bold text-text-primary">{title}</h2>
+    {actionTo && (
+      <Link
+        to={actionTo}
+        className="text-xs font-semibold text-text-secondary hover:text-text-primary"
       >
-        <VStack gap={4}>
-          <Text fontSize="sm" color="gray.600">
-            送付可能量
-          </Text>
+        すべて見る →
+      </Link>
+    )}
+  </div>
+);
 
-          <HStack gap={2} align="baseline">
-            <Text fontSize={{ base: "4xl", sm: "5xl" }} fontWeight="bold">
-              {Number(formatEther(mintableAmount || 0n)).toLocaleString()}
-            </Text>
-            <Text fontSize="xs" color="gray.500">
-              THX
-            </Text>
-          </HStack>
+interface SendableMobileCardProps {
+  sendableAmount: string;
+  receivedAmount: string;
+  deltaLabel?: string;
+  onSend: () => void;
+}
 
-          <CommonButton
-            fontSize="md"
-            borderRadius="xl"
-            bgColor="yellow.400"
-            _hover={{ bg: "yellow.500" }}
-            onClick={() => treeId && navigate(`/${treeId}/thankstoken/send`)}
+const SendableMobileCard: FC<SendableMobileCardProps> = ({
+  sendableAmount,
+  receivedAmount,
+  deltaLabel,
+  onSend,
+}) => (
+  <Card className="mx-1 gap-0 overflow-hidden py-0">
+    <div className="bg-primary-soft px-[18px] py-[18px]">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <div className="text-xs font-semibold text-[#7A5A2E]">
+            送れるサンクス
+          </div>
+          <div className="mt-1.5 flex items-baseline gap-1.5">
+            <span className="text-[40px] font-extrabold leading-none tracking-[-1px] text-text-primary">
+              {sendableAmount}
+            </span>
+            <span className="text-sm font-bold text-[#7A5A2E]">THX</span>
+          </div>
+        </div>
+        <div className="flex size-11 items-center justify-center rounded-full bg-primary text-white">
+          <Icon name="sparkle" size={22} />
+        </div>
+      </div>
+      <div className="mt-3 flex items-baseline justify-between text-xs text-[#7A5A2E]">
+        <span>
+          受け取った:{" "}
+          <strong className="text-text-primary">{receivedAmount} THX</strong>
+        </span>
+        {deltaLabel && <span>{deltaLabel}</span>}
+      </div>
+    </div>
+    <div className="p-3.5">
+      <Button variant="primary" full onClick={onSend}>
+        <Icon name="send" size={18} />
+        サンクスを送る
+      </Button>
+    </div>
+  </Card>
+);
+
+interface WeeklyBalanceCardProps {
+  sendableAmount: string;
+  deltaLabel?: string;
+  onSend: () => void;
+}
+
+const WeeklyBalanceCard: FC<WeeklyBalanceCardProps> = ({
+  sendableAmount,
+  deltaLabel,
+  onSend,
+}) => (
+  <Card
+    className="gap-4 border-0 py-5 text-[#3D2D14]"
+    style={{ background: "linear-gradient(160deg, #FFD668, #F5B82E)" }}
+  >
+    <div className="px-5">
+      <div className="text-xs font-bold opacity-70">今週の残高</div>
+      <div className="mt-2.5 mb-1 text-[56px] font-extrabold leading-none tracking-[-2px]">
+        {sendableAmount}
+        <span className="ml-1.5 text-lg opacity-80">THX</span>
+      </div>
+      <div className="text-xs opacity-80">
+        送付可能量{deltaLabel ? ` ・ ${deltaLabel}` : ""}
+      </div>
+    </div>
+    <div className="px-5">
+      <Button
+        variant="primary"
+        full
+        onClick={onSend}
+        className="bg-[#3D2D14] text-[#FFD668] hover:brightness-110"
+      >
+        <Icon name="send" size={16} />
+        サンクスを送る
+      </Button>
+    </div>
+  </Card>
+);
+
+interface MyDutyCardProps {
+  treeId: string;
+  hatId: `0x${string}`;
+  imageUri?: string;
+  detailsUri?: string;
+  myAddress: `0x${string}`;
+  size?: "lg" | "sm";
+}
+
+const MyDutyCard: FC<MyDutyCardProps> = ({
+  treeId,
+  hatId,
+  imageUri,
+  detailsUri,
+  myAddress,
+  size = "lg",
+}) => {
+  const detail = useHatDetail(detailsUri);
+  const imageUrl = ipfs2https(imageUri);
+  const isLg = size === "lg";
+  const name = detail?.data?.name ?? "当番";
+  return (
+    <Link
+      to={`/${treeId}/${hatId}/${myAddress}`}
+      className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 rounded-md"
+    >
+      <Card
+        className={cn(
+          "flex-row items-center gap-3 py-0 transition-colors hover:bg-bg",
+          isLg
+            ? "px-3.5 py-3.5"
+            : "border-0 bg-[#FBF8F1] px-4 py-3 shadow-none",
+        )}
+      >
+        <div
+          className={cn(
+            "flex shrink-0 items-center justify-center overflow-hidden",
+            isLg
+              ? "size-11 rounded-sm bg-[#F2EAD9]"
+              : "size-9 rounded-xs bg-[#D6B995]/30",
+          )}
+        >
+          {imageUrl ? (
+            <img src={imageUrl} alt="" className="size-full object-cover" />
+          ) : (
+            <Icon
+              name="duty"
+              size={isLg ? 22 : 18}
+              className="text-[#7A5A2E]"
+            />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div
+            className={cn(
+              "truncate font-bold text-text-primary",
+              isLg ? "text-[15px]" : "text-[13px]",
+            )}
           >
-            <HStack gap={2}>
-              <Text>サンクストークンを送る</Text>
-            </HStack>
-          </CommonButton>
-        </VStack>
-      </Box>
+            {name}
+          </div>
+          {isLg && detail?.data?.description && (
+            <div className="mt-0.5 truncate text-xs text-text-secondary">
+              {detail.data.description}
+            </div>
+          )}
+        </div>
+        {isLg ? (
+          <Badge kind="lead">担当中</Badge>
+        ) : (
+          <Icon
+            name="chevron-right"
+            size={14}
+            className="text-text-secondary"
+          />
+        )}
+      </Card>
+    </Link>
+  );
+};
 
-      <Box maxW="sm" mx="auto" w="full" pt={1}>
-        <Text fontSize="sm" color="gray.600">
-          受け取ったサンクストークン
-        </Text>
-        <HStack gap={2} align="baseline">
-          <Text fontSize="3xl" fontWeight="bold">
-            {Number(formatEther(BigInt(thanksTokenBalance))).toLocaleString()}
-          </Text>
-          <Text fontSize="xs" color="gray.500">
-            THX
-          </Text>
-        </HStack>
-      </Box>
-    </VStack>
+interface ActivityListProps {
+  isLoading: boolean;
+  items: ActivityItem[];
+  variant?: "card" | "flat";
+}
+
+const ActivityList: FC<ActivityListProps> = ({
+  isLoading,
+  items,
+  variant = "card",
+}) => {
+  const isFlat = variant === "flat";
+  if (isLoading && items.length === 0) {
+    const skeletons = [{ id: "row-a" }, { id: "row-b" }, { id: "row-c" }];
+    const skeletonBody = skeletons.map((s, i) => (
+      <Fragment key={s.id}>
+        <div className="flex items-center gap-3 px-4 py-3">
+          <div className="size-9 shrink-0 animate-pulse rounded-full bg-[#F0EBDE]" />
+          <div className="min-w-0 flex-1">
+            <div className="h-3 w-32 animate-pulse rounded bg-[#F0EBDE]" />
+            <div className="mt-2 h-2.5 w-16 animate-pulse rounded bg-[#F0EBDE]" />
+          </div>
+        </div>
+        {i < skeletons.length - 1 && <Divider inset={64} />}
+      </Fragment>
+    ));
+    return isFlat ? (
+      <div>{skeletonBody}</div>
+    ) : (
+      <Card className="mx-1 gap-0 overflow-hidden py-0">{skeletonBody}</Card>
+    );
+  }
+  if (items.length === 0) {
+    const empty = (
+      <p className="px-5 py-4 text-center text-[13px] text-text-secondary">
+        アクティビティはまだありません
+      </p>
+    );
+    return isFlat ? empty : <Card className="mx-1 py-6">{empty}</Card>;
+  }
+  const rows = items.map((item, i) => (
+    <Fragment key={item.id}>
+      <ActivityRow item={item} />
+      {i < items.length - 1 && <Divider inset={64} />}
+    </Fragment>
+  ));
+  if (isFlat) return <div>{rows}</div>;
+  return <Card className="mx-1 gap-0 overflow-hidden py-0">{rows}</Card>;
+};
+
+const ActivityRow: FC<{ item: ActivityItem }> = ({ item }) => {
+  const isSent = item.direction === "sent";
+  const accentClass = isSent ? "text-primary" : "text-contrib";
+  const ringClass = isSent ? "ring-primary/20" : "ring-contrib/20";
+  const iconName = isSent ? "send" : "heart";
+  const counterpartLabel =
+    item.direction === "received"
+      ? " さんから"
+      : item.direction === "sent"
+        ? " さんへ"
+        : " → ";
+  return (
+    <div className="flex items-center gap-3 px-4 py-3">
+      <div
+        className={cn(
+          "flex size-9 shrink-0 items-center justify-center rounded-full bg-card ring-[1.5px]",
+          accentClass,
+          ringClass,
+        )}
+      >
+        <Icon name={iconName} size={18} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-[13px] leading-tight text-text-primary">
+          <strong className="font-semibold">{item.counterpartName}</strong>
+          <span className="text-text-secondary">{counterpartLabel}</span>
+        </div>
+        {item.message && (
+          <div className="mt-0.5 truncate text-xs leading-tight text-text-secondary">
+            {item.message}
+          </div>
+        )}
+        <div className="mt-0.5 text-[11px] text-text-secondary">
+          {item.relativeTime}
+        </div>
+      </div>
+      <div
+        className={cn(
+          "text-[13px] font-bold",
+          isSent ? "text-text-secondary" : "text-contrib",
+        )}
+      >
+        {isSent ? "−" : "+"}
+        {item.amount} THX
+      </div>
+    </div>
+  );
+};
+
+const QuestRow: FC<{ quest: Quest }> = ({ quest }) => {
+  const amount = (() => {
+    try {
+      return Number(formatEther(BigInt(quest.amount))).toLocaleString();
+    } catch {
+      return "0";
+    }
+  })();
+  const isReview = quest.status === "PendingReview";
+  return (
+    <div className="flex flex-col gap-1.5 rounded-sm border bg-[#FBF8F1] px-3.5 py-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="truncate text-[13px] font-bold">
+          Quest #{quest.questId}
+        </div>
+        <div className="text-xs font-bold text-primary">+{amount} THX</div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Badge kind={isReview ? "info" : "lead"}>
+          {isReview ? "確認待ち" : "募集中"}
+        </Badge>
+        {quest.submitter && (
+          <span className="text-[11px] text-text-secondary">
+            {abbreviateAddress(quest.submitter as `0x${string}`)}
+          </span>
+        )}
+      </div>
+    </div>
   );
 };

--- a/pkgs/frontend/app/routes/$treeId._index.tsx
+++ b/pkgs/frontend/app/routes/$treeId._index.tsx
@@ -69,8 +69,10 @@ type Direction = "received" | "sent" | "third-party";
 interface ActivityItem {
   id: string;
   direction: Direction;
-  counterpartAddress: string;
-  counterpartName: string;
+  fromAddress: string;
+  toAddress: string;
+  fromName: string;
+  toName: string;
   amount: string;
   message?: string;
   relativeTime: string;
@@ -113,8 +115,9 @@ const WorkspaceHome: FC = () => {
       if (m.from) set.add(m.from.toLowerCase());
       if (m.to) set.add(m.to.toLowerCase());
     }
+    if (me) set.add(me.toLowerCase());
     return Array.from(set);
-  }, [recentMints]);
+  }, [recentMints, me]);
   const { names } = useNamesByAddresses(counterpartAddresses);
   const nameByAddress = useMemo(() => {
     const map = new Map<string, NameData>();
@@ -162,15 +165,19 @@ const WorkspaceHome: FC = () => {
   });
 
   const sendableAmount = useMemo(
-    () => Number(formatEther(mintableAmount || 0n)).toLocaleString(),
+    () =>
+      Math.floor(Number(formatEther(mintableAmount || 0n))).toLocaleString(),
     [mintableAmount],
   );
   const receivedFormatted = useMemo(
-    () => Number(formatEther(BigInt(receivedBalance))).toLocaleString(),
+    () =>
+      Math.floor(Number(formatEther(BigInt(receivedBalance)))).toLocaleString(),
     [receivedBalance],
   );
 
   const activityItems = useMemo<ActivityItem[]>(() => {
+    const resolveName = (addr: string) =>
+      nameByAddress.get(addr)?.name || abbreviateAddress(addr as `0x${string}`);
     return recentMints.slice(0, 4).map((m): ActivityItem => {
       const fromAddr = m.from.toLowerCase();
       const toAddr = m.to.toLowerCase();
@@ -182,11 +189,6 @@ const WorkspaceHome: FC = () => {
           : fromAddr === meAddr
             ? "sent"
             : "third-party";
-      const counterpartAddress = direction === "sent" ? toAddr : fromAddr;
-      const counterpart = nameByAddress.get(counterpartAddress);
-      const counterpartName =
-        counterpart?.name ||
-        abbreviateAddress(counterpartAddress as `0x${string}`);
       let message: string | undefined;
       try {
         const decoded = hexToString((m.data as `0x${string}`) || "0x");
@@ -197,8 +199,10 @@ const WorkspaceHome: FC = () => {
       return {
         id: m.id,
         direction,
-        counterpartAddress,
-        counterpartName,
+        fromAddress: fromAddr,
+        toAddress: toAddr,
+        fromName: resolveName(fromAddr),
+        toName: resolveName(toAddr),
         amount: Number(formatEther(BigInt(m.amount))).toLocaleString(),
         message,
         relativeTime: formatRelative(Number(m.blockTimestamp), nowMs),
@@ -289,6 +293,7 @@ const WorkspaceHome: FC = () => {
               size="wide"
               accent="var(--color-primary)"
               delta={weeklyStats.delta}
+              valueClassName="text-[26px]"
             />
             <StatCard
               label="受け取ったサンクス"
@@ -296,6 +301,7 @@ const WorkspaceHome: FC = () => {
               unit="THX"
               size="wide"
               accent="var(--color-contrib)"
+              valueClassName="text-[26px]"
             />
             <StatCard
               label="今週の貢献"
@@ -303,33 +309,25 @@ const WorkspaceHome: FC = () => {
               unit="件"
               size="wide"
               accent="var(--color-split)"
+              valueClassName="text-[26px]"
             />
           </div>
 
           <Card className="gap-3 py-5">
-            <SectionHeader
-              title="あなたの当番"
-              actionTo={treeId ? `/${treeId}/role` : undefined}
-            />
-            {myDuties.length > 0 ? (
-              <div className="grid grid-cols-2 gap-2.5 px-5">
-                {myDuties.slice(0, 4).map((h) => (
-                  <MyDutyCard
-                    key={h.id}
-                    treeId={treeId ?? ""}
-                    hatId={h.id as `0x${string}`}
-                    imageUri={h.imageUri}
-                    detailsUri={h.details}
-                    myAddress={(me ?? "0x") as `0x${string}`}
-                    size="sm"
-                  />
-                ))}
-              </div>
-            ) : (
-              <Typography variant="bodySm" tone="secondary" className="px-5">
-                担当中の当番はありません
-              </Typography>
-            )}
+            <SectionHeader title="進行中のクエスト" />
+            <div className="px-5">
+              {quests.length > 0 ? (
+                <div className="flex flex-col gap-2">
+                  {quests.slice(0, 3).map((q) => (
+                    <QuestRow key={q.id} quest={q} />
+                  ))}
+                </div>
+              ) : (
+                <Typography variant="bodySm" tone="secondary">
+                  進行中のクエストはありません
+                </Typography>
+              )}
+            </div>
           </Card>
 
           <Card className="gap-2 py-5">
@@ -353,41 +351,26 @@ const WorkspaceHome: FC = () => {
           />
 
           <Card className="gap-3 py-5">
-            <SectionHeader title="進行中のクエスト" />
-            <div className="px-5">
-              {quests.length > 0 ? (
-                <div className="flex flex-col gap-2">
-                  {quests.slice(0, 3).map((q) => (
-                    <QuestRow key={q.id} quest={q} />
-                  ))}
-                </div>
-              ) : (
-                <Typography variant="bodySm" tone="secondary">
-                  進行中のクエストはありません
-                </Typography>
-              )}
-            </div>
-          </Card>
-
-          <Card className="gap-3 py-5">
-            <SectionHeader title="原則" />
-            <ul className="flex flex-col gap-3 px-5">
-              {PRINCIPLES.map((p) => (
-                <li key={p.label} className="flex items-center gap-3">
-                  <div className="flex size-8 items-center justify-center rounded-xs bg-primary-soft text-sm text-[#7A5A2E]">
-                    {p.icon}
-                  </div>
-                  <div>
-                    <Typography as="div" variant="bodySm" weight="bold">
-                      {p.label}
-                    </Typography>
-                    <Typography as="div" variant="micro" tone="secondary">
-                      {p.desc}
-                    </Typography>
-                  </div>
-                </li>
-              ))}
-            </ul>
+            <SectionHeader title="あなたの当番" />
+            {myDuties.length > 0 ? (
+              <div className="flex flex-col gap-2.5 px-5">
+                {myDuties.slice(0, 4).map((h) => (
+                  <MyDutyCard
+                    key={h.id}
+                    treeId={treeId ?? ""}
+                    hatId={h.id as `0x${string}`}
+                    imageUri={h.imageUri}
+                    detailsUri={h.details}
+                    myAddress={(me ?? "0x") as `0x${string}`}
+                    size="sm"
+                  />
+                ))}
+              </div>
+            ) : (
+              <Typography variant="bodySm" tone="secondary" className="px-5">
+                担当中の当番はありません
+              </Typography>
+            )}
           </Card>
         </div>
       </div>
@@ -396,12 +379,6 @@ const WorkspaceHome: FC = () => {
 };
 
 export default WorkspaceHome;
-
-const PRINCIPLES = [
-  { icon: "♡", label: "Warm", desc: "やさしい人のつながり" },
-  { icon: "✺", label: "Clear", desc: "迷わないシンプルさ" },
-  { icon: "◍", label: "Community", desc: "みんなで育てる仕組み" },
-];
 
 const SectionHeader: FC<{ title: string; actionTo?: string }> = ({
   title,
@@ -456,7 +433,7 @@ const SendableMobileCard: FC<SendableMobileCardProps> = ({
             <Typography
               as="span"
               variant="statLg"
-              className="text-[40px] tracking-[-1px]"
+              className="text-[32px] tracking-[-1px]"
             >
               {sendableAmount}
             </Typography>
@@ -522,7 +499,7 @@ const WeeklyBalanceCard: FC<WeeklyBalanceCardProps> = ({
       <Typography
         as="div"
         variant="statLg"
-        className="mt-2.5 mb-1 text-[56px] tracking-[-2px]"
+        className="mt-2.5 mb-1 text-[40px] tracking-[-2px]"
       >
         {sendableAmount}
         <Typography as="span" variant="body" className="ml-1.5 opacity-80">
@@ -694,12 +671,6 @@ const ActivityRow: FC<{ item: ActivityItem }> = ({ item }) => {
   const accentClass = isSent ? "text-primary" : "text-contrib";
   const ringClass = isSent ? "ring-primary/20" : "ring-contrib/20";
   const iconName = isSent ? "send" : "heart";
-  const counterpartLabel =
-    item.direction === "received"
-      ? " さんから"
-      : item.direction === "sent"
-        ? " さんへ"
-        : " → ";
   return (
     <div className="flex items-center gap-3 px-4 py-3">
       <div
@@ -713,10 +684,11 @@ const ActivityRow: FC<{ item: ActivityItem }> = ({ item }) => {
       </div>
       <div className="min-w-0 flex-1">
         <Typography as="div" variant="bodySm" className="leading-tight">
-          <strong className="font-semibold">{item.counterpartName}</strong>
+          <strong className="font-semibold">{item.fromName}</strong>
           <Typography as="span" variant="bodySm" tone="secondary">
-            {counterpartLabel}
+            {" → "}
           </Typography>
+          <strong className="font-semibold">{item.toName}</strong>
         </Typography>
         {item.message && (
           <Typography

--- a/pkgs/frontend/hooks/useQuests.ts
+++ b/pkgs/frontend/hooks/useQuests.ts
@@ -1,0 +1,79 @@
+import { gql } from "@apollo/client/core";
+import { useQuery } from "@apollo/client/react/hooks";
+
+// Quest entities are defined in `pkgs/subgraph/schema.graphql` (HatsQuestModule
+// integration, issue #468). The deployed Goldsky endpoints haven't been
+// redeployed yet, so this query is written without codegen typings and uses
+// `errorPolicy: "ignore"` so the rest of the page renders cleanly when the
+// schema field is absent. Once the subgraph is redeployed the same query
+// shape returns data — no callsite changes required.
+
+export type QuestStatus = "Open" | "PendingReview" | "Completed" | "Cancelled";
+
+export interface Quest {
+  id: string;
+  questId: string;
+  hatId: string;
+  wearer: string;
+  creator: string;
+  submitter: string | null;
+  amount: string;
+  status: QuestStatus;
+  metadataHash: string;
+  approvalCount: number;
+  attemptCount: number;
+  createdAt: string;
+  blockTimestamp: string;
+}
+
+interface GetQuestsResult {
+  quests: Quest[];
+}
+
+const queryGetQuests = gql(`
+  query GetQuestsForWorkspace($workspaceId: String!, $first: Int = 10, $statuses: [String!]) {
+    quests(
+      where: { workspace: $workspaceId, status_in: $statuses }
+      orderBy: createdAt
+      orderDirection: desc
+      first: $first
+    ) {
+      id
+      questId
+      hatId
+      wearer
+      creator
+      submitter
+      amount
+      status
+      metadataHash
+      approvalCount
+      attemptCount
+      createdAt
+      blockTimestamp
+    }
+  }
+`);
+
+export const useQuests = (
+  workspaceId?: string,
+  options?: { statuses?: QuestStatus[]; first?: number },
+) => {
+  const { data, loading, error } = useQuery<GetQuestsResult>(queryGetQuests, {
+    variables: {
+      workspaceId: workspaceId ?? "",
+      first: options?.first ?? 10,
+      statuses: options?.statuses,
+    },
+    skip: !workspaceId,
+    // The Quest schema may not exist on every deployed subgraph yet — silence
+    // the error so the surrounding UI can render a graceful empty state.
+    errorPolicy: "ignore",
+  });
+
+  return {
+    quests: data?.quests ?? [],
+    isLoading: loading,
+    error,
+  };
+};


### PR DESCRIPTION
## Summary

Rebuilds the workspace home (`pkgs/frontend/app/routes/$treeId._index.tsx`) on top of the renewed design-system primitives, and reworks the surrounding AppShell so the home — and every nested page — uses the new sidebar / main-pane split.

### Workspace home (`/$treeId`)

- Greeting block ("こんにちは、X さん / 今日もおつかれさまです！") on top of a responsive layout:
  - **Mobile**: single column — `WeeklyBalanceCard` (gradient send-thanks card), 3-column stat grid (`受け取ったサンクス` / `今週の貢献` / `参加して …日目`), `あなたの当番`, `進行中のクエスト`, `最近のアクティビティ`.
  - **Desktop**: 2fr / 1fr grid — left column: stat grid, `進行中のクエスト`, `最近のアクティビティ`. Right column: `WeeklyBalanceCard`, `あなたの当番` (1-column).
- THX amounts are floored at the source (`Math.floor(Number(formatEther(...)))`), so all displays show integer values.
- StatCard gets a `valueClassName` pass-through; desktop value sizes step down from `statLg` (32 px) → 26 px so the stat row sits comfortably alongside the hero card.
- Recent-activity rows show **both** `from` and `to` names (resolved via ENS lookup, including the current user) instead of "X さんから / X さんへ".
- New `参加して …日目` stat — currently a **mock** (`daysSinceJoin = 45`). Tracking in #493: `HatsTimeFrameModule.getWoreTime(wearer, hatId)` exists per-hat on-chain (used by `ThanksToken.mintableAmount` for tenure weighting) but no subgraph entity / hook aggregates it into a per-workspace join time.

### AppShell adjustments

- **Sidebar account header**: the top "と / Toban / あたたかい当番帳" brand mark is replaced by `AccountMenu` (inline variant). When signed in the row shows avatar + name + address with a dropdown (プロフィール / 送金 / Logout); when signed out it renders a full-width primary Login button. The bottom user footer is removed (duplicate info).
- **Main-pane TopBar removed**: workspace title and notification bell are gone on both `TopBar` (desktop) and `AppHeader` (mobile). The workspace name lives in the sidebar, so the desktop header was redundant. `AppShellHandle` is trimmed to just `active`.
- **Scroll lock**: AppShell is now `h-dvh overflow-hidden` so the document doesn't scroll — only `<main>` does (`min-h-0 flex-1 overflow-y-auto`). Sidebar / BottomNav stay pinned.
- **WorkspaceSwitcherMenu** mounts only one primitive per viewport via a runtime `matchMedia` check. Previously both the desktop `Popover` and the mobile `Sheet` portaled to body at the same time and their focus traps fought — the bottom sheet flashed open and shut.
- **Sheet** bottom variant drops `border-t` (rounded top + shadow already separate the panel from the backdrop).

### Typography / UI

- Workspace home migrated to `Heading` / `Typography` primitives (no more raw `text-*` / `font-*` utilities on text nodes), matching the wider renewal in #491.
- 原則 (principles) card removed from desktop.

## Test plan

- [ ] `pnpm frontend dev` → open `/$treeId` as both signed-in and signed-out users.
- [ ] Mobile: hero card + 3-stat grid + duties + quests + activity render and scroll independently of the BottomNav.
- [ ] Desktop: left/right column layout with duties on the right, quests + activity on the left; only the main pane scrolls (sidebar stays pinned).
- [ ] Sidebar account header: dropdown actions navigate; signed-out state shows the Login CTA.
- [ ] Workspace switcher: clicking the sidebar pill opens the desktop Popover (no bottom sheet flash); same trigger on mobile opens only the Sheet.
- [ ] Recent activity shows `from → to` names, including the current user's name when involved.
- [ ] THX values are integer (no decimals) everywhere they appear.
- [ ] `pnpm frontend typecheck` and `pnpm biome:check` pass (verified in this branch's pre-commit runs).

Closes #433
Refs #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)