### PR TITLE
feat(frontend): renew duty list page (#434)

### DIFF
--- a/pkgs/frontend/app/routes/$treeId_.role.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.role.tsx
@@ -1,147 +1,982 @@
+import type { Hat } from "@hatsprotocol/sdk-v1-subgraph";
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { useNamesByAddresses } from "hooks/useENS";
 import { useGetBalanceOfFractionTokens } from "hooks/useFractionToken";
-import { useGetHats, useTreeInfo } from "hooks/useHats";
+import { useTreeInfo } from "hooks/useHats";
+import { type Quest, type QuestStatus, useQuests } from "hooks/useQuests";
 import { useActiveWallet } from "hooks/useWallet";
-import { type FC, useMemo } from "react";
-import { FaPlus } from "react-icons/fa6";
+import type { NameData } from "namestone-sdk";
+import { type FC, Fragment, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
-import type { Address } from "viem";
-import { StickyNav } from "~/components/StickyNav";
+import type { HatsDetailSchama } from "types/hats";
+import { ipfs2https } from "utils/ipfs";
+import { abbreviateAddress } from "utils/wallet";
+import { formatEther } from "viem";
+import { SectionLabel } from "~/components/composite/section-label";
+import { Segmented } from "~/components/composite/segmented";
+import { PageContainer } from "~/components/layout/PageContainer";
 import {
-  AspectRatio,
-  Box,
-  Heading,
-  SimpleGrid,
-  Text,
-  VStack,
-} from "~/components/chakra-shim";
-import CommonButton from "~/components/common/CommonButton";
-import { HatsListItemParser } from "~/components/common/HatsListItemParser";
-import { MyRole } from "~/components/roles/MyRole";
-import RoleWithBalance from "~/components/roles/RoleWithBalance";
-import { VRole } from "~/components/roles/VRole";
+  Avatar,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarImage,
+} from "~/components/ui/avatar";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Card } from "~/components/ui/card";
+import { Heading } from "~/components/ui/heading";
+import { Icon } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
+import { cn } from "~/lib/utils";
 
-const WorkspaceWithBalance: FC = () => {
-  const navigate = useNavigate();
+type DutyView = "duties" | "quests";
+type DutyFilter = "mine" | "all" | "open";
 
+// IPFS-backed Hat metadata. Shares the `["hats-detail", url]` cache key with
+// `HatsListItemParser` so we don't refetch when bouncing between the list and
+// detail screens.
+const useHatDetail = (detailsUri?: string) => {
+  const httpsUri = useMemo(() => ipfs2https(detailsUri), [detailsUri]);
+  const { data } = useQuery({
+    queryKey: ["hats-detail", httpsUri],
+    queryFn: async (): Promise<HatsDetailSchama | undefined> => {
+      if (!httpsUri) return;
+      const { data } = await axios.get<HatsDetailSchama>(httpsUri);
+      return data;
+    },
+    enabled: !!httpsUri,
+    staleTime: 1000 * 60 * 60,
+  });
+  return data;
+};
+
+const WorkspaceRoles: FC = () => {
   const { treeId } = useParams();
+  const navigate = useNavigate();
+  const { wallet } = useActiveWallet();
+  const me = wallet?.account?.address?.toLowerCase();
+
   const tree = useTreeInfo(Number(treeId));
 
-  const { wallet } = useActiveWallet();
-  const me = wallet?.account?.address;
+  const [view, setView] = useState<DutyView>("duties");
+  const [filter, setFilter] = useState<DutyFilter>("all");
 
-  const { data } = useGetBalanceOfFractionTokens({
-    where: {
-      workspaceId: treeId,
-      owner: wallet?.account.address.toLowerCase(),
-    },
-    first: 100,
-  });
-
-  const hatIds = useMemo(() => {
-    return Array.from(
-      new Set(data?.balanceOfFractionTokens.map(({ hatId }) => hatId)),
-    );
-  }, [data]);
-
-  const { hats } = useGetHats(hatIds || []);
-
-  const hatsWithBalance = useMemo(() => {
-    if (!hats || !data) return [];
-    return data.balanceOfFractionTokens
-      .map(({ hatId, balance, wearer }) => {
-        const hat = hats.find(({ id }) => hatId === BigInt(id).toString());
-        if (hat) return { hat, balance, wearer };
-      })
-      .filter((data) => !!data);
-  }, [hats, data]);
-
-  // 0002は管理系のハットなのでここでは除外
-  const tobanList = useMemo(() => {
-    return tree?.hats?.filter(
+  // Role-branch hats only (0001). 0002 is the admin/operator branch and is
+  // excluded from the duty list — matching the legacy behaviour in
+  // `WorkspaceWithBalance` before the renewal.
+  const dutyHats = useMemo(() => {
+    if (!tree?.hats) return [];
+    return tree.hats.filter(
       (h) =>
         Number(h.levelAtLocalTree) >= 2 &&
-        h.prettyId?.startsWith(`${tree?.id}.0001`),
+        h.prettyId?.startsWith(`${tree.id}.0001`),
     );
   }, [tree]);
 
+  const filteredDuties = useMemo(() => {
+    return dutyHats.filter((h) => {
+      const wearers = h.wearers ?? [];
+      if (filter === "mine") {
+        return !!me && wearers.some((w) => w.id?.toLowerCase() === me);
+      }
+      if (filter === "open") {
+        return wearers.length === 0;
+      }
+      return true;
+    });
+  }, [dutyHats, filter, me]);
+
+  // Workspace-wide FractionToken balances. Owners of a balance for a given hat
+  // who aren't themselves wearers count as "supporters" of that duty (they
+  // received a role share from a wearer). `first: 1000` caps an unbounded
+  // result set; very large workspaces would need pagination, but the existing
+  // subgraph balance queries elsewhere use the same ceiling.
+  const { data: balanceData } = useGetBalanceOfFractionTokens({
+    where: { workspaceId: treeId },
+    first: 1000,
+  });
+
+  // Per-hat supporter list, keyed by the hat's hex id (matching `hat.id` in
+  // the Hats subgraph). FractionToken `hatId` is decimal — convert via BigInt.
+  const supportersByHat = useMemo(() => {
+    const map = new Map<string, string[]>();
+    if (!balanceData) return map;
+    const wearerByHatHex = new Map<string, Set<string>>();
+    for (const h of dutyHats) {
+      const set = new Set<string>();
+      for (const w of h.wearers ?? []) {
+        if (w.id) set.add(w.id.toLowerCase());
+      }
+      wearerByHatHex.set(h.id.toLowerCase(), set);
+    }
+    const buckets = new Map<string, Set<string>>();
+    for (const b of balanceData.balanceOfFractionTokens) {
+      if (Number(b.balance) <= 0) continue;
+      let hatHex: string;
+      try {
+        hatHex = `0x${BigInt(b.hatId).toString(16).padStart(64, "0")}`;
+      } catch {
+        continue;
+      }
+      const wearers = wearerByHatHex.get(hatHex);
+      const owner = b.owner.toLowerCase();
+      // Skip wearers themselves so they show up exclusively as 担当者.
+      if (wearers?.has(owner)) continue;
+      if (!buckets.has(hatHex)) buckets.set(hatHex, new Set());
+      buckets.get(hatHex)?.add(owner);
+    }
+    for (const [hatHex, set] of buckets) {
+      map.set(hatHex, Array.from(set));
+    }
+    return map;
+  }, [balanceData, dutyHats]);
+
+  // Resolve all unique member addresses (wearers + supporters) up-front so
+  // each DutyCard reuses the same Namestone batch instead of issuing one
+  // query per row.
+  const memberAddresses = useMemo(() => {
+    const set = new Set<string>();
+    for (const h of dutyHats) {
+      for (const w of h.wearers ?? []) {
+        if (w.id) set.add(w.id.toLowerCase());
+      }
+    }
+    for (const supporters of supportersByHat.values()) {
+      for (const addr of supporters) set.add(addr);
+    }
+    return Array.from(set);
+  }, [dutyHats, supportersByHat]);
+  const { names } = useNamesByAddresses(memberAddresses);
+  const nameByAddress = useMemo(() => {
+    const map = new Map<string, NameData>();
+    for (const group of names) {
+      const entry = group[0];
+      if (entry?.address) map.set(entry.address.toLowerCase(), entry);
+    }
+    return map;
+  }, [names]);
+
+  const goCreateDuty = () => navigate(`/${treeId}/roles/new`);
+
   return (
-    <Box>
-      {/* All roles */}
-      <Box pt={5}>
-        <Heading pb={4}>当番一覧</Heading>
-        <SimpleGrid columns={4} gap={4}>
-          {tobanList?.map((h) => (
-            <Link key={`allrole${h.id}`} to={`/${treeId}/${h.id}`}>
-              <HatsListItemParser imageUri={h.imageUri} detailUri={h.details}>
-                <VRole iconSize="80px" />
-              </HatsListItemParser>
-            </Link>
-          ))}
-          <VStack>
-            <AspectRatio width="80px" ratio={1}>
-              <CommonButton
-                rounded="xl"
-                onClick={() => navigate(`/${treeId}/roles/new`)}
-                bgColor="gray.300"
-              >
-                <FaPlus />
-              </CommonButton>
-            </AspectRatio>
-            <Text>Add role</Text>
-          </VStack>
-        </SimpleGrid>
-      </Box>
+    <PageContainer className="pt-4 pb-8 md:pt-6">
+      {/* Mobile single-column. */}
+      <div className="md:hidden">
+        <header className="mb-3 px-1">
+          <Heading variant="h2" level={1}>
+            当番
+          </Heading>
+          <Typography variant="bodySm" tone="secondary" className="mt-0.5">
+            コミュニティの役割と関わり
+          </Typography>
+        </header>
 
-      {/* My roles */}
-      <Box pt={10}>
-        <Heading pb={4}>担当当番</Heading>
-        <VStack gap={3} align="stretch">
-          {tree?.hats
-            ?.filter((h) => Number(h.levelAtLocalTree) >= 2)
-            .filter((h) => h.wearers?.some((w) => w.id === me?.toLowerCase()))
-            .map((h) => (
-              <HatsListItemParser
-                key={h.id}
-                imageUri={h.imageUri}
-                detailUri={h.details}
-              >
-                <MyRole address={me} treeId={treeId} hatId={h.id} />
-              </HatsListItemParser>
-            ))}
-        </VStack>
-      </Box>
+        <div className="px-1 pb-3">
+          <Segmented
+            value={view}
+            onChange={setView}
+            options={[
+              { value: "duties", label: "当番" },
+              { value: "quests", label: "クエスト" },
+            ]}
+            className="w-full"
+          />
+        </div>
 
-      {/* Role Share */}
-      <Box pt={14}>
-        <Heading pb={4}>
-          {["144", "175", "780"].includes(treeId || "")
-            ? "ケアポイント"
-            : "ロールシェア"}
-          の残高
-        </Heading>
-        <VStack width="full" gapY={5}>
-          {wallet &&
-            hatsWithBalance.map(({ hat, balance, wearer }) => (
-              <HatsListItemParser
-                key={hat.id}
-                imageUri={hat.imageUri}
-                detailUri={hat.details}
-              >
-                <RoleWithBalance
-                  balance={Number(balance)}
-                  treeId={treeId}
-                  hatId={hat.id}
-                  wearer={wearer as Address}
-                  address={wallet?.account.address}
-                  showSendButton
-                />
-              </HatsListItemParser>
-            ))}
-        </VStack>
-      </Box>
-      <StickyNav />
-    </Box>
+        {view === "duties" ? (
+          <DutiesPanel
+            duties={filteredDuties}
+            filter={filter}
+            onFilterChange={setFilter}
+            treeId={treeId ?? ""}
+            nameByAddress={nameByAddress}
+            supportersByHat={supportersByHat}
+            onCreate={goCreateDuty}
+          />
+        ) : (
+          <QuestsPanel treeId={treeId} dutyHats={dutyHats} />
+        )}
+      </div>
+
+      {/* Desktop master + summary. */}
+      <div className="hidden md:block">
+        <DesktopRolesView
+          dutyHats={dutyHats}
+          filteredDuties={filteredDuties}
+          view={view}
+          onViewChange={setView}
+          filter={filter}
+          onFilterChange={setFilter}
+          treeId={treeId ?? ""}
+          nameByAddress={nameByAddress}
+          supportersByHat={supportersByHat}
+          onCreate={goCreateDuty}
+        />
+      </div>
+    </PageContainer>
   );
 };
 
-export default WorkspaceWithBalance;
+export default WorkspaceRoles;
+
+// ───────────────────────── Mobile: Duties panel ─────────────────────────
+
+interface DutiesPanelProps {
+  duties: Hat[];
+  filter: DutyFilter;
+  onFilterChange: (next: DutyFilter) => void;
+  treeId: string;
+  nameByAddress: Map<string, NameData>;
+  supportersByHat: Map<string, string[]>;
+  onCreate: () => void;
+}
+
+const DutiesPanel: FC<DutiesPanelProps> = ({
+  duties,
+  filter,
+  onFilterChange,
+  treeId,
+  nameByAddress,
+  supportersByHat,
+  onCreate,
+}) => (
+  <>
+    <div className="px-1 pb-3">
+      <Segmented
+        value={filter}
+        onChange={onFilterChange}
+        options={[
+          { value: "mine", label: "あなたの当番" },
+          { value: "all", label: "すべて" },
+          { value: "open", label: "空き" },
+        ]}
+        className="w-full"
+      />
+    </div>
+
+    {duties.length > 0 ? (
+      <div className="flex flex-col gap-2.5 px-1">
+        {duties.map((h) => (
+          <DutyCard
+            key={h.id}
+            hat={h}
+            treeId={treeId}
+            nameByAddress={nameByAddress}
+            supporters={supportersByHat.get(h.id.toLowerCase()) ?? []}
+          />
+        ))}
+      </div>
+    ) : (
+      <Card className="mx-1 py-8 text-center">
+        <Typography variant="bodySm" tone="secondary">
+          {emptyLabel(filter)}
+        </Typography>
+      </Card>
+    )}
+
+    <div className="px-1 pt-4">
+      <Button variant="secondary" full onClick={onCreate}>
+        <Icon name="plus" size={16} />
+        当番を作成
+      </Button>
+    </div>
+  </>
+);
+
+const emptyLabel = (filter: DutyFilter): string => {
+  if (filter === "mine") return "担当中の当番はありません";
+  if (filter === "open") return "空きの当番はありません";
+  return "当番がまだ作成されていません";
+};
+
+// ───────────────────────── DutyCard ─────────────────────────
+
+interface DutyCardProps {
+  hat: Hat;
+  treeId: string;
+  nameByAddress: Map<string, NameData>;
+  /** Supporter addresses (FractionToken holders excluding wearers). */
+  supporters: string[];
+  /** Render a compact variant (used in the desktop master list). */
+  compact?: boolean;
+  selected?: boolean;
+  onSelect?: () => void;
+}
+
+const DutyCard: FC<DutyCardProps> = ({
+  hat,
+  treeId,
+  nameByAddress,
+  supporters,
+  compact = false,
+  selected = false,
+  onSelect,
+}) => {
+  const detail = useHatDetail(hat.details);
+  const imageUrl = ipfs2https(hat.imageUri);
+  const name = detail?.data?.name ?? "当番";
+  const wearerAddresses = useMemo(
+    () =>
+      (hat.wearers ?? [])
+        .map((w) => w.id?.toLowerCase())
+        .filter((a): a is string => !!a),
+    [hat.wearers],
+  );
+  const content = (
+    <>
+      <div className="flex min-w-0 items-center gap-3">
+        <DutyIcon imageUrl={imageUrl} size={compact ? "sm" : "md"} />
+        {compact ? (
+          <Typography as="div" variant="bodySm" weight="bold" truncate>
+            {name}
+          </Typography>
+        ) : (
+          <Heading variant="h6" level={3} className="truncate">
+            {name}
+          </Heading>
+        )}
+      </div>
+      <div
+        className={cn(
+          "flex flex-col gap-1.5",
+          compact ? "pl-12" : "pl-[3.25rem]",
+        )}
+      >
+        <MemberRow
+          label="担当者"
+          addresses={wearerAddresses}
+          nameByAddress={nameByAddress}
+          emptyLabel="募集中"
+          maxVisible={compact ? 3 : 5}
+        />
+        <MemberRow
+          label="サポーター"
+          addresses={supporters}
+          nameByAddress={nameByAddress}
+          emptyLabel="なし"
+          maxVisible={compact ? 3 : 5}
+        />
+      </div>
+    </>
+  );
+
+  const cardClass = cn(
+    "gap-2 transition-colors",
+    compact
+      ? "cursor-pointer rounded-md border px-3 py-3 hover:bg-bg"
+      : "px-3.5 py-3.5 hover:bg-bg",
+    selected && "border-primary bg-surface shadow-2",
+  );
+
+  if (onSelect) {
+    return (
+      <button
+        type="button"
+        onClick={onSelect}
+        className="block w-full text-left"
+      >
+        <Card className={cardClass}>{content}</Card>
+      </button>
+    );
+  }
+
+  return (
+    <Link
+      to={`/${treeId}/${hat.id}`}
+      className="block focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+    >
+      <Card className={cardClass}>{content}</Card>
+    </Link>
+  );
+};
+
+interface MemberRowProps {
+  label: string;
+  addresses: string[];
+  nameByAddress: Map<string, NameData>;
+  emptyLabel: string;
+  maxVisible?: number;
+}
+
+const MemberRow: FC<MemberRowProps> = ({
+  label,
+  addresses,
+  nameByAddress,
+  emptyLabel,
+  maxVisible = 5,
+}) => {
+  return (
+    <div className="flex items-center gap-2">
+      <Typography
+        as="span"
+        variant="micro"
+        tone="secondary"
+        weight="semibold"
+        className="w-16 shrink-0"
+      >
+        {label}
+      </Typography>
+      {addresses.length === 0 ? (
+        <Typography variant="micro" tone="secondary" as="span">
+          {emptyLabel}
+        </Typography>
+      ) : (
+        <MemberAvatars
+          addresses={addresses}
+          nameByAddress={nameByAddress}
+          maxVisible={maxVisible}
+        />
+      )}
+    </div>
+  );
+};
+
+interface MemberAvatarsProps {
+  addresses: string[];
+  nameByAddress: Map<string, NameData>;
+  maxVisible?: number;
+}
+
+const MemberAvatars: FC<MemberAvatarsProps> = ({
+  addresses,
+  nameByAddress,
+  maxVisible = 5,
+}) => {
+  const visible = addresses.slice(0, maxVisible);
+  const overflow = addresses.length - visible.length;
+  return (
+    <AvatarGroup className="-space-x-1">
+      {visible.map((addr) => {
+        const entry = nameByAddress.get(addr);
+        const seed =
+          entry?.name ?? abbreviateAddress(addr as `0x${string}`) ?? addr;
+        const avatar = ipfs2https(entry?.text_records?.avatar);
+        return (
+          <Avatar
+            key={addr}
+            size="sm"
+            className="size-6 text-[9px]"
+            title={seed}
+          >
+            {avatar && <AvatarImage src={avatar} alt="" />}
+            <AvatarFallback seed={seed} />
+          </Avatar>
+        );
+      })}
+      {overflow > 0 && (
+        <AvatarGroupCount className="size-6 text-[10px]">
+          +{overflow}
+        </AvatarGroupCount>
+      )}
+    </AvatarGroup>
+  );
+};
+
+const DutyIcon: FC<{ imageUrl?: string; size: "sm" | "md" }> = ({
+  imageUrl,
+  size,
+}) => (
+  <div
+    className={cn(
+      "flex shrink-0 items-center justify-center overflow-hidden rounded-sm bg-[#F2EAD9]",
+      size === "md" ? "size-10" : "size-9",
+    )}
+  >
+    {imageUrl ? (
+      <img src={imageUrl} alt="" className="size-full object-cover" />
+    ) : (
+      <Icon
+        name="duty"
+        size={size === "md" ? 20 : 18}
+        className="text-[#7A5A2E]"
+      />
+    )}
+  </div>
+);
+
+// ───────────────────────── Quests panel ─────────────────────────
+
+interface QuestsPanelProps {
+  treeId?: string;
+  dutyHats: Hat[];
+}
+
+const QuestsPanel: FC<QuestsPanelProps> = ({ treeId, dutyHats }) => {
+  const { quests, isLoading } = useQuests(treeId, { first: 50 });
+
+  // Map hatId (decimal, returned by the Quest entity) → hat detail URI so
+  // each quest card can show its parent duty's name without re-fetching.
+  const hatByDecimalId = useMemo(() => {
+    const map = new Map<string, Hat>();
+    for (const h of dutyHats) {
+      try {
+        map.set(BigInt(h.id).toString(), h);
+      } catch {
+        // ignore non-hex ids
+      }
+    }
+    return map;
+  }, [dutyHats]);
+
+  const groups: { status: QuestStatus; title: string }[] = [
+    { status: "Open", title: "募集中のクエスト" },
+    { status: "PendingReview", title: "確認待ち" },
+    { status: "Completed", title: "完了" },
+  ];
+
+  const hasAny = quests.length > 0;
+
+  if (isLoading && !hasAny) {
+    return (
+      <Card className="mx-1 py-8 text-center">
+        <Typography variant="bodySm" tone="secondary">
+          クエストを読み込み中…
+        </Typography>
+      </Card>
+    );
+  }
+
+  if (!hasAny) {
+    return (
+      <Card className="mx-1 py-8 text-center">
+        <Typography variant="bodySm" tone="secondary">
+          クエストはまだありません
+        </Typography>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {groups.map((g) => {
+        const items = quests.filter((q) => q.status === g.status);
+        if (items.length === 0) return null;
+        return (
+          <Fragment key={g.status}>
+            <SectionLabel className="px-1">
+              {g.title}（{items.length}）
+            </SectionLabel>
+            <div className="flex flex-col gap-2 px-1">
+              {items.map((q) => (
+                <QuestCard
+                  key={q.id}
+                  quest={q}
+                  hat={hatByDecimalId.get(q.hatId)}
+                  treeId={treeId}
+                />
+              ))}
+            </div>
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+};
+
+interface QuestCardProps {
+  quest: Quest;
+  hat?: Hat;
+  treeId?: string;
+}
+
+const QuestCard: FC<QuestCardProps> = ({ quest, hat, treeId }) => {
+  const detail = useHatDetail(hat?.details);
+  const dutyName = detail?.data?.name;
+  const amount = (() => {
+    try {
+      return Number(formatEther(BigInt(quest.amount))).toLocaleString();
+    } catch {
+      return "0";
+    }
+  })();
+
+  const card = (
+    <Card className="gap-2 px-3.5 py-3 transition-colors hover:bg-bg">
+      <div className="flex items-start gap-2.5">
+        <div className="min-w-0 flex-1">
+          {dutyName && (
+            <Typography
+              as="div"
+              variant="micro"
+              tone="secondary"
+              weight="bold"
+              truncate
+              className="mb-0.5"
+            >
+              {dutyName}
+            </Typography>
+          )}
+          <Typography as="div" variant="bodySm" weight="bold" truncate>
+            Quest #{quest.questId}
+          </Typography>
+          <div className="mt-1 flex items-center gap-2">
+            <QuestStateBadge status={quest.status} />
+            <Typography variant="micro" tone="secondary" as="span">
+              {questMeta(quest)}
+            </Typography>
+          </div>
+        </div>
+        <div className="shrink-0 text-right">
+          <Typography variant="micro" tone="secondary" as="div">
+            当番シェア
+          </Typography>
+          <Typography
+            as="div"
+            variant="statMd"
+            className="text-primary tracking-[-0.5px]"
+          >
+            +{amount}
+            <Typography
+              as="span"
+              variant="micro"
+              tone="secondary"
+              className="ml-0.5"
+            >
+              THX
+            </Typography>
+          </Typography>
+        </div>
+      </div>
+    </Card>
+  );
+
+  // Quest detail route doesn't ship until #446. Wrap in Link only when we have
+  // a sensible hat to fall back to (parent duty), otherwise render unlinked.
+  if (treeId && hat?.id) {
+    return (
+      <Link
+        to={`/${treeId}/${hat.id}`}
+        className="block focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+      >
+        {card}
+      </Link>
+    );
+  }
+  return card;
+};
+
+const QuestStateBadge: FC<{ status: QuestStatus }> = ({ status }) => {
+  switch (status) {
+    case "Open":
+      return <Badge kind="lead">募集中</Badge>;
+    case "PendingReview":
+      return <Badge kind="info">確認待ち</Badge>;
+    case "Completed":
+      return <Badge kind="member">完了</Badge>;
+    case "Cancelled":
+      return <Badge kind="role">取消</Badge>;
+    default:
+      return null;
+  }
+};
+
+const questMeta = (q: Quest): string => {
+  if (q.status === "Open") {
+    return `作成者: ${abbreviateAddress(q.creator as `0x${string}`)}`;
+  }
+  if (q.status === "PendingReview") {
+    return `申請者: ${
+      q.submitter ? abbreviateAddress(q.submitter as `0x${string}`) : "-"
+    }・承認 ${q.approvalCount}/2`;
+  }
+  if (q.status === "Completed") {
+    return `${
+      q.submitter ? abbreviateAddress(q.submitter as `0x${string}`) : "-"
+    } が完了`;
+  }
+  return "";
+};
+
+// ───────────────────────── Desktop master-detail ─────────────────────────
+
+interface DesktopRolesViewProps {
+  dutyHats: Hat[];
+  filteredDuties: Hat[];
+  view: DutyView;
+  onViewChange: (v: DutyView) => void;
+  filter: DutyFilter;
+  onFilterChange: (f: DutyFilter) => void;
+  treeId: string;
+  nameByAddress: Map<string, NameData>;
+  supportersByHat: Map<string, string[]>;
+  onCreate: () => void;
+}
+
+const DesktopRolesView: FC<DesktopRolesViewProps> = ({
+  dutyHats,
+  filteredDuties,
+  view,
+  onViewChange,
+  filter,
+  onFilterChange,
+  treeId,
+  nameByAddress,
+  supportersByHat,
+  onCreate,
+}) => {
+  const [selectedId, setSelectedId] = useState<string | undefined>(
+    () => filteredDuties[0]?.id ?? dutyHats[0]?.id,
+  );
+  const selectedHat =
+    dutyHats.find((h) => h.id === selectedId) ??
+    filteredDuties[0] ??
+    dutyHats[0];
+
+  return (
+    <div className="grid grid-cols-[320px_1fr] gap-6">
+      {/* Master */}
+      <aside className="flex flex-col gap-3">
+        <header className="px-1">
+          <Heading variant="h2" level={1}>
+            当番
+          </Heading>
+          <Typography variant="bodySm" tone="secondary" className="mt-0.5">
+            コミュニティの役割と関わり
+          </Typography>
+        </header>
+        <Segmented
+          value={view}
+          onChange={onViewChange}
+          options={[
+            { value: "duties", label: "当番" },
+            { value: "quests", label: "クエスト" },
+          ]}
+          className="w-full"
+        />
+        {view === "duties" ? (
+          <>
+            <Segmented
+              value={filter}
+              onChange={onFilterChange}
+              options={[
+                { value: "mine", label: "あなた" },
+                { value: "all", label: "すべて" },
+                { value: "open", label: "空き" },
+              ]}
+              className="w-full"
+            />
+            {filteredDuties.length > 0 ? (
+              <div className="flex flex-col gap-1.5">
+                {filteredDuties.map((h) => (
+                  <DutyCard
+                    key={h.id}
+                    hat={h}
+                    treeId={treeId}
+                    nameByAddress={nameByAddress}
+                    supporters={supportersByHat.get(h.id.toLowerCase()) ?? []}
+                    compact
+                    selected={h.id === selectedHat?.id}
+                    onSelect={() => setSelectedId(h.id)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <Card className="py-6 text-center">
+                <Typography variant="bodySm" tone="secondary">
+                  {emptyLabel(filter)}
+                </Typography>
+              </Card>
+            )}
+            <Button
+              variant="secondary"
+              full
+              onClick={onCreate}
+              className="mt-1"
+            >
+              <Icon name="plus" size={16} />
+              当番を作成
+            </Button>
+          </>
+        ) : (
+          <QuestsPanel treeId={treeId} dutyHats={dutyHats} />
+        )}
+      </aside>
+
+      {/* Detail */}
+      <section>
+        {view === "duties" && selectedHat ? (
+          <DutyDetailPreview
+            hat={selectedHat}
+            treeId={treeId}
+            nameByAddress={nameByAddress}
+            supporters={supportersByHat.get(selectedHat.id.toLowerCase()) ?? []}
+          />
+        ) : view === "duties" ? (
+          <Card className="py-12 text-center">
+            <Typography variant="bodySm" tone="secondary">
+              当番を選択してください
+            </Typography>
+          </Card>
+        ) : (
+          <Card className="py-12 text-center">
+            <Typography variant="bodySm" tone="secondary">
+              左のリストからクエストを選択してください
+            </Typography>
+          </Card>
+        )}
+      </section>
+    </div>
+  );
+};
+
+interface DutyDetailPreviewProps {
+  hat: Hat;
+  treeId: string;
+  nameByAddress: Map<string, NameData>;
+  supporters: string[];
+}
+
+// Lightweight preview for the master-detail right pane. The full duty detail
+// page (#435) will eventually own this slot — until then, surface enough
+// information to confirm a selection and link out to the dedicated route.
+const DutyDetailPreview: FC<DutyDetailPreviewProps> = ({
+  hat,
+  treeId,
+  nameByAddress,
+  supporters,
+}) => {
+  const detail = useHatDetail(hat.details);
+  const imageUrl = ipfs2https(hat.imageUri);
+  const name = detail?.data?.name ?? "当番";
+  const description = detail?.data?.description;
+  const wearers = hat.wearers ?? [];
+  const wearerAddresses = wearers
+    .map((w) => w.id?.toLowerCase())
+    .filter((a): a is string => !!a);
+
+  return (
+    <Card className="gap-5 py-6">
+      <div className="flex items-start gap-4 px-6">
+        <div className="flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-md bg-[#F2EAD9]">
+          {imageUrl ? (
+            <img src={imageUrl} alt="" className="size-full object-cover" />
+          ) : (
+            <Icon name="duty" size={28} className="text-[#7A5A2E]" />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <Heading variant="h3" level={2} className="truncate">
+            {name}
+          </Heading>
+        </div>
+        <Button variant="secondary" asChild>
+          <Link to={`/${treeId}/${hat.id}`}>
+            詳細を見る
+            <Icon name="chevron-right" size={16} />
+          </Link>
+        </Button>
+      </div>
+
+      {description && (
+        <div className="px-6">
+          <SectionLabel className="mb-2 px-0">説明</SectionLabel>
+          <Typography variant="bodySm" tone="secondary">
+            {description}
+          </Typography>
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-4 px-6">
+        <MemberColumn
+          title="担当者"
+          count={wearerAddresses.length}
+          addresses={wearerAddresses}
+          nameByAddress={nameByAddress}
+          treeId={treeId}
+          hatId={hat.id}
+          linkable
+          emptyLabel="担当者を募集中"
+        />
+        <MemberColumn
+          title="サポーター"
+          count={supporters.length}
+          addresses={supporters}
+          nameByAddress={nameByAddress}
+          treeId={treeId}
+          hatId={hat.id}
+          linkable={false}
+          emptyLabel="まだいません"
+        />
+      </div>
+    </Card>
+  );
+};
+
+interface MemberColumnProps {
+  title: string;
+  count: number;
+  addresses: string[];
+  nameByAddress: Map<string, NameData>;
+  treeId: string;
+  hatId: string;
+  linkable: boolean;
+  emptyLabel: string;
+}
+
+const MemberColumn: FC<MemberColumnProps> = ({
+  title,
+  count,
+  addresses,
+  nameByAddress,
+  treeId,
+  hatId,
+  linkable,
+  emptyLabel,
+}) => (
+  <div>
+    <SectionLabel className="mb-2 px-0">
+      {title}（{count}）
+    </SectionLabel>
+    {addresses.length === 0 ? (
+      <Typography variant="bodySm" tone="secondary">
+        {emptyLabel}
+      </Typography>
+    ) : (
+      <div className="flex flex-col gap-1">
+        {addresses.map((addr) => {
+          const entry = nameByAddress.get(addr);
+          const displayName =
+            entry?.name ?? abbreviateAddress(addr as `0x${string}`);
+          const avatar = ipfs2https(entry?.text_records?.avatar);
+          const rowClass =
+            "flex items-center gap-2.5 rounded-sm px-2 py-1.5 hover:bg-bg";
+          if (linkable) {
+            return (
+              <Link
+                key={addr}
+                to={`/${treeId}/${hatId}/${addr}`}
+                className={rowClass}
+              >
+                <Avatar size="sm">
+                  {avatar && <AvatarImage src={avatar} alt="" />}
+                  <AvatarFallback seed={displayName} />
+                </Avatar>
+                <Typography
+                  as="span"
+                  variant="bodySm"
+                  weight="semibold"
+                  truncate
+                >
+                  {displayName}
+                </Typography>
+              </Link>
+            );
+          }
+          return (
+            <div key={addr} className={rowClass}>
+              <Avatar size="sm">
+                {avatar && <AvatarImage src={avatar} alt="" />}
+                <AvatarFallback seed={displayName} />
+              </Avatar>
+              <Typography as="span" variant="bodySm" weight="semibold" truncate>
+                {displayName}
+              </Typography>
+            </div>
+          );
+        })}
+      </div>
+    )}
+  </div>
+);


### PR DESCRIPTION
## Summary
- Rebuild `/{treeId}/role` on the new design system: subtitle header, 当番 / クエスト segmented switch, あなたの当番 / すべて / 空き filter.
- Replace the single 担当者名 line with two avatar-group rows split into **担当者** (Hat wearers) and **サポーター** (FractionToken holders excluding wearers). Supporters are derived from a workspace-wide `useGetBalanceOfFractionTokens` query.
- Desktop master-detail (`320px + 1fr`) with a lightweight `DutyDetailPreview` placeholder — to be replaced by Phase 3 #435 (Duty Detail).
- Quest panel groups by 募集中 / 確認待ち / 完了 and resolves parent duty name via `tree.hats`. Quest cards link to the parent duty until #446 (Quest Detail) ships.
- IPFS-backed avatars are routed through `ipfs2https()` so Pinata Gateway URLs are HTTPS-resolvable.

Closes #434.

## Test plan
- [ ] On mobile (< 768px): subtitle, view segmented (当番 / クエスト), filter segmented (あなたの当番 / すべて / 空き) all work; DutyCard tap navigates to `/{treeId}/{hatId}`; 「当番を作成」 navigates to `/{treeId}/roles/new`.
- [ ] On desktop (≥ 768px): master-detail layout shows; clicking a master card updates the right preview; 「詳細を見る」 links to `/{treeId}/{hatId}`.
- [ ] 担当者 / サポーター avatar groups render with images (Pinata gateway). Overflow shows `+N` chip when > 5 (mobile) or > 3 (desktop master).
- [ ] When the subgraph supports quests, クエスト view groups items by status and shows parent duty name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)