### PR TITLE
feat(frontend): renew duty detail + holder detail screens (#435)

### DIFF
--- a/pkgs/frontend/abi/hatsTimeFrameModule.ts
+++ b/pkgs/frontend/abi/hatsTimeFrameModule.ts
@@ -152,6 +152,25 @@ export const HATS_TIME_FRAME_MODULE_ABI = [
   {
     inputs: [
       {
+        internalType: "address",
+        name: "authority",
+        type: "address",
+      },
+    ],
+    name: "hasAuthority",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
         internalType: "uint256",
         name: "",
         type: "uint256",

--- a/pkgs/frontend/app/components/composite/breadcrumb.stories.tsx
+++ b/pkgs/frontend/app/components/composite/breadcrumb.stories.tsx
@@ -1,0 +1,40 @@
+import type { Story } from "@ladle/react";
+import { MemoryRouter } from "react-router";
+
+import { Breadcrumb } from "./breadcrumb";
+
+export default {
+  title: "Composite / Breadcrumb",
+};
+
+export const Default: Story = () => (
+  <MemoryRouter>
+    <div className="w-96">
+      <Breadcrumb
+        items={[
+          { label: "当番一覧", to: "/123/role" },
+          { label: "皿洗い", to: "/123/0xabc" },
+          { label: "担当者" },
+        ]}
+      />
+    </div>
+  </MemoryRouter>
+);
+
+export const TwoItems: Story = () => (
+  <MemoryRouter>
+    <div className="w-96">
+      <Breadcrumb
+        items={[{ label: "当番一覧", to: "/123/role" }, { label: "皿洗い" }]}
+      />
+    </div>
+  </MemoryRouter>
+);
+
+export const CurrentOnly: Story = () => (
+  <MemoryRouter>
+    <div className="w-96">
+      <Breadcrumb items={[{ label: "当番一覧" }]} />
+    </div>
+  </MemoryRouter>
+);

--- a/pkgs/frontend/app/components/composite/breadcrumb.tsx
+++ b/pkgs/frontend/app/components/composite/breadcrumb.tsx
@@ -1,0 +1,81 @@
+import type * as React from "react";
+import { Link } from "react-router";
+
+import { Icon } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
+import { cn } from "~/lib/utils";
+
+interface BreadcrumbItem {
+  label: React.ReactNode;
+  /** Optional href. The last item is always rendered as a disabled link so the
+   *  layout/baseline stays identical to the linked items above it. */
+  to?: string;
+}
+
+interface BreadcrumbProps
+  extends Omit<React.ComponentProps<"nav">, "children"> {
+  items: BreadcrumbItem[];
+}
+
+// Toban Breadcrumb — left-aligned chain of links + chevron separators that
+// doubles as the back-navigation control for nested duty/holder pages.
+// Every crumb is wrapped in a `<Link>` so the rendered element (and therefore
+// the text baseline) is consistent across the row. The current page is marked
+// disabled via `aria-disabled` + `pointer-events-none` so it isn't clickable.
+function Breadcrumb({ items, className, ...rest }: BreadcrumbProps) {
+  return (
+    <nav
+      aria-label="breadcrumb"
+      data-slot="breadcrumb"
+      className={cn("w-full", className)}
+      {...rest}
+    >
+      <ol className="flex flex-wrap items-center gap-1">
+        {items.map((item, i) => {
+          const isLast = i === items.length - 1;
+          const disabled = isLast || !item.to;
+          return (
+            <li
+              key={`${i}-${typeof item.label === "string" ? item.label : i}`}
+              className="flex min-w-0 items-center gap-1"
+            >
+              <Link
+                to={item.to ?? "."}
+                aria-disabled={disabled ? "true" : undefined}
+                tabIndex={disabled ? -1 : undefined}
+                onClick={disabled ? (e) => e.preventDefault() : undefined}
+                className={cn(
+                  "min-w-0 focus-visible:rounded-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+                  disabled && "pointer-events-none cursor-default",
+                )}
+              >
+                <Typography
+                  as="span"
+                  variant="caption"
+                  tone={isLast ? "primary" : "secondary"}
+                  truncate
+                  aria-current={isLast ? "page" : undefined}
+                  className={cn(
+                    !disabled && "transition-colors hover:text-text-primary",
+                  )}
+                >
+                  {item.label}
+                </Typography>
+              </Link>
+              {!isLast && (
+                <Icon
+                  name="chevron-right"
+                  size={12}
+                  className="shrink-0 text-text-secondary"
+                />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+
+export { Breadcrumb };
+export type { BreadcrumbItem, BreadcrumbProps };

--- a/pkgs/frontend/app/components/composite/share-distribution.stories.tsx
+++ b/pkgs/frontend/app/components/composite/share-distribution.stories.tsx
@@ -1,0 +1,71 @@
+import type { Story } from "@ladle/react";
+import { Avatar, AvatarFallback } from "~/components/ui/avatar";
+import { ShareDistribution } from "./share-distribution";
+
+export default {
+  title: "Composite / ShareDistribution",
+};
+
+export const Default: Story = () => (
+  <div className="w-80">
+    <ShareDistribution
+      items={[
+        { key: "ryu", label: "ryu", percent: 40 },
+        { key: "sg", label: "sg", percent: 30 },
+        { key: "eri", label: "eri", percent: 20 },
+        { key: "homma", label: "homma", percent: 10 },
+      ]}
+    />
+  </div>
+);
+
+export const WithAvatars: Story = () => (
+  <div className="w-80">
+    <ShareDistribution
+      items={[
+        {
+          key: "ryu",
+          label: "ryu",
+          percent: 55,
+          leading: (
+            <Avatar size="sm" className="size-6">
+              <AvatarFallback seed="ryu" />
+            </Avatar>
+          ),
+        },
+        {
+          key: "sg",
+          label: "sg",
+          percent: 25,
+          leading: (
+            <Avatar size="sm" className="size-6">
+              <AvatarFallback seed="sg" />
+            </Avatar>
+          ),
+        },
+        {
+          key: "homma",
+          label: "homma",
+          percent: 20,
+          leading: (
+            <Avatar size="sm" className="size-6">
+              <AvatarFallback seed="homma" />
+            </Avatar>
+          ),
+        },
+      ]}
+    />
+  </div>
+);
+
+export const SingleHolder: Story = () => (
+  <div className="w-80">
+    <ShareDistribution items={[{ key: "me", label: "あなた", percent: 100 }]} />
+  </div>
+);
+
+export const Empty: Story = () => (
+  <div className="w-80">
+    <ShareDistribution items={[]} />
+  </div>
+);

--- a/pkgs/frontend/app/components/composite/share-distribution.tsx
+++ b/pkgs/frontend/app/components/composite/share-distribution.tsx
@@ -1,0 +1,136 @@
+import type * as React from "react";
+
+import { Typography } from "~/components/ui/typography";
+import { cn } from "~/lib/utils";
+
+// Deterministic palette for share segments. Mirrors
+// `docs/design/handoff/project/quests.jsx:67`.
+const SHARE_PALETTE = [
+  "#D6B995",
+  "#65C98A",
+  "#5DADEC",
+  "#F5B82E",
+  "#B696E0",
+  "#E48F4F",
+  "#E48ABF",
+] as const;
+
+interface ShareItem {
+  /** Stable key per row. Usually the holder's address. */
+  key: string;
+  /** Display label — name + abbreviated address etc. */
+  label: React.ReactNode;
+  /** Optional avatar slot rendered between the colour dot and the label. */
+  leading?: React.ReactNode;
+  /** Percentage of the whole (0–100). */
+  percent: number;
+  /** Override the palette colour for this row + bar segment. */
+  color?: string;
+}
+
+interface ShareDistributionProps extends React.ComponentProps<"div"> {
+  items: ShareItem[];
+  /** Hide the bar height when there's only one item — design's choice. */
+  barHeight?: number;
+  /** Message shown when there are no items to distribute. */
+  emptyLabel?: React.ReactNode;
+}
+
+// Toban ShareDistribution — stacked horizontal bar + legend rows showing each
+// participant's share percentage. Mirrors
+// `docs/design/handoff/project/quests.jsx:65-88` and the desktop variant at
+// `docs/design/handoff/project/desktop.jsx:485-500`.
+function ShareDistribution({
+  items,
+  barHeight = 12,
+  emptyLabel = "シェアを持つメンバーがいません",
+  className,
+  ...rest
+}: ShareDistributionProps) {
+  if (items.length === 0) {
+    return (
+      <div
+        data-slot="share-distribution"
+        className={cn("py-4 text-center", className)}
+        {...rest}
+      >
+        <Typography variant="bodySm" tone="secondary">
+          {emptyLabel}
+        </Typography>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-slot="share-distribution"
+      className={cn("flex flex-col gap-3", className)}
+      {...rest}
+    >
+      <div
+        className="flex overflow-hidden rounded-xs bg-[#F0EBE0]"
+        style={{ height: barHeight }}
+      >
+        {items.map((s, i) => (
+          <div
+            key={s.key}
+            title={
+              typeof s.label === "string"
+                ? `${s.label}: ${s.percent}%`
+                : undefined
+            }
+            style={{
+              width: `${Math.max(0, Math.min(100, s.percent))}%`,
+              backgroundColor:
+                s.color ?? SHARE_PALETTE[i % SHARE_PALETTE.length],
+            }}
+          />
+        ))}
+      </div>
+
+      <ul className="flex flex-col gap-2">
+        {items.map((s, i) => {
+          const color = s.color ?? SHARE_PALETTE[i % SHARE_PALETTE.length];
+          return (
+            <li key={s.key} className="flex items-center gap-2.5">
+              <span
+                aria-hidden
+                className="size-2 shrink-0 rounded-full"
+                style={{ backgroundColor: color }}
+              />
+              {s.leading}
+              <Typography
+                as="div"
+                variant="bodySm"
+                weight="semibold"
+                truncate
+                className="min-w-0 flex-1"
+              >
+                {s.label}
+              </Typography>
+              <Typography
+                as="span"
+                variant="bodySm"
+                weight="bold"
+                className="tabular-nums"
+              >
+                {Math.round(s.percent)}
+                <Typography
+                  as="span"
+                  variant="micro"
+                  tone="secondary"
+                  className="ml-0.5"
+                >
+                  %
+                </Typography>
+              </Typography>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export { ShareDistribution, SHARE_PALETTE };
+export type { ShareDistributionProps, ShareItem };

--- a/pkgs/frontend/app/components/quests/QuestPanel.tsx
+++ b/pkgs/frontend/app/components/quests/QuestPanel.tsx
@@ -1,0 +1,194 @@
+import type { Quest, QuestStatus } from "hooks/useQuests";
+import { type FC, Fragment, useMemo } from "react";
+import { Link } from "react-router";
+import { abbreviateAddress } from "utils/wallet";
+import { formatEther } from "viem";
+
+import { SectionLabel } from "~/components/composite/section-label";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Card } from "~/components/ui/card";
+import { Icon } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
+
+interface QuestPanelProps {
+  quests: Quest[];
+  loading: boolean;
+  treeId?: string;
+  hatId?: string;
+  /** Only render the "クエストを作成" CTA when the viewer actually holds role
+   *  share — quest creation requires spending share, so the button would be
+   *  a dead-end otherwise. Defaults to false. */
+  canCreate?: boolean;
+}
+
+// Toban QuestPanel — labelled section that groups a hat's quests by status
+// (Open / PendingReview / Completed) and ends with the "クエストを作成" CTA.
+// Shared between the duty detail and holder detail pages.
+const QuestPanel: FC<QuestPanelProps> = ({
+  quests,
+  loading,
+  treeId,
+  hatId,
+  canCreate = false,
+}) => {
+  const groups: { status: QuestStatus; title: string }[] = [
+    { status: "Open", title: "募集中のクエスト" },
+    { status: "PendingReview", title: "確認待ち" },
+    { status: "Completed", title: "完了" },
+  ];
+
+  const createButton = canCreate ? (
+    <Button asChild variant="secondary" full>
+      <Link to={`/${treeId}/${hatId}/quests/new`}>
+        <Icon name="plus" size={16} />
+        クエストを作成
+      </Link>
+    </Button>
+  ) : null;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <SectionLabel className="px-0">クエスト</SectionLabel>
+
+      {loading && quests.length === 0 ? (
+        <Card className="py-8 text-center">
+          <Typography variant="bodySm" tone="secondary">
+            クエストを読み込み中…
+          </Typography>
+        </Card>
+      ) : quests.length === 0 ? (
+        <Card className="py-8 text-center">
+          <Typography variant="bodySm" tone="secondary">
+            この当番にはまだクエストがありません
+          </Typography>
+        </Card>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {groups.map((g) => {
+            const items = quests.filter((q) => q.status === g.status);
+            if (items.length === 0) return null;
+            return (
+              <Fragment key={g.status}>
+                <SectionLabel className="px-0 pt-0">
+                  {g.title}（{items.length}）
+                </SectionLabel>
+                <div className="flex flex-col gap-2">
+                  {items.map((q) => (
+                    <QuestCard
+                      key={q.id}
+                      quest={q}
+                      treeId={treeId}
+                      hatId={hatId}
+                    />
+                  ))}
+                </div>
+              </Fragment>
+            );
+          })}
+        </div>
+      )}
+
+      {createButton}
+    </section>
+  );
+};
+
+const QuestCard: FC<{ quest: Quest; treeId?: string; hatId?: string }> = ({
+  quest,
+  treeId,
+  hatId,
+}) => {
+  const amount = useMemo(() => {
+    try {
+      return Number(formatEther(BigInt(quest.amount))).toLocaleString();
+    } catch {
+      return "0";
+    }
+  }, [quest.amount]);
+
+  const card = (
+    <Card className="gap-2 px-3.5 py-3 transition-colors hover:bg-bg">
+      <div className="flex items-start gap-2.5">
+        <div className="min-w-0 flex-1">
+          <Typography as="div" variant="bodySm" weight="bold" truncate>
+            Quest #{quest.questId}
+          </Typography>
+          <div className="mt-1 flex items-center gap-2">
+            <QuestStateBadge status={quest.status} />
+            <Typography variant="micro" tone="secondary" as="span">
+              {questMeta(quest)}
+            </Typography>
+          </div>
+        </div>
+        <div className="shrink-0 text-right">
+          <Typography variant="micro" tone="secondary" as="div">
+            当番シェア
+          </Typography>
+          <Typography
+            as="div"
+            variant="statMd"
+            className="text-primary tracking-[-0.5px]"
+          >
+            +{amount}
+            <Typography
+              as="span"
+              variant="micro"
+              tone="secondary"
+              className="ml-0.5"
+            >
+              THX
+            </Typography>
+          </Typography>
+        </div>
+      </div>
+    </Card>
+  );
+
+  // Quest detail route ships in a later phase. Link back to the duty as a
+  // sensible fall-through so the card is still clickable.
+  if (treeId && hatId) {
+    return (
+      <Link
+        to={`/${treeId}/${hatId}`}
+        className="block focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+      >
+        {card}
+      </Link>
+    );
+  }
+  return card;
+};
+
+const QuestStateBadge: FC<{ status: QuestStatus }> = ({ status }) => {
+  switch (status) {
+    case "Open":
+      return <Badge kind="lead">募集中</Badge>;
+    case "PendingReview":
+      return <Badge kind="info">確認待ち</Badge>;
+    case "Completed":
+      return <Badge kind="member">完了</Badge>;
+    case "Cancelled":
+      return <Badge kind="role">取消</Badge>;
+    default:
+      return null;
+  }
+};
+
+const questMeta = (q: Quest): string => {
+  if (q.status === "Open") {
+    return `作成者: ${abbreviateAddress(q.creator)}`;
+  }
+  if (q.status === "PendingReview") {
+    return `申請者: ${
+      q.submitter ? abbreviateAddress(q.submitter) : "-"
+    }・承認 ${q.approvalCount}/2`;
+  }
+  if (q.status === "Completed") {
+    return `${q.submitter ? abbreviateAddress(q.submitter) : "-"} が完了`;
+  }
+  return "";
+};
+
+export { QuestPanel };
+export type { QuestPanelProps };

--- a/pkgs/frontend/app/routes/$treeId_.$hatId.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.$hatId.tsx
@@ -3,7 +3,7 @@ import axios from "axios";
 import { useNamesByAddresses } from "hooks/useENS";
 import { useGetBalanceOfFractionTokens } from "hooks/useFractionToken";
 import { useTreeInfo } from "hooks/useHats";
-import { type Quest, type QuestStatus, useQuests } from "hooks/useQuests";
+import { useQuests } from "hooks/useQuests";
 import { useActiveWallet } from "hooks/useWallet";
 import type { NameData } from "namestone-sdk";
 import { type FC, Fragment, useMemo } from "react";
@@ -11,12 +11,12 @@ import { Link, useParams } from "react-router";
 import type { HatsDetailSchama } from "types/hats";
 import { ipfs2https } from "utils/ipfs";
 import { abbreviateAddress } from "utils/wallet";
-import { formatEther } from "viem";
 import { Breadcrumb } from "~/components/composite/breadcrumb";
 import { Divider } from "~/components/composite/divider";
 import { Row } from "~/components/composite/row";
 import { SectionLabel } from "~/components/composite/section-label";
 import { PageContainer } from "~/components/layout/PageContainer";
+import { QuestPanel } from "~/components/quests/QuestPanel";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
@@ -141,6 +141,21 @@ const DutyDetail: FC = () => {
     return quests.filter((q) => q.hatId === hatIdDecimal);
   }, [quests, hatIdDecimal]);
 
+  // Quest creation requires the viewer to actually hold some role share for
+  // this hat (any wearer's shard). Check across all balances we already
+  // fetched for this hatId.
+  const canCreateQuest = useMemo(() => {
+    if (!me || !balanceData) return false;
+    return balanceData.balanceOfFractionTokens.some((b) => {
+      if (b.owner.toLowerCase() !== me) return false;
+      try {
+        return BigInt(b.balance) > 0n;
+      } catch {
+        return false;
+      }
+    });
+  }, [me, balanceData]);
+
   const breadcrumbItems = [
     { label: "当番一覧", to: `/${treeId}/role` },
     { label: dutyName },
@@ -204,6 +219,7 @@ const DutyDetail: FC = () => {
             loading={questsLoading}
             treeId={treeId}
             hatId={hatId}
+            canCreate={canCreateQuest}
           />
 
           <CurrentAssigneesCard
@@ -275,6 +291,7 @@ const DutyDetail: FC = () => {
               loading={questsLoading}
               treeId={treeId}
               hatId={hatId}
+              canCreate={canCreateQuest}
             />
           </aside>
         </div>
@@ -469,177 +486,4 @@ const CurrentAssigneesCard: FC<CurrentAssigneesCardProps> = ({
       </Card>
     </section>
   );
-};
-
-// ───────────────────────── Quest panel ─────────────────────────
-
-interface QuestPanelProps {
-  quests: Quest[];
-  loading: boolean;
-  treeId?: string;
-  hatId?: string;
-}
-
-const QuestPanel: FC<QuestPanelProps> = ({
-  quests,
-  loading,
-  treeId,
-  hatId,
-}) => {
-  const groups: { status: QuestStatus; title: string }[] = [
-    { status: "Open", title: "募集中のクエスト" },
-    { status: "PendingReview", title: "確認待ち" },
-    { status: "Completed", title: "完了" },
-  ];
-
-  const createButton = (
-    <Button asChild variant="secondary" full>
-      <Link to={`/${treeId}/${hatId}/quests/new`}>
-        <Icon name="plus" size={16} />
-        クエストを作成
-      </Link>
-    </Button>
-  );
-
-  return (
-    <section className="flex flex-col gap-3">
-      <SectionLabel className="px-0">クエスト</SectionLabel>
-
-      {loading && quests.length === 0 ? (
-        <Card className="py-8 text-center">
-          <Typography variant="bodySm" tone="secondary">
-            クエストを読み込み中…
-          </Typography>
-        </Card>
-      ) : quests.length === 0 ? (
-        <Card className="py-8 text-center">
-          <Typography variant="bodySm" tone="secondary">
-            この当番にはまだクエストがありません
-          </Typography>
-        </Card>
-      ) : (
-        <div className="flex flex-col gap-3">
-          {groups.map((g) => {
-            const items = quests.filter((q) => q.status === g.status);
-            if (items.length === 0) return null;
-            return (
-              <Fragment key={g.status}>
-                <SectionLabel className="px-0 pt-0">
-                  {g.title}（{items.length}）
-                </SectionLabel>
-                <div className="flex flex-col gap-2">
-                  {items.map((q) => (
-                    <QuestCard
-                      key={q.id}
-                      quest={q}
-                      treeId={treeId}
-                      hatId={hatId}
-                    />
-                  ))}
-                </div>
-              </Fragment>
-            );
-          })}
-        </div>
-      )}
-
-      {createButton}
-    </section>
-  );
-};
-
-const QuestCard: FC<{ quest: Quest; treeId?: string; hatId?: string }> = ({
-  quest,
-  treeId,
-  hatId,
-}) => {
-  const amount = useMemo(() => {
-    try {
-      return Number(formatEther(BigInt(quest.amount))).toLocaleString();
-    } catch {
-      return "0";
-    }
-  }, [quest.amount]);
-
-  const card = (
-    <Card className="gap-2 px-3.5 py-3 transition-colors hover:bg-bg">
-      <div className="flex items-start gap-2.5">
-        <div className="min-w-0 flex-1">
-          <Typography as="div" variant="bodySm" weight="bold" truncate>
-            Quest #{quest.questId}
-          </Typography>
-          <div className="mt-1 flex items-center gap-2">
-            <QuestStateBadge status={quest.status} />
-            <Typography variant="micro" tone="secondary" as="span">
-              {questMeta(quest)}
-            </Typography>
-          </div>
-        </div>
-        <div className="shrink-0 text-right">
-          <Typography variant="micro" tone="secondary" as="div">
-            当番シェア
-          </Typography>
-          <Typography
-            as="div"
-            variant="statMd"
-            className="text-primary tracking-[-0.5px]"
-          >
-            +{amount}
-            <Typography
-              as="span"
-              variant="micro"
-              tone="secondary"
-              className="ml-0.5"
-            >
-              THX
-            </Typography>
-          </Typography>
-        </div>
-      </div>
-    </Card>
-  );
-
-  // Quest detail route ships in a later phase. Link back to the duty as a
-  // sensible fall-through so the card is still clickable.
-  if (treeId && hatId) {
-    return (
-      <Link
-        to={`/${treeId}/${hatId}`}
-        className="block focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-      >
-        {card}
-      </Link>
-    );
-  }
-  return card;
-};
-
-const QuestStateBadge: FC<{ status: QuestStatus }> = ({ status }) => {
-  switch (status) {
-    case "Open":
-      return <Badge kind="lead">募集中</Badge>;
-    case "PendingReview":
-      return <Badge kind="info">確認待ち</Badge>;
-    case "Completed":
-      return <Badge kind="member">完了</Badge>;
-    case "Cancelled":
-      return <Badge kind="role">取消</Badge>;
-    default:
-      return null;
-  }
-};
-
-const questMeta = (q: Quest): string => {
-  if (q.status === "Open") {
-    return `作成者: ${abbreviateAddress(q.creator)}`;
-  }
-  if (q.status === "PendingReview") {
-    return `申請者: ${
-      q.submitter ? abbreviateAddress(q.submitter) : "-"
-    }・承認 ${q.approvalCount}/2`;
-  }
-  if (q.status === "Completed") {
-    return `${q.submitter ? abbreviateAddress(q.submitter) : "-"} が完了`;
-  }
-  return "";
 };

--- a/pkgs/frontend/app/routes/$treeId_.$hatId.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.$hatId.tsx
@@ -1,184 +1,645 @@
-import { hatIdHexToDecimal, treeIdToTopHatId } from "@hatsprotocol/sdk-v1-core";
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
 import { useNamesByAddresses } from "hooks/useENS";
 import { useGetBalanceOfFractionTokens } from "hooks/useFractionToken";
-import { useGetHatById } from "hooks/useHats";
-import { useWearingElapsedTime } from "hooks/useHatsTimeFrameModule";
+import { useTreeInfo } from "hooks/useHats";
+import { type Quest, type QuestStatus, useQuests } from "hooks/useQuests";
 import { useActiveWallet } from "hooks/useWallet";
-import { useGetWorkspace } from "hooks/useWorkspace";
-import { type FC, useMemo } from "react";
-import { Link, useNavigate, useParams } from "react-router";
+import type { NameData } from "namestone-sdk";
+import { type FC, Fragment, useMemo } from "react";
+import { Link, useParams } from "react-router";
+import type { HatsDetailSchama } from "types/hats";
 import { ipfs2https } from "utils/ipfs";
 import { abbreviateAddress } from "utils/wallet";
-import type { Address } from "viem";
-import { BasicButton } from "~/components/BasicButton";
-import { StickyNav } from "~/components/StickyNav";
-import { Box, HStack, Heading, Text, VStack } from "~/components/chakra-shim";
-import { HatsListItemParser } from "~/components/common/HatsListItemParser";
-import { UserIcon } from "~/components/icon/UserIcon";
-import { HatDetail, RoleName } from "~/components/roles/HolderDetail";
+import { formatEther } from "viem";
+import { Breadcrumb } from "~/components/composite/breadcrumb";
+import { Divider } from "~/components/composite/divider";
+import { Row } from "~/components/composite/row";
+import { SectionLabel } from "~/components/composite/section-label";
+import { PageContainer } from "~/components/layout/PageContainer";
+import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Card } from "~/components/ui/card";
+import { Heading } from "~/components/ui/heading";
+import { Icon } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
+import { cn } from "~/lib/utils";
 
-const RoleDetails: FC = () => {
-  const { treeId, hatId } = useParams();
-
-  const { wallet } = useActiveWallet();
-  const me = wallet?.account?.address;
-
-  const { hat } = useGetHatById(hatId || "");
-
-  const wearerIds = useMemo(
-    () => (hat ? hat.wearers.map((w) => w.id) : []),
-    [hat],
-  );
-
-  // wearer
-  const { names: wearerNames } = useNamesByAddresses(wearerIds);
-
-  const { data: balanceOfFractionTokensData } = useGetBalanceOfFractionTokens({
-    where: {
-      hatId: String(hatIdHexToDecimal(hatId || "")),
+const useHatDetail = (detailsUri?: string) => {
+  const httpsUri = useMemo(() => ipfs2https(detailsUri), [detailsUri]);
+  const { data } = useQuery({
+    queryKey: ["hats-detail", httpsUri],
+    queryFn: async (): Promise<HatsDetailSchama | undefined> => {
+      if (!httpsUri) return;
+      const { data } = await axios.get<HatsDetailSchama>(httpsUri);
+      return data;
     },
+    enabled: !!httpsUri,
+    staleTime: 1000 * 60 * 60,
   });
-  const assistantMembers = useMemo(
+  return data;
+};
+
+const DutyDetail: FC = () => {
+  const { treeId, hatId } = useParams();
+  const { wallet } = useActiveWallet();
+  const me = wallet?.account?.address?.toLowerCase();
+
+  // Pull the whole tree so we have consistent hat data (matches the
+  // sibling routes — useGetHatById is the only Apollo path that needs
+  // its own fetch and we hit transient null returns from it in the field).
+  const tree = useTreeInfo(Number(treeId));
+  const treeLoading = !tree;
+  const hat = useMemo(
+    () => tree?.hats?.find((h) => h.id?.toLowerCase() === hatId?.toLowerCase()),
+    [tree, hatId],
+  );
+  const detail = useHatDetail(hat?.details);
+  const dutyName = detail?.data?.name ?? "当番";
+  const description = detail?.data?.description;
+  const responsabilities = detail?.data?.responsabilities ?? [];
+  const imageUrl = ipfs2https(hat?.imageUri);
+
+  // ── Authorization (TopHat wearer can edit) ─────────────────
+  // Top hat lives at `levelAtLocalTree === 0` inside the same tree we just
+  // fetched, so reuse it instead of issuing a second query.
+  const topHat = useMemo(
+    () => tree?.hats?.find((h) => Number(h.levelAtLocalTree) === 0),
+    [tree],
+  );
+  const isAuthorized = useMemo(() => {
+    if (!me) return false;
+    return topHat?.wearers?.some((w) => w.id?.toLowerCase() === me) ?? false;
+  }, [me, topHat]);
+
+  // ── Wearers & supporters ───────────────────────────────────
+  const wearerAddresses = useMemo(
     () =>
-      balanceOfFractionTokensData
-        ? balanceOfFractionTokensData.balanceOfFractionTokens
-            .filter((h) => !wearerIds.includes(h.owner))
-            .map((h) => h.owner)
-        : [],
-    [balanceOfFractionTokensData, wearerIds],
-  );
-  const { names: holderNames } = useNamesByAddresses(assistantMembers);
-
-  // 各wearerのWearingElapsedTimeを取得
-  const { data } = useGetWorkspace({ workspaceId: treeId || "" });
-  const hatsTimeFrameModuleAddress = useMemo(
-    () => data?.workspace?.hatsTimeFrameModule,
-    [data],
-  );
-  const timeList = useWearingElapsedTime(
-    hatsTimeFrameModuleAddress as Address,
-    hatId,
-    wearerIds,
+      (hat?.wearers ?? [])
+        .map((w) => w.id?.toLowerCase())
+        .filter((a): a is string => !!a),
+    [hat?.wearers],
   );
 
-  const { hat: topHat } = useGetHatById(
-    String(treeIdToTopHatId(Number(treeId))),
+  // FractionToken balances for this hat. `hatId` is decimal in the subgraph.
+  const hatIdDecimal = useMemo(() => {
+    if (!hatId) return undefined;
+    try {
+      return BigInt(hatId).toString();
+    } catch {
+      return undefined;
+    }
+  }, [hatId]);
+  const { data: balanceData } = useGetBalanceOfFractionTokens({
+    where: { hatId: hatIdDecimal },
+    first: 1000,
+  });
+
+  // Supporters = positive-balance owners who aren't wearers themselves.
+  const wearerSet = useMemo(() => new Set(wearerAddresses), [wearerAddresses]);
+  const supporterAddresses = useMemo(() => {
+    if (!balanceData) return [];
+    const seen = new Set<string>();
+    for (const b of balanceData.balanceOfFractionTokens) {
+      let bal: bigint;
+      try {
+        bal = BigInt(b.balance);
+      } catch {
+        continue;
+      }
+      if (bal <= 0n) continue;
+      const owner = b.owner.toLowerCase();
+      if (wearerSet.has(owner)) continue;
+      seen.add(owner);
+    }
+    return Array.from(seen);
+  }, [balanceData, wearerSet]);
+
+  // Pull name + avatar for every address that appears anywhere on the page
+  // in a single Namestone batch.
+  const allAddresses = useMemo(
+    () => Array.from(new Set([...wearerAddresses, ...supporterAddresses])),
+    [wearerAddresses, supporterAddresses],
   );
-  const isAuthorized = useMemo(
-    () => topHat?.wearers?.some((w) => w.id === me?.toLowerCase()),
-    [me, topHat],
-  );
+  const { names } = useNamesByAddresses(allAddresses);
+  const nameByAddress = useMemo(() => {
+    const m = new Map<string, NameData>();
+    for (const group of names) {
+      const entry = group[0];
+      if (entry?.address) m.set(entry.address.toLowerCase(), entry);
+    }
+    return m;
+  }, [names]);
 
-  const navigate = useNavigate();
+  // ── Quests scoped to this hat ───────────────────────────────
+  const { quests, isLoading: questsLoading } = useQuests(treeId, {
+    first: 100,
+  });
+  const dutyQuests = useMemo(() => {
+    if (!hatIdDecimal) return [];
+    return quests.filter((q) => q.hatId === hatIdDecimal);
+  }, [quests, hatIdDecimal]);
 
-  return hat ? (
-    <Box>
-      <HatsListItemParser imageUri={hat.imageUri} detailUri={hat.details}>
-        <RoleName treeId={treeId} />
+  const breadcrumbItems = [
+    { label: "当番一覧", to: `/${treeId}/role` },
+    { label: dutyName },
+  ];
 
-        {isAuthorized && (
-          <Link to={`/${treeId}/${hatId}/edit`}>
-            <BasicButton
-              fontWeight="bold"
-              minH={2}
-              size="xs"
-              bgColor="blue.300"
-              w="auto"
-            >
-              編集
-            </BasicButton>
-          </Link>
-        )}
-        <HatDetail />
-      </HatsListItemParser>
+  if (!hat) {
+    return (
+      <PageContainer className="pt-4 pb-8 md:pt-6">
+        <Breadcrumb
+          className="mb-3 px-1"
+          items={[
+            { label: "当番一覧", to: `/${treeId}/role` },
+            { label: "当番" },
+          ]}
+        />
+        <Card className="mt-3 py-12 text-center">
+          <Typography variant="bodySm" tone="secondary">
+            {treeLoading ? "読み込み中…" : "ロールが見つかりませんでした"}
+          </Typography>
+        </Card>
+      </PageContainer>
+    );
+  }
 
-      <HStack justifyContent="space-between">
-        <Heading size="lg">貢献メンバー</Heading>
+  const mobileEditButton = isAuthorized ? (
+    <Button
+      asChild
+      size="icon-sm"
+      variant="ghost"
+      aria-label="編集"
+      className="-mr-1 shrink-0"
+    >
+      <Link to={`/${treeId}/${hatId}/edit`}>
+        <Icon name="edit" size={18} />
+      </Link>
+    </Button>
+  ) : null;
 
-        <Link to={`/${treeId}/${hatId}/assign`}>
-          <BasicButton
-            fontWeight="bold"
-            minH={5}
-            size="xs"
-            bgColor="yellow.400"
-          >
-            当番をわたす
-          </BasicButton>
-        </Link>
-      </HStack>
+  return (
+    <>
+      <PageContainer className="pt-2 pb-10 md:pt-4">
+        <Breadcrumb className="mb-3 px-1" items={breadcrumbItems} />
 
-      <VStack width="full" alignItems="start" gap={3} paddingY={4}>
-        {wearerNames.flat().map((n) => (
-          <HStack
-            key={`${n.name}w`}
-            width="full"
-            onClick={() => navigate(`/${treeId}/${hatId}/${n.address}`)}
-          >
-            <UserIcon
-              userImageUrl={ipfs2https(n.text_records?.avatar)}
-              size={10}
+        {/* Mobile: single column */}
+        <div className="md:hidden flex flex-col gap-4 px-1 pt-1">
+          <DutyHeader
+            name={dutyName}
+            imageUrl={imageUrl}
+            wearerCount={wearerAddresses.length}
+            supporterCount={supporterAddresses.length}
+            right={mobileEditButton}
+          />
+
+          <DescriptionCard
+            description={description}
+            responsabilities={responsabilities}
+          />
+
+          <QuestPanel
+            quests={dutyQuests}
+            loading={questsLoading}
+            treeId={treeId}
+            hatId={hatId}
+          />
+
+          <CurrentAssigneesCard
+            wearerAddresses={wearerAddresses}
+            supporterAddresses={supporterAddresses}
+            nameByAddress={nameByAddress}
+            treeId={treeId ?? ""}
+            hatId={hatId ?? ""}
+          />
+
+          <div className="pt-2">
+            <Button asChild variant="primary" full>
+              <Link to={`/${treeId}/${hatId}/assign`}>
+                <Icon name="plus" size={16} />
+                担当を追加
+              </Link>
+            </Button>
+          </div>
+        </div>
+
+        {/* Desktop: 60% main + 40% side (quests live on the side panel) */}
+        <div className="hidden md:grid grid-cols-[3fr_2fr] gap-6 pt-2">
+          <div className="flex flex-col gap-5 min-w-0">
+            <div className="flex items-center gap-4">
+              <DutyIcon imageUrl={imageUrl} size="lg" />
+              <div className="min-w-0 flex-1">
+                <Heading variant="h2" level={1} className="truncate">
+                  {dutyName}
+                </Heading>
+                <Typography variant="caption" tone="secondary" className="mt-1">
+                  担当: {wearerAddresses.length}人 ・ サポーター{" "}
+                  {supporterAddresses.length}人
+                </Typography>
+              </div>
+              {isAuthorized && (
+                <Button asChild variant="secondary" size="sm">
+                  <Link to={`/${treeId}/${hatId}/edit`}>
+                    <Icon name="edit" size={14} />
+                    編集
+                  </Link>
+                </Button>
+              )}
+            </div>
+
+            <DescriptionCard
+              description={description}
+              responsabilities={responsabilities}
             />
-            <VStack flexGrow={1} alignItems="start" gapY={1}>
-              <Text lineBreak="anywhere" flexGrow={1}>
-                {n.name
-                  ? `${n.name} (${abbreviateAddress(n.address)})`
-                  : abbreviateAddress(n.address)}
-              </Text>
-              <Text fontWeight="medium">
-                {Math.floor(
-                  (timeList.find(
-                    ({ wearer }) =>
-                      wearer.toLowerCase() === n.address.toLowerCase(),
-                  )?.time || 0) / 86400,
-                )}{" "}
-                days
-              </Text>
-            </VStack>
-            <Box
-              fontSize="xs"
-              paddingX={2}
-              paddingY={1}
-              rounded="md"
-              bgColor="yellow.200"
-            >
-              当番リード
-            </Box>
-          </HStack>
-        ))}
 
-        {holderNames.flat().map((n) => (
-          <HStack key={`${n.name}h`} width="full">
-            <UserIcon
-              userImageUrl={ipfs2https(n.text_records?.avatar)}
-              size={10}
+            <CurrentAssigneesCard
+              wearerAddresses={wearerAddresses}
+              supporterAddresses={supporterAddresses}
+              nameByAddress={nameByAddress}
+              treeId={treeId ?? ""}
+              hatId={hatId ?? ""}
             />
-            <Text lineBreak="anywhere" flexGrow={1}>
-              {n.name
-                ? `${n.name} (${abbreviateAddress(n.address)})`
-                : abbreviateAddress(n.address)}
-            </Text>
-            <Box
-              fontSize="xs"
-              paddingX={2}
-              paddingY={1}
-              rounded="md"
-              bgColor="blue.200"
-            >
-              サポーター
-            </Box>
-          </HStack>
-        ))}
-      </VStack>
 
-      <StickyNav />
-    </Box>
-  ) : (
-    <Box minHeight="50vh" alignContent="center" justifyItems="center">
-      <Text width="fit" fontSize="lg" fontWeight="bold" color="gray.400">
-        ロールが見つかりませんでした
-      </Text>
-    </Box>
+            <Button asChild variant="primary" full>
+              <Link to={`/${treeId}/${hatId}/assign`}>
+                <Icon name="plus" size={16} />
+                担当を追加
+              </Link>
+            </Button>
+          </div>
+
+          <aside className="flex flex-col gap-4">
+            <QuestPanel
+              quests={dutyQuests}
+              loading={questsLoading}
+              treeId={treeId}
+              hatId={hatId}
+            />
+          </aside>
+        </div>
+      </PageContainer>
+    </>
   );
 };
 
-export default RoleDetails;
+export default DutyDetail;
+
+// ───────────────────────── Sub-components ─────────────────────────
+
+interface DutyHeaderProps {
+  name: string;
+  imageUrl?: string;
+  wearerCount: number;
+  supporterCount: number;
+  right?: React.ReactNode;
+}
+
+const DutyHeader: FC<DutyHeaderProps> = ({
+  name,
+  imageUrl,
+  wearerCount,
+  supporterCount,
+  right,
+}) => (
+  <div className="flex items-center gap-3.5">
+    <DutyIcon imageUrl={imageUrl} size="md" />
+    <div className="min-w-0 flex-1">
+      <Heading variant="h3" level={1} className="truncate">
+        {name}
+      </Heading>
+      <Typography variant="caption" tone="secondary" className="mt-0.5">
+        担当 {wearerCount}人 ・ サポーター {supporterCount}人
+      </Typography>
+    </div>
+    {right}
+  </div>
+);
+
+const DutyIcon: FC<{ imageUrl?: string; size: "md" | "lg" }> = ({
+  imageUrl,
+  size,
+}) => (
+  <div
+    className={cn(
+      "flex shrink-0 items-center justify-center overflow-hidden rounded-md bg-[#F2EAD9]",
+      size === "lg" ? "size-16" : "size-14",
+    )}
+  >
+    {imageUrl ? (
+      <img src={imageUrl} alt="" className="size-full object-cover" />
+    ) : (
+      <Icon
+        name="duty"
+        size={size === "lg" ? 32 : 28}
+        className="text-[#7A5A2E]"
+      />
+    )}
+  </div>
+);
+
+interface DescriptionCardProps {
+  description?: string;
+  responsabilities: NonNullable<HatsDetailSchama["data"]["responsabilities"]>;
+}
+
+const DescriptionCard: FC<DescriptionCardProps> = ({
+  description,
+  responsabilities,
+}) => {
+  const bullets: string[] = [];
+  if (description) bullets.push(description);
+  for (const r of responsabilities) {
+    if (r.label) bullets.push(r.label);
+  }
+
+  return (
+    <section className="flex flex-col gap-2">
+      <SectionLabel className="px-0">説明</SectionLabel>
+      <Card className="px-4 py-4">
+        {bullets.length === 0 ? (
+          <Typography variant="bodySm" tone="secondary">
+            まだ説明はありません
+          </Typography>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {bullets.map((line) => (
+              <li key={line} className="flex items-start gap-2.5">
+                <span
+                  aria-hidden
+                  className="mt-2 size-1.5 shrink-0 rounded-full bg-primary"
+                />
+                <Typography
+                  variant="bodySm"
+                  as="span"
+                  className="leading-relaxed"
+                >
+                  {line}
+                </Typography>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+    </section>
+  );
+};
+
+interface CurrentAssigneesCardProps {
+  wearerAddresses: string[];
+  supporterAddresses: string[];
+  nameByAddress: Map<string, NameData>;
+  treeId: string;
+  hatId: string;
+}
+
+const CurrentAssigneesCard: FC<CurrentAssigneesCardProps> = ({
+  wearerAddresses,
+  supporterAddresses,
+  nameByAddress,
+  treeId,
+  hatId,
+}) => {
+  const rows = useMemo(
+    () => [
+      ...wearerAddresses.map((addr) => ({ addr, kind: "lead" as const })),
+      ...supporterAddresses.map((addr) => ({
+        addr,
+        kind: "supporter" as const,
+      })),
+    ],
+    [wearerAddresses, supporterAddresses],
+  );
+
+  return (
+    <section className="flex flex-col gap-2">
+      <SectionLabel className="px-0">現在の担当</SectionLabel>
+      <Card className="gap-0 p-0">
+        {rows.length === 0 ? (
+          <div className="py-8 text-center">
+            <Typography variant="bodySm" tone="secondary">
+              まだ担当者はいません
+            </Typography>
+          </div>
+        ) : (
+          rows.map(({ addr, kind }, i) => {
+            const entry = nameByAddress.get(addr);
+            const displayName = entry?.name ?? abbreviateAddress(addr);
+            const avatar = ipfs2https(entry?.text_records?.avatar);
+            const badge =
+              kind === "lead" ? (
+                <Badge kind="lead">当番リード</Badge>
+              ) : (
+                <Badge kind="supporter">サポーター</Badge>
+              );
+            const inner = (
+              <Row
+                className={cn(
+                  kind === "lead" &&
+                    "cursor-pointer transition-colors hover:bg-bg",
+                )}
+                left={
+                  <Avatar size="default">
+                    {avatar && <AvatarImage src={avatar} alt="" />}
+                    <AvatarFallback seed={displayName} />
+                  </Avatar>
+                }
+                title={displayName}
+                subtitle={abbreviateAddress(addr)}
+                right={badge}
+              />
+            );
+            return (
+              <Fragment key={`${kind}-${addr}`}>
+                {i > 0 && <Divider inset={56} />}
+                {kind === "lead" ? (
+                  <Link
+                    to={`/${treeId}/${hatId}/${addr}`}
+                    className="block focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                  >
+                    {inner}
+                  </Link>
+                ) : (
+                  inner
+                )}
+              </Fragment>
+            );
+          })
+        )}
+      </Card>
+    </section>
+  );
+};
+
+// ───────────────────────── Quest panel ─────────────────────────
+
+interface QuestPanelProps {
+  quests: Quest[];
+  loading: boolean;
+  treeId?: string;
+  hatId?: string;
+}
+
+const QuestPanel: FC<QuestPanelProps> = ({
+  quests,
+  loading,
+  treeId,
+  hatId,
+}) => {
+  const groups: { status: QuestStatus; title: string }[] = [
+    { status: "Open", title: "募集中のクエスト" },
+    { status: "PendingReview", title: "確認待ち" },
+    { status: "Completed", title: "完了" },
+  ];
+
+  const createButton = (
+    <Button asChild variant="secondary" full>
+      <Link to={`/${treeId}/${hatId}/quests/new`}>
+        <Icon name="plus" size={16} />
+        クエストを作成
+      </Link>
+    </Button>
+  );
+
+  return (
+    <section className="flex flex-col gap-3">
+      <SectionLabel className="px-0">クエスト</SectionLabel>
+
+      {loading && quests.length === 0 ? (
+        <Card className="py-8 text-center">
+          <Typography variant="bodySm" tone="secondary">
+            クエストを読み込み中…
+          </Typography>
+        </Card>
+      ) : quests.length === 0 ? (
+        <Card className="py-8 text-center">
+          <Typography variant="bodySm" tone="secondary">
+            この当番にはまだクエストがありません
+          </Typography>
+        </Card>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {groups.map((g) => {
+            const items = quests.filter((q) => q.status === g.status);
+            if (items.length === 0) return null;
+            return (
+              <Fragment key={g.status}>
+                <SectionLabel className="px-0 pt-0">
+                  {g.title}（{items.length}）
+                </SectionLabel>
+                <div className="flex flex-col gap-2">
+                  {items.map((q) => (
+                    <QuestCard
+                      key={q.id}
+                      quest={q}
+                      treeId={treeId}
+                      hatId={hatId}
+                    />
+                  ))}
+                </div>
+              </Fragment>
+            );
+          })}
+        </div>
+      )}
+
+      {createButton}
+    </section>
+  );
+};
+
+const QuestCard: FC<{ quest: Quest; treeId?: string; hatId?: string }> = ({
+  quest,
+  treeId,
+  hatId,
+}) => {
+  const amount = useMemo(() => {
+    try {
+      return Number(formatEther(BigInt(quest.amount))).toLocaleString();
+    } catch {
+      return "0";
+    }
+  }, [quest.amount]);
+
+  const card = (
+    <Card className="gap-2 px-3.5 py-3 transition-colors hover:bg-bg">
+      <div className="flex items-start gap-2.5">
+        <div className="min-w-0 flex-1">
+          <Typography as="div" variant="bodySm" weight="bold" truncate>
+            Quest #{quest.questId}
+          </Typography>
+          <div className="mt-1 flex items-center gap-2">
+            <QuestStateBadge status={quest.status} />
+            <Typography variant="micro" tone="secondary" as="span">
+              {questMeta(quest)}
+            </Typography>
+          </div>
+        </div>
+        <div className="shrink-0 text-right">
+          <Typography variant="micro" tone="secondary" as="div">
+            当番シェア
+          </Typography>
+          <Typography
+            as="div"
+            variant="statMd"
+            className="text-primary tracking-[-0.5px]"
+          >
+            +{amount}
+            <Typography
+              as="span"
+              variant="micro"
+              tone="secondary"
+              className="ml-0.5"
+            >
+              THX
+            </Typography>
+          </Typography>
+        </div>
+      </div>
+    </Card>
+  );
+
+  // Quest detail route ships in a later phase. Link back to the duty as a
+  // sensible fall-through so the card is still clickable.
+  if (treeId && hatId) {
+    return (
+      <Link
+        to={`/${treeId}/${hatId}`}
+        className="block focus-visible:rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+      >
+        {card}
+      </Link>
+    );
+  }
+  return card;
+};
+
+const QuestStateBadge: FC<{ status: QuestStatus }> = ({ status }) => {
+  switch (status) {
+    case "Open":
+      return <Badge kind="lead">募集中</Badge>;
+    case "PendingReview":
+      return <Badge kind="info">確認待ち</Badge>;
+    case "Completed":
+      return <Badge kind="member">完了</Badge>;
+    case "Cancelled":
+      return <Badge kind="role">取消</Badge>;
+    default:
+      return null;
+  }
+};
+
+const questMeta = (q: Quest): string => {
+  if (q.status === "Open") {
+    return `作成者: ${abbreviateAddress(q.creator)}`;
+  }
+  if (q.status === "PendingReview") {
+    return `申請者: ${
+      q.submitter ? abbreviateAddress(q.submitter) : "-"
+    }・承認 ${q.approvalCount}/2`;
+  }
+  if (q.status === "Completed") {
+    return `${q.submitter ? abbreviateAddress(q.submitter) : "-"} が完了`;
+  }
+  return "";
+};

--- a/pkgs/frontend/app/routes/$treeId_.$hatId_.$address.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.$hatId_.$address.tsx
@@ -7,6 +7,7 @@ import { useTreeInfo } from "hooks/useHats";
 import {
   useActiveState,
   useDeactivate,
+  useHasAuthority,
   useReactivate,
   useRenounceHatFromTimeFrameModule,
 } from "hooks/useHatsTimeFrameModule";
@@ -84,6 +85,11 @@ const HolderDetail: FC = () => {
     hatId,
     address,
   );
+
+  // Contract also allows admins / wearers of the module's `minterHatId` to
+  // pause / resume / renounce, not just the wearer themselves.
+  const hasModuleAuthority = useHasAuthority(hatsTimeFrameModuleAddress, me);
+  const canManage = isMe || hasModuleAuthority;
 
   const formattedWoreTime = useMemo(
     () => (woreTime ? dayjs.unix(woreTime).format("YYYY/MM/DD") : undefined),
@@ -297,7 +303,7 @@ const HolderDetail: FC = () => {
   );
 
   const authorizedActionsBlock =
-    isMe && hatsTimeFrameModuleAddress ? (
+    canManage && hatsTimeFrameModuleAddress ? (
       <div className="flex flex-col gap-2 pt-2">
         {isActive ? (
           <Button

--- a/pkgs/frontend/app/routes/$treeId_.$hatId_.$address.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.$hatId_.$address.tsx
@@ -10,6 +10,7 @@ import {
   useReactivate,
   useRenounceHatFromTimeFrameModule,
 } from "hooks/useHatsTimeFrameModule";
+import { useQuests } from "hooks/useQuests";
 import { useActiveWallet } from "hooks/useWallet";
 import { useGetWorkspace } from "hooks/useWorkspace";
 import { type FC, useMemo, useState } from "react";
@@ -30,6 +31,7 @@ import {
   ShareDistribution,
 } from "~/components/composite/share-distribution";
 import { PageContainer } from "~/components/layout/PageContainer";
+import { QuestPanel } from "~/components/quests/QuestPanel";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
@@ -162,6 +164,24 @@ const HolderDetail: FC = () => {
 
   const [sendSheetOpen, setSendSheetOpen] = useState(false);
 
+  // Quests scoped to this hat — same data as the duty detail page so the
+  // user can act on quests without bouncing back up the breadcrumb.
+  const hatIdDecimal = useMemo(() => {
+    if (!hatId) return undefined;
+    try {
+      return BigInt(hatId).toString();
+    } catch {
+      return undefined;
+    }
+  }, [hatId]);
+  const { quests, isLoading: questsLoading } = useQuests(treeId, {
+    first: 100,
+  });
+  const dutyQuests = useMemo(() => {
+    if (!hatIdDecimal) return [];
+    return quests.filter((q) => q.hatId === hatIdDecimal);
+  }, [quests, hatIdDecimal]);
+
   // Care-point variant — three legacy workspaces show ケアポイント copy.
   const isCarePoint = ["144", "175", "780"].includes(treeId || "");
   const shareTitle = isCarePoint ? "ケアポイント" : "ロールシェア";
@@ -204,148 +224,175 @@ const HolderDetail: FC = () => {
     );
   }
 
+  const headerBlock = (
+    <div className="flex items-center gap-3.5">
+      <DutyIcon imageUrl={imageUrl} />
+      <div className="min-w-0 flex-1">
+        <Typography
+          as="div"
+          variant="caption"
+          tone="secondary"
+          truncate
+          className="mb-0.5"
+        >
+          {dutyName}
+        </Typography>
+        <div className="flex items-center gap-2">
+          <Avatar size="sm" className="size-6">
+            {wearerAvatar && <AvatarImage src={wearerAvatar} alt="" />}
+            <AvatarFallback seed={wearerName} />
+          </Avatar>
+          <Heading variant="h4" level={1} className="truncate">
+            {wearerName}
+          </Heading>
+        </div>
+        <Typography
+          variant="micro"
+          tone="secondary"
+          as="div"
+          className="mt-0.5"
+        >
+          {abbreviateAddress(address || "")}
+        </Typography>
+      </div>
+      <Badge kind={isActive ? "lead" : "supporter"}>
+        {isActive ? "アクティブ" : "休止中"}
+      </Badge>
+    </div>
+  );
+
+  const statsBlock = (
+    <Card className="px-4 py-4">
+      <div className="grid grid-cols-3 gap-3">
+        <Stat label="活動開始日" value={formattedWoreTime ?? "—"} />
+        <Stat
+          label="総活動日数"
+          value={formattedDays !== undefined ? `${formattedDays}日` : "—"}
+        />
+        <Stat
+          label={`あなたの${shareTitle}`}
+          value={ownBalance !== undefined ? ownBalance.toLocaleString() : "—"}
+        />
+      </div>
+    </Card>
+  );
+
+  const sendButton = me ? (
+    <Button variant="secondary" full onClick={() => setSendSheetOpen(true)}>
+      <Icon name="send" size={16} />
+      {shareTitle}を送る
+    </Button>
+  ) : null;
+
+  const shareDistributionBlock = (
+    <section className="flex flex-col gap-2">
+      <SectionLabel className="px-0">{shareTitle}の保有率</SectionLabel>
+      <Card className="px-4 py-4">
+        <ShareDistribution
+          items={shareItems}
+          emptyLabel="シェアはまだ配布されていません"
+        />
+      </Card>
+    </section>
+  );
+
+  const authorizedActionsBlock =
+    isMe && hatsTimeFrameModuleAddress ? (
+      <div className="flex flex-col gap-2 pt-2">
+        {isActive ? (
+          <Button
+            variant="secondary"
+            full
+            disabled={isDeactivating}
+            onClick={async () => {
+              if (!hatId || !address) return;
+              try {
+                await deactivate(hatId, address);
+                await refetch();
+                toast.success("一時休止しました");
+              } catch (error) {
+                console.error(error);
+                toast.error("一時休止に失敗しました");
+              }
+            }}
+          >
+            {isDeactivating ? "一時休止中…" : "一時休止"}
+          </Button>
+        ) : (
+          <Button
+            variant="primary"
+            full
+            disabled={isReactivating}
+            onClick={async () => {
+              if (!hatId || !address) return;
+              try {
+                await reactivate(hatId, address);
+                await refetch();
+                toast.success("当番を再開しました");
+              } catch (error) {
+                console.error(error);
+                toast.error("再開に失敗しました");
+              }
+            }}
+          >
+            {isReactivating ? "再開中…" : "再開する"}
+          </Button>
+        )}
+        <Button
+          variant="danger"
+          full
+          disabled={isRenouncing}
+          onClick={async () => {
+            if (!hatId || !address) return;
+            try {
+              await renounceHat(BigInt(hatId), address as Address);
+            } catch (error) {
+              console.error(error);
+              return;
+            }
+            navigate(`/${treeId}/${hatId}`);
+          }}
+        >
+          {isRenouncing ? "剥奪中…" : "当番を剥奪"}
+        </Button>
+      </div>
+    ) : null;
+
+  const questBlock = (
+    <QuestPanel
+      quests={dutyQuests}
+      loading={questsLoading}
+      treeId={treeId}
+      hatId={hatId}
+      canCreate={ownBalance !== undefined && ownBalance > 0}
+    />
+  );
+
   return (
     <>
       <PageContainer className="pt-2 pb-10">
         <Breadcrumb className="mb-3 px-1" items={breadcrumbItems} />
 
-        <div className="flex flex-col gap-4 px-1 pt-1">
-          {/* Header */}
-          <div className="flex items-center gap-3.5">
-            <DutyIcon imageUrl={imageUrl} />
-            <div className="min-w-0 flex-1">
-              <Typography
-                as="div"
-                variant="caption"
-                tone="secondary"
-                truncate
-                className="mb-0.5"
-              >
-                {dutyName}
-              </Typography>
-              <div className="flex items-center gap-2">
-                <Avatar size="sm" className="size-6">
-                  {wearerAvatar && <AvatarImage src={wearerAvatar} alt="" />}
-                  <AvatarFallback seed={wearerName} />
-                </Avatar>
-                <Heading variant="h4" level={1} className="truncate">
-                  {wearerName}
-                </Heading>
-              </div>
-              <Typography
-                variant="micro"
-                tone="secondary"
-                as="div"
-                className="mt-0.5"
-              >
-                {abbreviateAddress(address || "")}
-              </Typography>
-            </div>
-            <Badge kind={isActive ? "lead" : "supporter"}>
-              {isActive ? "アクティブ" : "休止中"}
-            </Badge>
+        {/* Mobile: single column */}
+        <div className="md:hidden flex flex-col gap-4 px-1 pt-1">
+          {headerBlock}
+          {statsBlock}
+          {sendButton}
+          {shareDistributionBlock}
+          {questBlock}
+          {authorizedActionsBlock}
+        </div>
+
+        {/* Desktop: 60/40 split — quests live on the side panel */}
+        <div className="hidden md:grid grid-cols-[3fr_2fr] gap-6 pt-2">
+          <div className="flex flex-col gap-4 min-w-0">
+            {headerBlock}
+            {statsBlock}
+            {sendButton}
+            {shareDistributionBlock}
+            {authorizedActionsBlock}
           </div>
-
-          {/* Stats */}
-          <Card className="px-4 py-4">
-            <div className="grid grid-cols-3 gap-3">
-              <Stat label="活動開始日" value={formattedWoreTime ?? "—"} />
-              <Stat
-                label="総活動日数"
-                value={formattedDays !== undefined ? `${formattedDays}日` : "—"}
-              />
-              <Stat
-                label={`あなたの${shareTitle}`}
-                value={
-                  ownBalance !== undefined ? ownBalance.toLocaleString() : "—"
-                }
-              />
-            </div>
-          </Card>
-
-          {me && (
-            <Button
-              variant="secondary"
-              full
-              onClick={() => setSendSheetOpen(true)}
-            >
-              <Icon name="send" size={16} />
-              {shareTitle}を送る
-            </Button>
-          )}
-
-          {/* ロールシェアの保有率 */}
-          <section className="flex flex-col gap-2">
-            <SectionLabel className="px-0">{shareTitle}の保有率</SectionLabel>
-            <Card className="px-4 py-4">
-              <ShareDistribution
-                items={shareItems}
-                emptyLabel="シェアはまだ配布されていません"
-              />
-            </Card>
-          </section>
-
-          {/* Authorized actions */}
-          {isMe && hatsTimeFrameModuleAddress && (
-            <div className="flex flex-col gap-2 pt-2">
-              {isActive ? (
-                <Button
-                  variant="secondary"
-                  full
-                  disabled={isDeactivating}
-                  onClick={async () => {
-                    if (!hatId || !address) return;
-                    try {
-                      await deactivate(hatId, address);
-                      await refetch();
-                      toast.success("一時休止しました");
-                    } catch (error) {
-                      console.error(error);
-                      toast.error("一時休止に失敗しました");
-                    }
-                  }}
-                >
-                  {isDeactivating ? "一時休止中…" : "一時休止"}
-                </Button>
-              ) : (
-                <Button
-                  variant="primary"
-                  full
-                  disabled={isReactivating}
-                  onClick={async () => {
-                    if (!hatId || !address) return;
-                    try {
-                      await reactivate(hatId, address);
-                      await refetch();
-                      toast.success("当番を再開しました");
-                    } catch (error) {
-                      console.error(error);
-                      toast.error("再開に失敗しました");
-                    }
-                  }}
-                >
-                  {isReactivating ? "再開中…" : "再開する"}
-                </Button>
-              )}
-              <Button
-                variant="danger"
-                full
-                disabled={isRenouncing}
-                onClick={async () => {
-                  if (!hatId || !address) return;
-                  try {
-                    await renounceHat(BigInt(hatId), address as Address);
-                  } catch (error) {
-                    console.error(error);
-                    return;
-                  }
-                  navigate(`/${treeId}/${hatId}`);
-                }}
-              >
-                {isRenouncing ? "剥奪中…" : "当番を剥奪"}
-              </Button>
-            </div>
-          )}
+          <aside className="flex flex-col gap-4">{questBlock}</aside>
         </div>
       </PageContainer>
 

--- a/pkgs/frontend/app/routes/$treeId_.$hatId_.$address.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.$hatId_.$address.tsx
@@ -1,3 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import dayjs from "dayjs";
 import { useNamesByAddresses } from "hooks/useENS";
 import { useGetBalanceOfFractionTokens } from "hooks/useFractionToken";
 import { useTreeInfo } from "hooks/useHats";
@@ -11,97 +14,85 @@ import { useActiveWallet } from "hooks/useWallet";
 import { useGetWorkspace } from "hooks/useWorkspace";
 import { type FC, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
+// Sonner — appends its stylesheet to the END of <head>, so importing at
+// route-module level is safe for SSR hydration. react-toastify uses
+// `insertBefore(..., firstChild)` and breaks hydration on direct loads.
+import { toast } from "sonner";
+import type { HatsDetailSchama } from "types/hats";
 import { ipfs2https } from "utils/ipfs";
 import { abbreviateAddress } from "utils/wallet";
 import type { Address } from "viem";
-import { BasicButton } from "~/components/BasicButton";
-import { StickyNav } from "~/components/StickyNav";
 import { AssistCreditSendSheet } from "~/components/assistcredit/AssistCreditSendSheet";
-import { Box, HStack, Heading, Text, VStack } from "~/components/chakra-shim";
-import { HatsListItemParser } from "~/components/common/HatsListItemParser";
-import { UserIcon } from "~/components/icon/UserIcon";
+import { Breadcrumb } from "~/components/composite/breadcrumb";
+import { SectionLabel } from "~/components/composite/section-label";
 import {
-  ActiveState,
-  HatDetail,
-  RoleNameWithWearer,
-} from "~/components/roles/HolderDetail";
+  SHARE_PALETTE,
+  ShareDistribution,
+} from "~/components/composite/share-distribution";
+import { PageContainer } from "~/components/layout/PageContainer";
+import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Card } from "~/components/ui/card";
+import { Heading } from "~/components/ui/heading";
+import { Icon } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
+import { cn } from "~/lib/utils";
 
-const RoleHolderDetails: FC = () => {
+const useHatDetail = (detailsUri?: string) => {
+  const httpsUri = useMemo(() => ipfs2https(detailsUri), [detailsUri]);
+  const { data } = useQuery({
+    queryKey: ["hats-detail", httpsUri],
+    queryFn: async (): Promise<HatsDetailSchama | undefined> => {
+      if (!httpsUri) return;
+      const { data } = await axios.get<HatsDetailSchama>(httpsUri);
+      return data;
+    },
+    enabled: !!httpsUri,
+    staleTime: 1000 * 60 * 60,
+  });
+  return data;
+};
+
+const HolderDetail: FC = () => {
   const { treeId, hatId, address } = useParams();
-
+  const navigate = useNavigate();
   const { wallet } = useActiveWallet();
-  const me = wallet?.account?.address;
+  const me = wallet?.account?.address?.toLowerCase();
+  const isMe = !!me && me === address?.toLowerCase();
 
   const tree = useTreeInfo(Number(treeId));
-
   const hat = useMemo(() => {
-    if (!tree || !tree.hats) return;
+    if (!tree?.hats) return;
     return tree.hats.find((h) => h.id === hatId);
   }, [tree, hatId]);
+  const detail = useHatDetail(hat?.details);
+  const dutyName = detail?.data?.name ?? "当番";
+  const imageUrl = ipfs2https(hat?.imageUri);
 
-  // HatsTimeFrameModuleのアドレスを取得
-  const { data } = useGetWorkspace({ workspaceId: treeId || "" });
-  const hatsTimeFrameModuleAuthorities = useMemo(() => {
-    return [];
-  }, []);
-  const hatsTimeFrameModuleAddress = useMemo(
-    () => data?.workspace?.hatsTimeFrameModule,
-    [data],
-  );
-
-  // ログインユーザーがこのhatの権限を持っているかどうか
-  const isAuthorised = useMemo(() => {
-    return false; // Simplified for now since authorities are not implemented
-  }, []);
-
-  // wearerの名前とアイコンを取得
-  const addresses = useMemo(() => (address ? [address] : undefined), [address]);
-  const { names: wearerNames } = useNamesByAddresses(addresses);
-  const { wearerName, wearerIcon } = useMemo(
-    () =>
-      wearerNames.flat().length > 0
-        ? {
-            wearerName: wearerNames.flat()[0].name,
-            wearerIcon: wearerNames.flat()[0].text_records?.avatar,
-          }
-        : {},
-    [wearerNames],
-  );
-
-  // holderをbalanceとともに取得
-  const { data: balanceOfFractionTokens } = useGetBalanceOfFractionTokens({
-    where: {
-      wearer: address?.toLowerCase(),
-      hatId: BigInt(hatId || 0).toString(10),
-    },
+  // ── HatsTimeFrameModule (active / wore time / renounce) ────
+  const { data: workspaceData } = useGetWorkspace({
+    workspaceId: treeId || "",
   });
-  const holders = useMemo(
-    () => balanceOfFractionTokens?.balanceOfFractionTokens.map((d) => d.owner),
-    [balanceOfFractionTokens],
-  );
-  const { names: holderNames } = useNamesByAddresses(holders);
-  const holderDetail = useMemo(
-    () =>
-      holderNames.flat().map((n) => ({
-        ...n,
-        balance: balanceOfFractionTokens?.balanceOfFractionTokens.find(
-          ({ owner }) => owner.toLowerCase() === n.address.toLowerCase(),
-        )?.balance,
-      })),
-    [balanceOfFractionTokens, holderNames],
-  );
+  const hatsTimeFrameModuleAddress = workspaceData?.workspace
+    ?.hatsTimeFrameModule as Address | undefined;
 
-  // HatsTimeFrameModule関連の情報をボタンクリックの後再取得できるようにカウンターを設置
-  const [count, setCount] = useState(0);
-  const [sendSheetOpen, setSendSheetOpen] = useState(false);
-  const { isActive, woreTime, wearingElapsedTime } = useActiveState(
+  const { isActive, woreTime, wearingElapsedTime, refetch } = useActiveState(
     hatsTimeFrameModuleAddress,
     hatId,
     address,
-    count,
   );
 
-  // reactivate, deactivate, renounce
+  const formattedWoreTime = useMemo(
+    () => (woreTime ? dayjs.unix(woreTime).format("YYYY/MM/DD") : undefined),
+    [woreTime],
+  );
+  const formattedDays = useMemo(
+    () =>
+      wearingElapsedTime ? Math.floor(wearingElapsedTime / 86400) : undefined,
+    [wearingElapsedTime],
+  );
+
   const { reactivate, isLoading: isReactivating } = useReactivate(
     hatsTimeFrameModuleAddress,
   );
@@ -111,121 +102,252 @@ const RoleHolderDetails: FC = () => {
   const { renounceHat, isLoading: isRenouncing } =
     useRenounceHatFromTimeFrameModule(hatsTimeFrameModuleAddress as Address);
 
-  const navigate = useNavigate();
+  // ── Wearer name + avatar ───────────────────────────────────
+  const addresses = useMemo(() => (address ? [address] : undefined), [address]);
+  const { names: wearerNames } = useNamesByAddresses(addresses);
+  const wearer = useMemo(() => wearerNames.flat()[0], [wearerNames]);
+  const wearerName = wearer?.name ?? abbreviateAddress(address || "");
+  const wearerAvatar = ipfs2https(wearer?.text_records?.avatar);
 
-  if (!hat) return;
+  // ── Holders for this (wearer, hat) shard ────────────────────
+  const { data: balanceOfFractionTokens } = useGetBalanceOfFractionTokens({
+    where: {
+      wearer: address?.toLowerCase(),
+      hatId: BigInt(hatId || 0).toString(10),
+    },
+  });
+  const holderAddresses = useMemo(
+    () =>
+      balanceOfFractionTokens?.balanceOfFractionTokens.map((d) =>
+        d.owner.toLowerCase(),
+      ) ?? [],
+    [balanceOfFractionTokens],
+  );
+  const { names: holderNames } = useNamesByAddresses(holderAddresses);
+  const holderDetails = useMemo(
+    () =>
+      holderNames.flat().map((n) => {
+        const lower = n.address.toLowerCase();
+        const balanceStr =
+          balanceOfFractionTokens?.balanceOfFractionTokens.find(
+            ({ owner }) => owner.toLowerCase() === lower,
+          )?.balance;
+        // FractionToken is ERC-1155 — balances are raw integer counts, not
+        // 18-decimal wei. Do not formatEther here.
+        const balance = balanceStr ? Number(balanceStr) : 0;
+        return {
+          address: lower,
+          name: n.name ?? abbreviateAddress(lower),
+          avatar: ipfs2https(n.text_records?.avatar),
+          balance,
+        };
+      }),
+    [balanceOfFractionTokens, holderNames],
+  );
+
+  // The logged-in user's holdings of THIS wearer's (hat, wearer) shard.
+  // FractionToken is ERC-1155 — balances are raw integer counts, no
+  // formatEther. Returns `undefined` whenever the value shouldn't be a
+  // numeric "0": still loading, not logged in, or the shard hasn't been
+  // minted yet (no balance entries at all). A real "0" only shows when
+  // other people hold this shard but the current user doesn't.
+  const ownBalance = useMemo<number | undefined>(() => {
+    if (!me || !balanceOfFractionTokens) return undefined;
+    const entries = balanceOfFractionTokens.balanceOfFractionTokens;
+    if (entries.length === 0) return undefined;
+    const mine = entries.find((b) => b.owner.toLowerCase() === me);
+    if (!mine) return 0;
+    return Number(mine.balance);
+  }, [balanceOfFractionTokens, me]);
+
+  const [sendSheetOpen, setSendSheetOpen] = useState(false);
+
+  // Care-point variant — three legacy workspaces show ケアポイント copy.
+  const isCarePoint = ["144", "175", "780"].includes(treeId || "");
+  const shareTitle = isCarePoint ? "ケアポイント" : "ロールシェア";
+
+  // ロールシェアの保有率 — sort by balance desc, then map to percent of total.
+  const shareItems = useMemo(() => {
+    const total = holderDetails.reduce((acc, h) => acc + h.balance, 0);
+    if (total <= 0) return [];
+    const sorted = [...holderDetails].sort((a, b) => b.balance - a.balance);
+    return sorted.map((h, i) => ({
+      key: h.address,
+      percent: (h.balance / total) * 100,
+      color: SHARE_PALETTE[i % SHARE_PALETTE.length],
+      leading: (
+        <Avatar size="sm" className="size-6">
+          {h.avatar && <AvatarImage src={h.avatar} alt="" />}
+          <AvatarFallback seed={h.name} />
+        </Avatar>
+      ),
+      label: h.name,
+    }));
+  }, [holderDetails]);
+
+  const breadcrumbItems = [
+    { label: "当番一覧", to: `/${treeId}/role` },
+    { label: dutyName, to: `/${treeId}/${hatId}` },
+    { label: wearerName },
+  ];
+
+  if (!hat) {
+    return (
+      <PageContainer className="pt-2 pb-8">
+        <Breadcrumb className="mb-3 px-1" items={breadcrumbItems} />
+        <Card className="mt-3 py-12 text-center">
+          <Typography variant="bodySm" tone="secondary">
+            担当者情報が見つかりませんでした
+          </Typography>
+        </Card>
+      </PageContainer>
+    );
+  }
 
   return (
-    <Box>
-      <HatsListItemParser imageUri={hat.imageUri} detailUri={hat.details}>
-        <RoleNameWithWearer
-          treeId={treeId}
-          hatId={hatId}
-          wearerId={address}
-          wearerName={wearerName}
-          wearerIcon={wearerIcon}
-        />
-        <ActiveState
-          isActive={isActive}
-          woreTime={woreTime}
-          wearingElapsedTime={wearingElapsedTime}
-        />
-        <HatDetail />
-      </HatsListItemParser>
+    <>
+      <PageContainer className="pt-2 pb-10">
+        <Breadcrumb className="mb-3 px-1" items={breadcrumbItems} />
 
-      <HStack paddingTop={8} justifyContent="space-between">
-        <Heading size="lg">
-          {["144", "175", "780"].includes(treeId || "")
-            ? "ケアポイント"
-            : "ロールシェア"}
-        </Heading>
-        <BasicButton
-          minH={5}
-          size="xs"
-          bgColor="yellow.400"
-          onClick={() => setSendSheetOpen(true)}
-        >
-          誰かに送る
-        </BasicButton>
-      </HStack>
+        <div className="flex flex-col gap-4 px-1 pt-1">
+          {/* Header */}
+          <div className="flex items-center gap-3.5">
+            <DutyIcon imageUrl={imageUrl} />
+            <div className="min-w-0 flex-1">
+              <Typography
+                as="div"
+                variant="caption"
+                tone="secondary"
+                truncate
+                className="mb-0.5"
+              >
+                {dutyName}
+              </Typography>
+              <div className="flex items-center gap-2">
+                <Avatar size="sm" className="size-6">
+                  {wearerAvatar && <AvatarImage src={wearerAvatar} alt="" />}
+                  <AvatarFallback seed={wearerName} />
+                </Avatar>
+                <Heading variant="h4" level={1} className="truncate">
+                  {wearerName}
+                </Heading>
+              </div>
+              <Typography
+                variant="micro"
+                tone="secondary"
+                as="div"
+                className="mt-0.5"
+              >
+                {abbreviateAddress(address || "")}
+              </Typography>
+            </div>
+            <Badge kind={isActive ? "lead" : "supporter"}>
+              {isActive ? "アクティブ" : "休止中"}
+            </Badge>
+          </div>
 
-      <VStack width="full" alignItems="start" gap={3} paddingY={4}>
-        {holderDetail.length === 0 ? (
-          <Text fontStyle="italic" color="gray.400">
-            No holders
-          </Text>
-        ) : (
-          holderDetail.map((h) => (
-            <HStack key={`${h.name}h`} width="full">
-              <UserIcon
-                userImageUrl={ipfs2https(h.text_records?.avatar)}
-                size={10}
+          {/* Stats */}
+          <Card className="px-4 py-4">
+            <div className="grid grid-cols-3 gap-3">
+              <Stat label="活動開始日" value={formattedWoreTime ?? "—"} />
+              <Stat
+                label="総活動日数"
+                value={formattedDays !== undefined ? `${formattedDays}日` : "—"}
               />
-              <Text lineBreak="anywhere" flexGrow={1}>
-                {h.name
-                  ? `${h.name} (${abbreviateAddress(h.address)})`
-                  : abbreviateAddress(h.address)}
-              </Text>
-              {h.balance !== undefined && (
-                <Text>{Number(h.balance).toLocaleString()}</Text>
-              )}
-            </HStack>
-          ))
-        )}
-      </VStack>
+              <Stat
+                label={`あなたの${shareTitle}`}
+                value={
+                  ownBalance !== undefined ? ownBalance.toLocaleString() : "—"
+                }
+              />
+            </div>
+          </Card>
 
-      {/* hatについて権限があるかどうかで表示の有無が変わるボタン */}
-      {isAuthorised && (
-        <>
-          {isActive ? (
-            <BasicButton
-              marginTop={8}
-              bgColor="red.200"
-              onClick={async () => {
-                await deactivate(hatId, address);
-                setCount(count + 1);
-              }}
-              disabled={isDeactivating}
-              loading={isDeactivating}
+          {me && (
+            <Button
+              variant="secondary"
+              full
+              onClick={() => setSendSheetOpen(true)}
             >
-              一時休止
-            </BasicButton>
-          ) : (
-            <BasicButton
-              marginTop={8}
-              bgColor="blue.400"
-              onClick={async () => {
-                await reactivate(hatId, address);
-                setCount(count + 1);
-              }}
-              disabled={isReactivating}
-            >
-              {isReactivating ? "Reactivating..." : "Reactivate"}
-            </BasicButton>
+              <Icon name="send" size={16} />
+              {shareTitle}を送る
+            </Button>
           )}
-          {/* 現時点では表示されても実際にrevokeできるのはwearerのみ */}
-          <BasicButton
-            marginY={4}
-            bgColor="red.400"
-            color="white"
-            onClick={async () => {
-              try {
-                await renounceHat(BigInt(hatId || 0), address as Address);
-              } catch (error) {
-                console.error(error);
-                return;
-              }
-              navigate(`/${treeId}/${hatId}`);
-            }}
-            disabled={isRenouncing}
-            loading={isRenouncing}
-          >
-            当番を剥奪
-          </BasicButton>
-        </>
-      )}
 
-      <StickyNav />
+          {/* ロールシェアの保有率 */}
+          <section className="flex flex-col gap-2">
+            <SectionLabel className="px-0">{shareTitle}の保有率</SectionLabel>
+            <Card className="px-4 py-4">
+              <ShareDistribution
+                items={shareItems}
+                emptyLabel="シェアはまだ配布されていません"
+              />
+            </Card>
+          </section>
+
+          {/* Authorized actions */}
+          {isMe && hatsTimeFrameModuleAddress && (
+            <div className="flex flex-col gap-2 pt-2">
+              {isActive ? (
+                <Button
+                  variant="secondary"
+                  full
+                  disabled={isDeactivating}
+                  onClick={async () => {
+                    if (!hatId || !address) return;
+                    try {
+                      await deactivate(hatId, address);
+                      await refetch();
+                      toast.success("一時休止しました");
+                    } catch (error) {
+                      console.error(error);
+                      toast.error("一時休止に失敗しました");
+                    }
+                  }}
+                >
+                  {isDeactivating ? "一時休止中…" : "一時休止"}
+                </Button>
+              ) : (
+                <Button
+                  variant="primary"
+                  full
+                  disabled={isReactivating}
+                  onClick={async () => {
+                    if (!hatId || !address) return;
+                    try {
+                      await reactivate(hatId, address);
+                      await refetch();
+                      toast.success("当番を再開しました");
+                    } catch (error) {
+                      console.error(error);
+                      toast.error("再開に失敗しました");
+                    }
+                  }}
+                >
+                  {isReactivating ? "再開中…" : "再開する"}
+                </Button>
+              )}
+              <Button
+                variant="danger"
+                full
+                disabled={isRenouncing}
+                onClick={async () => {
+                  if (!hatId || !address) return;
+                  try {
+                    await renounceHat(BigInt(hatId), address as Address);
+                  } catch (error) {
+                    console.error(error);
+                    return;
+                  }
+                  navigate(`/${treeId}/${hatId}`);
+                }}
+              >
+                {isRenouncing ? "剥奪中…" : "当番を剥奪"}
+              </Button>
+            </div>
+          )}
+        </div>
+      </PageContainer>
 
       {treeId && hatId && address && (
         <AssistCreditSendSheet
@@ -236,8 +358,36 @@ const RoleHolderDetails: FC = () => {
           wearer={address as Address}
         />
       )}
-    </Box>
+    </>
   );
 };
 
-export default RoleHolderDetails;
+export default HolderDetail;
+
+const DutyIcon: FC<{ imageUrl?: string }> = ({ imageUrl }) => (
+  <div
+    className={cn(
+      "flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-md bg-[#F2EAD9]",
+    )}
+  >
+    {imageUrl ? (
+      <img src={imageUrl} alt="" className="size-full object-cover" />
+    ) : (
+      <Icon name="duty" size={28} className="text-[#7A5A2E]" />
+    )}
+  </div>
+);
+
+const Stat: FC<{ label: React.ReactNode; value: React.ReactNode }> = ({
+  label,
+  value,
+}) => (
+  <div className="flex flex-col gap-1">
+    <Typography variant="micro" tone="secondary" as="span" weight="semibold">
+      {label}
+    </Typography>
+    <Typography variant="bodySm" as="span" weight="bold">
+      {value}
+    </Typography>
+  </div>
+);

--- a/pkgs/frontend/app/routes/$treeId_.role.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.role.tsx
@@ -867,12 +867,20 @@ const DutyDetailPreview: FC<DutyDetailPreviewProps> = ({
             {name}
           </Heading>
         </div>
-        <Button variant="secondary" asChild>
-          <Link to={`/${treeId}/${hat.id}`}>
-            詳細を見る
-            <Icon name="chevron-right" size={16} />
-          </Link>
-        </Button>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button variant="secondary" asChild>
+            <Link to={`/${treeId}/${hat.id}`}>
+              詳細
+              <Icon name="chevron-right" size={16} />
+            </Link>
+          </Button>
+          <Button variant="primary" asChild>
+            <Link to={`/${treeId}/${hat.id}/assign`}>
+              <Icon name="plus" size={16} />
+              担当を追加
+            </Link>
+          </Button>
+        </div>
       </div>
 
       {description && (

--- a/pkgs/frontend/app/routes/$treeId_.role.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.role.tsx
@@ -13,6 +13,7 @@ import type { HatsDetailSchama } from "types/hats";
 import { ipfs2https } from "utils/ipfs";
 import { abbreviateAddress } from "utils/wallet";
 import { formatEther } from "viem";
+import { Breadcrumb } from "~/components/composite/breadcrumb";
 import { SectionLabel } from "~/components/composite/section-label";
 import { Segmented } from "~/components/composite/segmented";
 import { PageContainer } from "~/components/layout/PageContainer";
@@ -162,6 +163,11 @@ const WorkspaceRoles: FC = () => {
 
   return (
     <PageContainer className="pt-4 pb-8 md:pt-6">
+      <Breadcrumb
+        className="mb-3 px-1"
+        items={[{ label: "ホーム", to: `/${treeId}` }, { label: "当番一覧" }]}
+      />
+
       {/* Mobile single-column. */}
       <div className="md:hidden">
         <header className="mb-3 px-1">

--- a/pkgs/frontend/hooks/useHatsTimeFrameModule.ts
+++ b/pkgs/frontend/hooks/useHatsTimeFrameModule.ts
@@ -103,6 +103,37 @@ export const useDeactivate = (hatsTimeFrameModuleAddress?: string) => {
   return { deactivate, isLoading };
 };
 
+// Mirrors `HatsTimeFrameModule.hasAuthority(address)` — true if the address
+// is the wearer or admin of the module's configured `minterHatId`, which the
+// contract uses to gate `deactivate` / `reactivate` / `renounce` for accounts
+// other than the wearer themselves.
+export const useHasAuthority = (
+  hatsTimeFrameModuleAddress?: string,
+  authority?: string,
+) => {
+  const enabled = !!hatsTimeFrameModuleAddress && !!authority;
+  const { data } = useQuery({
+    queryKey: [
+      "hatsTimeFrame",
+      "hasAuthority",
+      hatsTimeFrameModuleAddress,
+      authority,
+    ],
+    queryFn: async () => {
+      const result = await publicClient.readContract({
+        ...hatsTimeFrameContractBaseConfig(
+          hatsTimeFrameModuleAddress as Address,
+        ),
+        functionName: "hasAuthority",
+        args: [authority as Address],
+      });
+      return result;
+    },
+    enabled,
+  });
+  return data ?? false;
+};
+
 export const useActiveState = (
   hatsTimeFrameModuleAddress?: string,
   hatId?: string,

--- a/pkgs/frontend/hooks/useHatsTimeFrameModule.ts
+++ b/pkgs/frontend/hooks/useHatsTimeFrameModule.ts
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
 import type { Address } from "viem";
 import { hatsTimeFrameContractBaseConfig } from "./useContracts";
@@ -59,8 +60,6 @@ export const useReactivate = (hatsTimeFrameModuleAddress?: string) => {
         await publicClient.waitForTransactionReceipt({
           hash: txHash,
         });
-      } catch (error) {
-        console.error(error);
       } finally {
         setIsLoading(false);
       }
@@ -94,8 +93,6 @@ export const useDeactivate = (hatsTimeFrameModuleAddress?: string) => {
         await publicClient.waitForTransactionReceipt({
           hash: txHash,
         });
-      } catch (error) {
-        console.error(error);
       } finally {
         setIsLoading(false);
       }
@@ -110,57 +107,55 @@ export const useActiveState = (
   hatsTimeFrameModuleAddress?: string,
   hatId?: string,
   wearer?: string,
-  count?: number,
 ) => {
-  const [activeState, setActiveState] = useState({
-    isActive: false,
-    woreTime: 0,
-    wearingElapsedTime: 0,
+  const enabled = !!hatsTimeFrameModuleAddress && !!hatId && !!wearer;
+  const { data, refetch } = useQuery({
+    queryKey: [
+      "hatsTimeFrame",
+      "activeState",
+      hatsTimeFrameModuleAddress,
+      hatId,
+      wearer,
+    ],
+    queryFn: async () => {
+      const [isActive, woreTime, wearingElapsedTime] = await Promise.all([
+        publicClient.readContract({
+          ...hatsTimeFrameContractBaseConfig(
+            hatsTimeFrameModuleAddress as Address,
+          ),
+          functionName: "isActive",
+          args: [BigInt(hatId as string), wearer as Address],
+        }),
+        publicClient.readContract({
+          ...hatsTimeFrameContractBaseConfig(
+            hatsTimeFrameModuleAddress as Address,
+          ),
+          functionName: "getWoreTime",
+          args: [wearer as Address, BigInt(hatId as string)],
+        }),
+        publicClient.readContract({
+          ...hatsTimeFrameContractBaseConfig(
+            hatsTimeFrameModuleAddress as Address,
+          ),
+          functionName: "getWearingElapsedTime",
+          args: [wearer as Address, BigInt(hatId as string)],
+        }),
+      ]);
+      return {
+        isActive,
+        woreTime: Number(woreTime),
+        wearingElapsedTime: Number(wearingElapsedTime),
+      };
+    },
+    enabled,
   });
 
-  useEffect(() => {
-    const fetch = async () => {
-      if (!hatsTimeFrameModuleAddress || !hatId || !wearer) return;
-
-      try {
-        const [isActive, woreTime, wearingElapsedTime] = await Promise.all([
-          publicClient.readContract({
-            ...hatsTimeFrameContractBaseConfig(
-              hatsTimeFrameModuleAddress as Address,
-            ),
-            functionName: "isActive",
-            args: [BigInt(hatId), wearer as Address],
-          }),
-          publicClient.readContract({
-            ...hatsTimeFrameContractBaseConfig(
-              hatsTimeFrameModuleAddress as Address,
-            ),
-            functionName: "getWoreTime",
-            args: [wearer as Address, BigInt(hatId)],
-          }),
-          publicClient.readContract({
-            ...hatsTimeFrameContractBaseConfig(
-              hatsTimeFrameModuleAddress as Address,
-            ),
-            functionName: "getWearingElapsedTime",
-            args: [wearer as Address, BigInt(hatId)],
-          }),
-        ]);
-
-        setActiveState({
-          isActive,
-          woreTime: Number(woreTime),
-          wearingElapsedTime: Number(wearingElapsedTime),
-        });
-      } catch (error) {
-        console.error(error);
-      }
-    };
-
-    fetch();
-  }, [hatsTimeFrameModuleAddress, hatId, wearer]);
-
-  return activeState;
+  return {
+    isActive: data?.isActive ?? false,
+    woreTime: data?.woreTime ?? 0,
+    wearingElapsedTime: data?.wearingElapsedTime ?? 0,
+    refetch,
+  };
 };
 
 export const useWearingElapsedTime = (


### PR DESCRIPTION
## Summary
- Rebuild `/{treeId}/{hatId}` on the design system — breadcrumb, header, description card, combined assignees + supporters card (with `当番リード` / `サポーター` badges), and a quest panel that lives on the right side (60/40 split) on desktop or below 説明 on mobile. クエスト作成 button is part of the quest panel.
- Rebuild `/{treeId}/{hatId}/{address}` — duty/wearer header with active/休止 badge, stats card (`活動開始日` / `総活動日数` / `あなたの{ロールシェア|ケアポイント}`), `ロールシェアの保有率` chart, send shortcut (hidden when logged out), and 一時休止 / 再開 / 当番を剥奪 actions with `sonner` toast on success.
- Add two design-system composites with Ladle stories: `Breadcrumb` (every crumb rendered as a `<Link>` with the current page disabled, so the baseline is identical) and `ShareDistribution` (stacked horizontal bar + legend with avatars + percent).
- Wire breadcrumbs across `/{treeId}/role`, `/{treeId}/{hatId}`, `/{treeId}/{hatId}/{address}` so navigation back through the chain works without per-page back buttons.
- Convert `useActiveState` to `useQuery` and return `refetch` — the holder detail flips アクティブ → 休止中 from chain-confirmed data instead of revalidation tokens or optimistic state.
- Fix the FractionToken display bug where `formatEther` was being applied to ERC-1155 integer balances and turning them into near-zero "dummy" values.

Closes #435.

## Test plan
- [ ] Navigate `/{treeId}/role` → `/{treeId}/{hatId}`: breadcrumb shows `当番一覧 > {duty}`, クエスト一覧が右(or下)に表示、クエスト作成ボタンが同じパネルにある
- [ ] On `/{treeId}/{hatId}`, 現在の担当 card lists wearers with `当番リード` and RoleShare holders with `サポーター` badges
- [ ] Visit `/{treeId}/{hatId}/{address}`: breadcrumb shows `当番一覧 > {duty} > {resolved name}`, 活動開始日 / 総活動日数 / あなたのロールシェア が表示
- [ ] `あなたのロールシェア` shows `—` when the shard hasn't been minted yet or the user is logged out, `0` only when others hold but the user doesn't, the real number otherwise
- [ ] 一時休止 → toast成功後にバッジが `アクティブ` → `休止中` に切り替わる。再開も同様
- [ ] 「ロールシェアを送る」ボトムシートはログイン時のみ表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)