### PR TITLE
feat(frontend): renew split list / detail / create (#440 #441 #442)

### DIFF
--- a/pkgs/frontend/CLAUDE.md
+++ b/pkgs/frontend/CLAUDE.md
@@ -50,7 +50,7 @@ Use `react-icons` (already a dependency). **Do not install `lucide-react`.** Whe
 
 ## Toasts — sonner only
 
-Use `sonner` for toasts: `import { toast } from "sonner"` (matches the `toast.success` / `toast.error` API). The global `<Toaster />` is already mounted inside `PrivyAppRoot`. **Do not import from `react-toastify`** in any route module or any module that a route imports at the top level — `react-toastify@11`'s ESM entry runs `document.head.insertBefore(<style>, head.firstChild)` at module evaluation, which shifts every expected `<meta>` position in `<head>` and breaks SSR hydration on direct loads ("Expected server HTML to contain a matching `<meta>` in `<head>`"). Sonner is safe because its equivalent uses `appendChild` (END of `<head>`), so the order of React-rendered children is preserved. `react-toastify`'s `<ToastContainer />` is still mounted via the lazy `PrivyAppRoot` for the legacy chakra-era surfaces that haven't migrated yet (issue #422); leave those alone but don't add new imports.
+Use `sonner` for toasts: `import { toast } from "sonner"` (matches the `toast.success` / `toast.error` API). The global `<Toaster />` is already mounted inside `PrivyAppRoot`. `react-toastify` is no longer a dependency — issue #422 is done. If shadcn/ui generator output suggests toast libraries other than sonner, swap them for sonner.
 
 ## Commands
 

--- a/pkgs/frontend/app/components/PrivyAppRoot.tsx
+++ b/pkgs/frontend/app/components/PrivyAppRoot.tsx
@@ -3,7 +3,6 @@ import { SmartWalletsProvider } from "@privy-io/react-auth/smart-wallets";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { currentChain } from "hooks/useViem";
 import { useActiveWallet } from "hooks/useWallet";
-import { ToastContainer } from "react-toastify";
 import { PWAUpdater } from "./PWAUpdater";
 import { SmartWalletLoading } from "./SmartWalletLoading";
 import { SwitchNetwork } from "./SwitchNetwork";
@@ -42,7 +41,6 @@ export default function PrivyAppRoot() {
           <SwitchNetwork />
           <PWAUpdater />
           <AppContent />
-          <ToastContainer />
           <Toaster />
         </QueryClientProvider>
       </SmartWalletsProvider>

--- a/pkgs/frontend/app/components/SignupForm.tsx
+++ b/pkgs/frontend/app/components/SignupForm.tsx
@@ -3,7 +3,7 @@ import { useUploadImageFileToIpfs } from "hooks/useIpfs";
 import { useActiveWallet } from "hooks/useWallet";
 import type { TextRecords } from "namestone-sdk";
 import { type FC, useCallback, useEffect, useMemo, useState } from "react";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 import { FieldLabel } from "~/components/composite/field-label";
 import {
   Avatar,

--- a/pkgs/frontend/app/components/assistcredit/AssistCreditSendSheet.tsx
+++ b/pkgs/frontend/app/components/assistcredit/AssistCreditSendSheet.tsx
@@ -9,11 +9,6 @@ import { useTreeInfo } from "hooks/useHats";
 import type { NameData } from "namestone-sdk";
 import { type FC, Fragment, useMemo, useState } from "react";
 import { LuCheck } from "react-icons/lu";
-// Sonner — appends its stylesheet to the END of <head> on module eval, so
-// loading it at module level is safe for hydration. react-toastify uses
-// `insertBefore(..., firstChild)` which shifts every expected <meta>
-// position and breaks SSR hydration on direct loads (see commit dfd24c0
-// + #422 migration).
 import { toast } from "sonner";
 import type { HatsDetailSchama } from "types/hats";
 import { ipfs2https } from "utils/ipfs";

--- a/pkgs/frontend/app/components/common/QrAddressReader.tsx
+++ b/pkgs/frontend/app/components/common/QrAddressReader.tsx
@@ -1,7 +1,7 @@
 import { BrowserMultiFormatReader } from "@zxing/library";
 import { type FC, useCallback, useRef, useState } from "react";
 import { MdQrCodeScanner } from "react-icons/md";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 import { Box, IconButton } from "~/components/chakra-shim";
 import CommonButton from "./CommonButton";
 

--- a/pkgs/frontend/app/components/composite/donut-chart.stories.tsx
+++ b/pkgs/frontend/app/components/composite/donut-chart.stories.tsx
@@ -1,0 +1,43 @@
+import type { Story } from "@ladle/react";
+import { DonutChart } from "./donut-chart";
+
+export default {
+  title: "Composite / DonutChart",
+};
+
+const sample = [
+  { key: "atsu", percent: 24 },
+  { key: "ryoma", percent: 21 },
+  { key: "yumaito", percent: 18 },
+  { key: "takerun", percent: 14 },
+  { key: "koichi", percent: 11 },
+  { key: "eri", percent: 7 },
+  { key: "sg", percent: 5 },
+];
+
+export const Small: Story = () => <DonutChart slices={sample} size={72} />;
+
+export const Large: Story = () => (
+  <DonutChart
+    slices={sample}
+    size={130}
+    center={
+      <>
+        <span className="text-2xl font-extrabold leading-none">100</span>
+        <span className="mt-0.5 text-[10px] font-bold text-text-secondary">
+          %
+        </span>
+      </>
+    }
+  />
+);
+
+export const Partial: Story = () => (
+  <DonutChart
+    slices={[
+      { key: "ryu", percent: 35 },
+      { key: "sg", percent: 25 },
+    ]}
+    size={120}
+  />
+);

--- a/pkgs/frontend/app/components/composite/donut-chart.tsx
+++ b/pkgs/frontend/app/components/composite/donut-chart.tsx
@@ -1,0 +1,127 @@
+import type * as React from "react";
+
+import { cn } from "~/lib/utils";
+
+// Donut palette — split-blue family from the design source.
+// Mirrors `docs/design/handoff/project/screens.jsx:487`.
+const DONUT_PALETTE = [
+  "#5DADEC",
+  "#F5B82E",
+  "#65C98A",
+  "#D6B995",
+  "#E48F4F",
+  "#B696E0",
+  "#E48ABF",
+  "#7AC2D9",
+  "#F2A6A0",
+] as const;
+
+interface DonutSlice {
+  /** Stable key per slice — usually the recipient address or name. */
+  key: string;
+  /** Percentage of the whole (0–100). */
+  percent: number;
+  /** Override palette colour for this slice. */
+  color?: string;
+}
+
+interface DonutChartProps extends React.ComponentProps<"div"> {
+  slices: DonutSlice[];
+  /** Pixel size of the SVG container. */
+  size?: number;
+  /** Optional center content; when omitted shows "{n}人". Pass `null` to hide. */
+  center?: React.ReactNode;
+  /** Track (background) colour shown when no slice fills the segment. */
+  trackColor?: string;
+  /** Stroke width relative to size — defaults to `size / 7.2`. */
+  thickness?: number;
+}
+
+// Toban DonutChart — segmented ring for share distributions. Mirrors
+// `docs/design/handoff/project/screens.jsx:493-516`. Designed for the splits
+// list cards (size=72) and split-detail cards (size=130/140).
+function DonutChart({
+  slices,
+  size = 80,
+  center,
+  trackColor = "#F0EBE0",
+  thickness,
+  className,
+  ...rest
+}: DonutChartProps) {
+  const strokeWidth = thickness ?? Math.max(6, Math.round(size / 7.2));
+  const r = size / 2 - strokeWidth / 2 - 2;
+  const cx = size / 2;
+  const cy = size / 2;
+  const circ = 2 * Math.PI * r;
+
+  const sum = slices.reduce((acc, s) => acc + Math.max(0, s.percent), 0);
+  const remainder = Math.max(0, 100 - sum);
+  const all =
+    remainder > 0.5
+      ? [...slices, { key: "__other", percent: remainder, color: trackColor }]
+      : slices;
+
+  let offset = 0;
+  return (
+    <div
+      data-slot="donut-chart"
+      className={cn("relative shrink-0", className)}
+      style={{ width: size, height: size }}
+      {...rest}
+    >
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        style={{ transform: "rotate(-90deg)" }}
+        aria-hidden
+      >
+        <title>分配の比率</title>
+        <circle
+          cx={cx}
+          cy={cy}
+          r={r}
+          fill="none"
+          stroke={trackColor}
+          strokeWidth={strokeWidth}
+        />
+        {all.map((s, i) => {
+          const pct = Math.max(0, Math.min(100, s.percent));
+          const len = (pct / 100) * circ;
+          const color = s.color ?? DONUT_PALETTE[i % DONUT_PALETTE.length];
+          const segment = (
+            <circle
+              key={s.key}
+              cx={cx}
+              cy={cy}
+              r={r}
+              fill="none"
+              stroke={color}
+              strokeWidth={strokeWidth}
+              strokeDasharray={`${len} ${circ - len}`}
+              strokeDashoffset={-offset}
+            />
+          );
+          offset += len;
+          return segment;
+        })}
+      </svg>
+      {center !== null && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
+          {center ?? (
+            <span
+              className="font-bold text-text-secondary"
+              style={{ fontSize: Math.max(10, Math.round(size * 0.16)) }}
+            >
+              {slices.length}人
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export { DonutChart, DONUT_PALETTE };
+export type { DonutChartProps, DonutSlice };

--- a/pkgs/frontend/app/components/splits/RuleCard.tsx
+++ b/pkgs/frontend/app/components/splits/RuleCard.tsx
@@ -1,0 +1,113 @@
+import type { FC } from "react";
+
+import { Divider } from "~/components/composite/divider";
+import { WeightBar } from "~/components/composite/weight-bar";
+import { Card } from "~/components/ui/card";
+import { Typography } from "~/components/ui/typography";
+
+// Weights captured at split creation time. Normalised to plain `number` so the
+// same component renders both the live form state (numbers from sliders) and
+// the on-chain values recovered from decoded calldata (bigint → number).
+export interface WeightInfo {
+  roleWeight: number;
+  thanksTokenWeight: number;
+  thanksTokenReceivedWeight: number;
+  thanksTokenSentWeight: number;
+}
+
+export interface RuleCardProps {
+  weights?: WeightInfo | null;
+  loading?: boolean;
+}
+
+// Toban split "分配ルール" card — `WeightBar`s for the top-level toban/thanks
+// split + a stat pair for the thanks-internal received/sent weight. Used both
+// on the split detail screen (#441) and the create-flow preview (#442) so the
+// rule shape stays identical between authoring and viewing.
+export const RuleCard: FC<RuleCardProps> = ({ weights, loading }) => {
+  if (loading) {
+    return (
+      <Card className="px-4 py-6 text-center">
+        <Typography variant="bodySm" tone="secondary">
+          ルールを読み込み中…
+        </Typography>
+      </Card>
+    );
+  }
+  if (!weights) {
+    return (
+      <Card className="px-4 py-6 text-center">
+        <Typography variant="bodySm" tone="secondary">
+          ルール情報を取得できませんでした
+        </Typography>
+      </Card>
+    );
+  }
+
+  const total = weights.roleWeight + weights.thanksTokenWeight;
+  const dutyPct =
+    total > 0 ? Math.round((weights.roleWeight / total) * 100) : 0;
+  const thanksPct =
+    total > 0 ? Math.round((weights.thanksTokenWeight / total) * 100) : 0;
+  const recvTotal =
+    weights.thanksTokenReceivedWeight + weights.thanksTokenSentWeight;
+  const recvPct =
+    recvTotal > 0
+      ? Math.round((weights.thanksTokenReceivedWeight / recvTotal) * 100)
+      : 0;
+  const sentPct =
+    recvTotal > 0
+      ? Math.round((weights.thanksTokenSentWeight / recvTotal) * 100)
+      : 0;
+
+  return (
+    <Card className="gap-4 px-4 py-4">
+      <WeightBar label="当番ベース" pct={dutyPct} color="var(--color-role)" />
+      <WeightBar
+        label="サンクスベース"
+        pct={thanksPct}
+        color="var(--color-contrib)"
+      />
+      <Divider />
+      <div>
+        <Typography
+          as="div"
+          variant="caption"
+          tone="secondary"
+          weight="semibold"
+          className="mb-2"
+        >
+          サンクス内の重み
+        </Typography>
+        <div className="flex gap-2.5">
+          <RuleStat
+            label="受け取り"
+            value={recvPct}
+            color="var(--color-contrib)"
+          />
+          <RuleStat label="送付" value={sentPct} color="var(--color-primary)" />
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+const RuleStat: FC<{ label: string; value: number; color: string }> = ({
+  label,
+  value,
+  color,
+}) => (
+  <div className="flex flex-1 flex-col items-center gap-1 rounded-sm bg-bg px-3 py-3 text-center">
+    <Typography variant="micro" tone="secondary" as="span">
+      {label}
+    </Typography>
+    <Typography
+      as="span"
+      variant="statMd"
+      className="tabular-nums"
+      style={{ color }}
+    >
+      {value}%
+    </Typography>
+  </div>
+);

--- a/pkgs/frontend/app/components/splits/SplitBreakdownCard.tsx
+++ b/pkgs/frontend/app/components/splits/SplitBreakdownCard.tsx
@@ -1,0 +1,115 @@
+import type { FC } from "react";
+
+import { abbreviateAddress } from "utils/wallet";
+import { Divider } from "~/components/composite/divider";
+import { DONUT_PALETTE } from "~/components/composite/donut-chart";
+import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import { Card } from "~/components/ui/card";
+import { Typography } from "~/components/ui/typography";
+
+export interface BreakdownRecipient {
+  /** Stable key — usually the recipient address (lowercased). */
+  address: string;
+  /** Pre-computed percentage of the whole (0-100). */
+  pct: number;
+}
+
+export interface BreakdownNameInfo {
+  name?: string;
+  avatarUrl?: string;
+}
+
+export interface SplitBreakdownCardProps {
+  recipients: BreakdownRecipient[];
+  /** Map from lowercased address → display name + avatar. Optional entries. */
+  nameByAddress: Map<string, BreakdownNameInfo>;
+  /** Message shown when there are no recipients to render. */
+  emptyLabel?: string;
+}
+
+// Toban split "分配の内訳" card — rank + avatar + name + colour bar + %.
+// Shared between the split detail screen (#441) and the create-flow preview
+// (#442) so authoring and viewing use the same row shape and palette.
+//
+// The colour palette matches the DonutChart by index — rank `n` shares its
+// colour with the nth slice. Bar width is the recipient's percentage on an
+// absolute 0–100 scale (so 30% reads as a third-full bar, not "fullest in
+// this list").
+export const SplitBreakdownCard: FC<SplitBreakdownCardProps> = ({
+  recipients,
+  nameByAddress,
+  emptyLabel = "分配先がありません",
+}) => {
+  if (recipients.length === 0) {
+    return (
+      <Card className="gap-0 p-0">
+        <Typography
+          variant="bodySm"
+          tone="secondary"
+          className="px-4 py-6 text-center"
+        >
+          {emptyLabel}
+        </Typography>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="gap-0 p-0">
+      {recipients.map((r, i) => {
+        const entry = nameByAddress.get(r.address.toLowerCase());
+        const name =
+          entry?.name ?? abbreviateAddress(r.address as `0x${string}`);
+        const color = DONUT_PALETTE[i % DONUT_PALETTE.length];
+        return (
+          <div key={r.address}>
+            <div className="flex items-center gap-3 px-4 py-3">
+              <Typography
+                as="span"
+                variant="caption"
+                weight="bold"
+                tone="secondary"
+                className="w-6 shrink-0"
+              >
+                {i + 1}
+              </Typography>
+              <Avatar size="default" className="size-8">
+                {entry?.avatarUrl && (
+                  <AvatarImage src={entry.avatarUrl} alt="" />
+                )}
+                <AvatarFallback seed={name} />
+              </Avatar>
+              <Typography
+                as="div"
+                variant="bodySm"
+                weight="semibold"
+                truncate
+                className="min-w-0 flex-1"
+              >
+                {name}
+              </Typography>
+              <div className="hidden h-1.5 w-20 overflow-hidden rounded-xs bg-[#F0EBE0] sm:block">
+                <div
+                  className="h-full"
+                  style={{
+                    width: `${Math.max(0, Math.min(100, r.pct))}%`,
+                    backgroundColor: color,
+                  }}
+                />
+              </div>
+              <Typography
+                as="span"
+                variant="bodySm"
+                weight="bold"
+                className="w-14 shrink-0 text-right tabular-nums"
+              >
+                {r.pct.toFixed(2)}%
+              </Typography>
+            </div>
+            {i < recipients.length - 1 && <Divider inset={16} />}
+          </div>
+        );
+      })}
+    </Card>
+  );
+};

--- a/pkgs/frontend/app/root.tsx
+++ b/pkgs/frontend/app/root.tsx
@@ -1,7 +1,6 @@
 import { ApolloProvider } from "@apollo/client/react";
 import { Suspense, lazy, useEffect, useState } from "react";
 import { Links, Meta, Scripts, ScrollRestoration } from "react-router";
-import toastStyles from "react-toastify/ReactToastify.css?url";
 import swiperStyles from "swiper/css?url";
 import { goldskyClient } from "utils/apollo";
 // Self-host the brand fonts (Issue #426). Inter carries Latin numerals/labels
@@ -72,7 +71,6 @@ export const links = () => [
   { rel: "icon", href: "/images/favicon.ico" },
   { rel: "manifest", href: "/manifest.webmanifest" },
   { rel: "apple-touch-icon", href: "/images/apple-touch-icon.png" },
-  { rel: "stylesheet", href: toastStyles },
   { rel: "stylesheet", href: swiperStyles },
 ];
 

--- a/pkgs/frontend/app/routes/$treeId_.$hatId_.$address.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.$hatId_.$address.tsx
@@ -16,9 +16,6 @@ import { useActiveWallet } from "hooks/useWallet";
 import { useGetWorkspace } from "hooks/useWorkspace";
 import { type FC, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
-// Sonner — appends its stylesheet to the END of <head>, so importing at
-// route-module level is safe for SSR hydration. react-toastify uses
-// `insertBefore(..., firstChild)` and breaks hydration on direct loads.
 import { toast } from "sonner";
 import type { HatsDetailSchama } from "types/hats";
 import { ipfs2https } from "utils/ipfs";

--- a/pkgs/frontend/app/routes/$treeId_.member_.$address.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.member_.$address.tsx
@@ -13,7 +13,7 @@ import {
 import type { TextRecords } from "namestone-sdk";
 import { type FC, useCallback, useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 import { Box, Flex, Input, Text } from "~/components/chakra-shim";
 import { UserThanksHistory } from "~/components/thankstoken/History";
 import {

--- a/pkgs/frontend/app/routes/$treeId_.settings.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.settings.tsx
@@ -23,7 +23,7 @@ import type { NameData } from "namestone-sdk";
 import { type FC, useCallback, useEffect, useMemo, useState } from "react";
 import { FaCircleCheck } from "react-icons/fa6";
 import { useParams } from "react-router";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 import type { HatsDetailSchama } from "types/hats";
 import { ipfs2https } from "utils/ipfs";
 import { abbreviateAddress, isValidEthAddress } from "utils/wallet";

--- a/pkgs/frontend/app/routes/$treeId_.splits.$splitId.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.splits.$splitId.tsx
@@ -18,16 +18,14 @@ import { ipfs2https } from "utils/ipfs";
 import { abbreviateAddress } from "utils/wallet";
 import { type Address, decodeFunctionData } from "viem";
 import { Breadcrumb } from "~/components/composite/breadcrumb";
-import { Divider } from "~/components/composite/divider";
 import {
-  DONUT_PALETTE,
   DonutChart,
   type DonutSlice,
 } from "~/components/composite/donut-chart";
 import { SectionLabel } from "~/components/composite/section-label";
-import { WeightBar } from "~/components/composite/weight-bar";
 import { PageContainer } from "~/components/layout/PageContainer";
-import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import { RuleCard, type WeightInfo } from "~/components/splits/RuleCard";
+import { SplitBreakdownCard } from "~/components/splits/SplitBreakdownCard";
 import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
 import { Heading } from "~/components/ui/heading";
@@ -59,13 +57,6 @@ const consolidateRecipients = (
     totalOwnership: total,
   };
 };
-
-interface WeightInfo {
-  roleWeight: number;
-  thanksTokenWeight: number;
-  thanksTokenReceivedWeight: number;
-  thanksTokenSentWeight: number;
-}
 
 // The Toban subgraph doesn't index split creation weights — they exist only as
 // `create()` calldata. We recover them by finding the `SplitsCreated` log that
@@ -212,23 +203,23 @@ const SplitDetailPage: FC = () => {
     [recipients],
   );
 
-  const ranking = useMemo(() => {
+  const breakdownRows = useMemo(() => {
     if (recipients.totalOwnership === 0) return [];
-    return recipients.list.map((r, i) => {
-      const pct = (r.ownership / recipients.totalOwnership) * 100;
-      const entry = recipientNameByAddress.get(r.address.toLowerCase());
-      const name = entry?.name ?? abbreviateAddress(r.address as `0x${string}`);
-      const avatarUrl = ipfs2https(entry?.text_records?.avatar);
-      const color = DONUT_PALETTE[i % DONUT_PALETTE.length];
-      return {
-        address: r.address,
-        name,
-        avatarUrl,
-        pct,
-        color,
-      };
-    });
-  }, [recipients, recipientNameByAddress]);
+    return recipients.list.map((r) => ({
+      address: r.address,
+      pct: (r.ownership / recipients.totalOwnership) * 100,
+    }));
+  }, [recipients]);
+  const breakdownNameByAddress = useMemo(() => {
+    const m = new Map<string, { name?: string; avatarUrl?: string }>();
+    for (const [addr, entry] of recipientNameByAddress) {
+      m.set(addr, {
+        name: entry.name,
+        avatarUrl: ipfs2https(entry.text_records?.avatar),
+      });
+    }
+    return m;
+  }, [recipientNameByAddress]);
 
   const goBack = () => navigate(`/${treeId}/splits`);
 
@@ -294,25 +285,11 @@ const SplitDetailPage: FC = () => {
         </div>
 
         <section className="flex flex-col gap-2">
-          <SectionLabel className="px-0">分配結果</SectionLabel>
-          <Card className="gap-0 p-0">
-            {ranking.length === 0 ? (
-              <Typography
-                variant="bodySm"
-                tone="secondary"
-                className="px-4 py-6 text-center"
-              >
-                分配先がありません
-              </Typography>
-            ) : (
-              ranking.map((row, i) => (
-                <div key={row.address}>
-                  <RankRow row={row} rank={i + 1} />
-                  {i < ranking.length - 1 && <Divider inset={16} />}
-                </div>
-              ))
-            )}
-          </Card>
+          <SectionLabel className="px-0">分配の内訳</SectionLabel>
+          <SplitBreakdownCard
+            recipients={breakdownRows}
+            nameByAddress={breakdownNameByAddress}
+          />
         </section>
 
         <ClaimableBalancesCard
@@ -364,25 +341,11 @@ const SplitDetailPage: FC = () => {
           </div>
 
           <section className="flex flex-col gap-2">
-            <SectionLabel className="px-0">分配結果</SectionLabel>
-            <Card className="gap-0 p-0">
-              {ranking.length === 0 ? (
-                <Typography
-                  variant="bodySm"
-                  tone="secondary"
-                  className="px-4 py-6 text-center"
-                >
-                  分配先がありません
-                </Typography>
-              ) : (
-                ranking.map((row, i) => (
-                  <div key={row.address}>
-                    <RankRow row={row} rank={i + 1} />
-                    {i < ranking.length - 1 && <Divider inset={16} />}
-                  </div>
-                ))
-              )}
-            </Card>
+            <SectionLabel className="px-0">分配の内訳</SectionLabel>
+            <SplitBreakdownCard
+              recipients={breakdownRows}
+              nameByAddress={breakdownNameByAddress}
+            />
           </section>
         </div>
 
@@ -438,161 +401,6 @@ const DonutSummaryCard: FC<DonutSummaryCardProps> = ({
       }
     />
   </Card>
-);
-
-// ─── RankRow ───────────────────────────────────────────────────────────────
-
-interface RankRowProps {
-  row: {
-    address: string;
-    name: string;
-    avatarUrl?: string;
-    pct: number;
-    color: string;
-  };
-  rank: number;
-}
-
-// Bar width is the recipient's percentage of the whole (0-100). Earlier this
-// was scaled to the top recipient so the leader always showed a full bar; the
-// design wants an absolute scale so reading "30%" matches a bar a third full.
-const RankRow: FC<RankRowProps> = ({ row, rank }) => (
-  <div className="flex items-center gap-3 px-4 py-3">
-    <Typography
-      as="span"
-      variant="caption"
-      weight="bold"
-      tone="secondary"
-      className="w-6 shrink-0"
-    >
-      {rank}
-    </Typography>
-    <Avatar size="default" className="size-8">
-      {row.avatarUrl && <AvatarImage src={row.avatarUrl} alt="" />}
-      <AvatarFallback seed={row.name} />
-    </Avatar>
-    <Typography
-      as="div"
-      variant="bodySm"
-      weight="semibold"
-      truncate
-      className="min-w-0 flex-1"
-    >
-      {row.name}
-    </Typography>
-    <div className="hidden h-1.5 w-20 overflow-hidden rounded-xs bg-[#F0EBE0] sm:block">
-      <div
-        className="h-full"
-        style={{
-          width: `${Math.max(0, Math.min(100, row.pct))}%`,
-          backgroundColor: row.color,
-        }}
-      />
-    </div>
-    <Typography
-      as="span"
-      variant="bodySm"
-      weight="bold"
-      className="w-14 shrink-0 text-right tabular-nums"
-    >
-      {row.pct.toFixed(2)}%
-    </Typography>
-  </div>
-);
-
-// ─── RuleCard ──────────────────────────────────────────────────────────────
-
-interface RuleCardProps {
-  weights?: WeightInfo | null;
-  loading: boolean;
-}
-
-const RuleCard: FC<RuleCardProps> = ({ weights, loading }) => {
-  if (loading) {
-    return (
-      <Card className="px-4 py-6 text-center">
-        <Typography variant="bodySm" tone="secondary">
-          ルールを読み込み中…
-        </Typography>
-      </Card>
-    );
-  }
-  if (!weights) {
-    return (
-      <Card className="px-4 py-6 text-center">
-        <Typography variant="bodySm" tone="secondary">
-          ルール情報を取得できませんでした
-        </Typography>
-      </Card>
-    );
-  }
-
-  const total = weights.roleWeight + weights.thanksTokenWeight;
-  const dutyPct =
-    total > 0 ? Math.round((weights.roleWeight / total) * 100) : 0;
-  const thanksPct =
-    total > 0 ? Math.round((weights.thanksTokenWeight / total) * 100) : 0;
-  const recvTotal =
-    weights.thanksTokenReceivedWeight + weights.thanksTokenSentWeight;
-  const recvPct =
-    recvTotal > 0
-      ? Math.round((weights.thanksTokenReceivedWeight / recvTotal) * 100)
-      : 0;
-  const sentPct =
-    recvTotal > 0
-      ? Math.round((weights.thanksTokenSentWeight / recvTotal) * 100)
-      : 0;
-
-  return (
-    <Card className="gap-4 px-4 py-4">
-      <WeightBar label="当番ベース" pct={dutyPct} color="var(--color-role)" />
-      <WeightBar
-        label="サンクスベース"
-        pct={thanksPct}
-        color="var(--color-contrib)"
-      />
-      <Divider />
-      <div>
-        <Typography
-          as="div"
-          variant="caption"
-          tone="secondary"
-          weight="semibold"
-          className="mb-2"
-        >
-          サンクス内の重み
-        </Typography>
-        <div className="flex gap-2.5">
-          <RuleStat
-            label="受け取り"
-            value={recvPct}
-            color="var(--color-contrib)"
-          />
-          <RuleStat label="送付" value={sentPct} color="var(--color-primary)" />
-        </div>
-      </div>
-    </Card>
-  );
-};
-
-const RuleStat: FC<{ label: string; value: number; color: string }> = ({
-  label,
-  value,
-  color,
-}) => (
-  <div className="flex flex-1 flex-col items-center gap-1 rounded-sm bg-bg px-3 py-3 text-center">
-    <Typography variant="micro" tone="secondary" as="span">
-      {label}
-    </Typography>
-    <Typography
-      as="span"
-      variant="statMd"
-      className="tabular-nums"
-      style={{ color }}
-    >
-      {value}%
-    </Typography>
-  </div>
 );
 
 // ─── AddressRow / CopyIconButton ───────────────────────────────────────────

--- a/pkgs/frontend/app/routes/$treeId_.splits.$splitId.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.splits.$splitId.tsx
@@ -1,0 +1,737 @@
+import type { Split } from "@0xsplits/splits-sdk";
+import { useQuery } from "@tanstack/react-query";
+import { SPLITS_CREATOR_ABI } from "abi/splits";
+import dayjs from "dayjs";
+import { useCopyToClipboard } from "hooks/useCopyToClipboard";
+import { useNamesByAddresses } from "hooks/useENS";
+import {
+  useSplit,
+  useSplitsCreatorRelatedSplits,
+} from "hooks/useSplitsCreator";
+import { alchemyPublicClient, currentChain, publicClient } from "hooks/useViem";
+import { useGetWorkspace } from "hooks/useWorkspace";
+import type { NameData } from "namestone-sdk";
+import { type FC, useMemo } from "react";
+import { useNavigate, useParams } from "react-router";
+import { toast } from "sonner";
+import { ipfs2https } from "utils/ipfs";
+import { abbreviateAddress } from "utils/wallet";
+import { type Address, decodeFunctionData } from "viem";
+import { Breadcrumb } from "~/components/composite/breadcrumb";
+import { Divider } from "~/components/composite/divider";
+import {
+  DONUT_PALETTE,
+  DonutChart,
+  type DonutSlice,
+} from "~/components/composite/donut-chart";
+import { SectionLabel } from "~/components/composite/section-label";
+import { WeightBar } from "~/components/composite/weight-bar";
+import { PageContainer } from "~/components/layout/PageContainer";
+import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import { Button } from "~/components/ui/button";
+import { Card } from "~/components/ui/card";
+import { Heading } from "~/components/ui/heading";
+import { Icon } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
+import { cn } from "~/lib/utils";
+
+interface ConsolidatedRecipients {
+  list: { address: string; ownership: number }[];
+  totalOwnership: number;
+}
+
+const consolidateRecipients = (
+  split: Split | undefined,
+): ConsolidatedRecipients => {
+  if (!split) return { list: [], totalOwnership: 0 };
+  const totals = new Map<string, number>();
+  let total = 0;
+  for (const r of split.recipients) {
+    const addr = r.recipient.address.toLowerCase();
+    const value = Number(r.ownership);
+    totals.set(addr, (totals.get(addr) ?? 0) + value);
+    total += value;
+  }
+  return {
+    list: Array.from(totals.entries())
+      .map(([address, ownership]) => ({ address, ownership }))
+      .sort((a, b) => b.ownership - a.ownership),
+    totalOwnership: total,
+  };
+};
+
+interface WeightInfo {
+  roleWeight: number;
+  thanksTokenWeight: number;
+  thanksTokenReceivedWeight: number;
+  thanksTokenSentWeight: number;
+}
+
+// The Toban subgraph doesn't index split creation weights — they exist only as
+// `create()` calldata. We recover them by finding the `SplitsCreated` log that
+// matches this split's address (around `createdBlock`) and decoding the
+// originating transaction's input. We hit the Alchemy-only client directly
+// because the fallback `publicClient` rotates through a bare `http()` default
+// RPC first and that endpoint is unreliable for `getLogs` — every flake there
+// surfaced as "ルール情報を取得できませんでした" on the screen. Cached
+// indefinitely by split address since weights are immutable post-creation.
+const useSplitWeights = (
+  splitsCreatorAddress: Address | undefined,
+  split: Split | undefined,
+) => {
+  return useQuery({
+    queryKey: ["split-weights", splitsCreatorAddress, split?.address],
+    enabled: !!splitsCreatorAddress && !!split,
+    staleTime: Number.POSITIVE_INFINITY,
+    retry: 3,
+    retryDelay: (attempt) => Math.min(2000, 300 * 2 ** attempt),
+    queryFn: async (): Promise<WeightInfo | null> => {
+      if (!splitsCreatorAddress || !split) return null;
+      const splitAddrLower = split.address.toLowerCase();
+      const created = BigInt(split.createdBlock);
+      const logs = await alchemyPublicClient.getContractEvents({
+        address: splitsCreatorAddress,
+        abi: SPLITS_CREATOR_ABI,
+        eventName: "SplitsCreated",
+        fromBlock: created,
+        toBlock: created,
+      });
+      const log = logs.find(
+        (l) => l.args.split?.toLowerCase() === splitAddrLower,
+      );
+      if (!log) return null;
+      const tx = await alchemyPublicClient.getTransaction({
+        hash: log.transactionHash,
+      });
+      const decoded = decodeFunctionData({
+        abi: SPLITS_CREATOR_ABI,
+        data: tx.input,
+      });
+      if (decoded.functionName !== "create") return null;
+      const weights = decoded.args?.[1] as
+        | {
+            roleWeight: bigint;
+            thanksTokenWeight: bigint;
+            thanksTokenReceivedWeight: bigint;
+            thanksTokenSentWeight: bigint;
+          }
+        | undefined;
+      if (!weights) return null;
+      return {
+        roleWeight: Number(weights.roleWeight),
+        thanksTokenWeight: Number(weights.thanksTokenWeight),
+        thanksTokenReceivedWeight: Number(weights.thanksTokenReceivedWeight),
+        thanksTokenSentWeight: Number(weights.thanksTokenSentWeight),
+      };
+    },
+  });
+};
+
+const SplitDetailPage: FC = () => {
+  const { treeId, splitId } = useParams();
+  const navigate = useNavigate();
+
+  const { data: workspaceData } = useGetWorkspace({
+    workspaceId: treeId || "",
+  });
+  const splitsCreatorAddress = workspaceData?.workspace?.splitCreator as
+    | Address
+    | undefined;
+
+  const { splits, isLoading } =
+    useSplitsCreatorRelatedSplits(splitsCreatorAddress);
+  const split = useMemo(() => {
+    if (!splitId) return undefined;
+    return splits.find(
+      (s) => s.address.toLowerCase() === splitId.toLowerCase(),
+    );
+  }, [splits, splitId]);
+
+  const recipients = useMemo(() => consolidateRecipients(split), [split]);
+
+  // Resolve names for split + recipients in a single Namestone batch.
+  const splitAddrArray = useMemo(() => (split ? [split.address] : []), [split]);
+  const recipientAddresses = useMemo(
+    () => recipients.list.map((r) => r.address),
+    [recipients],
+  );
+  const { names: splitNames } = useNamesByAddresses(splitAddrArray);
+  const { names: recipientNames } = useNamesByAddresses(recipientAddresses);
+
+  const splitEnsEntry = splitNames[0]?.[0];
+  const displayName = splitEnsEntry?.name
+    ? `${splitEnsEntry.name}.${splitEnsEntry.domain}`
+    : split
+      ? abbreviateAddress(split.address)
+      : "";
+  const ensFullName = splitEnsEntry?.name
+    ? `${splitEnsEntry.name}.${splitEnsEntry.domain}`
+    : undefined;
+
+  const recipientNameByAddress = useMemo(() => {
+    const m = new Map<string, NameData>();
+    for (const group of recipientNames) {
+      const entry = group[0];
+      if (entry?.address) m.set(entry.address.toLowerCase(), entry);
+    }
+    return m;
+  }, [recipientNames]);
+
+  const createdAtSec = useQuery({
+    queryKey: ["split-block", split?.createdBlock],
+    enabled: !!split,
+    staleTime: Number.POSITIVE_INFINITY,
+    queryFn: async () => {
+      if (!split) return undefined;
+      const block = await publicClient.getBlock({
+        blockNumber: BigInt(split.createdBlock),
+      });
+      return Number(block.timestamp);
+    },
+  });
+  const createdAt = createdAtSec.data
+    ? dayjs(createdAtSec.data * 1000).format("YYYY/MM/DD")
+    : undefined;
+
+  const weightsQuery = useSplitWeights(splitsCreatorAddress, split);
+  const weights = weightsQuery.data;
+
+  // SplitDetail (legacy) handles claimable balances + external splits.org
+  // links. We surface the latter directly here too.
+  const splitEarnings = useSplit(split?.address as Address | undefined);
+
+  const slices = useMemo<DonutSlice[]>(
+    () =>
+      recipients.list.map((r) => ({
+        key: r.address,
+        percent:
+          recipients.totalOwnership > 0
+            ? (r.ownership / recipients.totalOwnership) * 100
+            : 0,
+      })),
+    [recipients],
+  );
+
+  const ranking = useMemo(() => {
+    if (recipients.totalOwnership === 0) return [];
+    return recipients.list.map((r, i) => {
+      const pct = (r.ownership / recipients.totalOwnership) * 100;
+      const entry = recipientNameByAddress.get(r.address.toLowerCase());
+      const name = entry?.name ?? abbreviateAddress(r.address as `0x${string}`);
+      const avatarUrl = ipfs2https(entry?.text_records?.avatar);
+      const color = DONUT_PALETTE[i % DONUT_PALETTE.length];
+      return {
+        address: r.address,
+        name,
+        avatarUrl,
+        pct,
+        color,
+      };
+    });
+  }, [recipients, recipientNameByAddress]);
+
+  const goBack = () => navigate(`/${treeId}/splits`);
+
+  if (!split && !isLoading) {
+    return (
+      <PageContainer className="pt-4 pb-8">
+        <Breadcrumb
+          className="mb-3 px-1"
+          items={[
+            { label: "分配", to: `/${treeId}/splits` },
+            { label: "分配詳細" },
+          ]}
+        />
+        <Card className="py-12 text-center">
+          <Typography variant="bodySm" tone="secondary">
+            分配ルールが見つかりませんでした
+          </Typography>
+          <div className="mt-4 flex justify-center">
+            <Button variant="secondary" onClick={goBack}>
+              一覧へ戻る
+            </Button>
+          </div>
+        </Card>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer className="pt-2 pb-10 md:pt-4">
+      <Breadcrumb
+        className="mb-3 px-1"
+        items={[
+          { label: "分配", to: `/${treeId}/splits` },
+          { label: displayName || "分配詳細" },
+        ]}
+      />
+
+      {/* Mobile / single column. */}
+      <div className="flex flex-col gap-4 px-1 md:hidden">
+        <header className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-1.5">
+            <Heading variant="h3" level={1} className="min-w-0 truncate">
+              {displayName || "分配詳細"}
+            </Heading>
+            {ensFullName && (
+              <CopyIconButton label="ENS名" value={ensFullName} />
+            )}
+          </div>
+          {split?.address && <AddressRow address={split.address} />}
+          <Typography variant="caption" tone="secondary">
+            {createdAt && `作成日: ${createdAt}`}
+            {createdAt && " ・ "}
+            対象 {recipients.list.length}人
+          </Typography>
+        </header>
+
+        <div className="grid grid-cols-2 gap-3">
+          <DonutSummaryCard
+            slices={slices}
+            recipientCount={recipients.list.length}
+          />
+          <RuleCard weights={weights} loading={weightsQuery.isLoading} />
+        </div>
+
+        <section className="flex flex-col gap-2">
+          <SectionLabel className="px-0">分配結果</SectionLabel>
+          <Card className="gap-0 p-0">
+            {ranking.length === 0 ? (
+              <Typography
+                variant="bodySm"
+                tone="secondary"
+                className="px-4 py-6 text-center"
+              >
+                分配先がありません
+              </Typography>
+            ) : (
+              ranking.map((row, i) => (
+                <div key={row.address}>
+                  <RankRow row={row} rank={i + 1} />
+                  {i < ranking.length - 1 && <Divider inset={16} />}
+                </div>
+              ))
+            )}
+          </Card>
+        </section>
+
+        <ClaimableBalancesCard
+          balances={splitEarnings.splitEarnings.data?.activeBalances}
+          isDistributing={splitEarnings.isDistributing}
+          onDistribute={(tokenAddress) =>
+            splitEarnings.distribute(tokenAddress as Address)
+          }
+        />
+
+        <div className="pt-2">
+          <Button asChild variant="secondary" full>
+            <a
+              href={`https://app.splits.org/accounts/${split?.address}/?chainId=${currentChain.id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Splits.org で開く
+            </a>
+          </Button>
+        </div>
+      </div>
+
+      {/* Desktop layout — 2/3 main + 1/3 side. */}
+      <div className="hidden grid-cols-[2fr_1fr] gap-6 pt-2 md:grid">
+        <div className="flex min-w-0 flex-col gap-5">
+          <header className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <Heading variant="h2" level={1} className="min-w-0 truncate">
+                {displayName || "分配詳細"}
+              </Heading>
+              {ensFullName && (
+                <CopyIconButton label="ENS名" value={ensFullName} />
+              )}
+            </div>
+            {split?.address && <AddressRow address={split.address} />}
+            <Typography variant="bodySm" tone="secondary">
+              合計 100% ・ 対象 {recipients.list.length}人
+              {createdAt && ` ・ 作成日 ${createdAt}`}
+            </Typography>
+          </header>
+
+          <div className="grid grid-cols-2 gap-4 items-stretch">
+            <DonutSummaryCard
+              slices={slices}
+              recipientCount={recipients.list.length}
+            />
+            <RuleCard weights={weights} loading={weightsQuery.isLoading} />
+          </div>
+
+          <section className="flex flex-col gap-2">
+            <SectionLabel className="px-0">分配結果</SectionLabel>
+            <Card className="gap-0 p-0">
+              {ranking.length === 0 ? (
+                <Typography
+                  variant="bodySm"
+                  tone="secondary"
+                  className="px-4 py-6 text-center"
+                >
+                  分配先がありません
+                </Typography>
+              ) : (
+                ranking.map((row, i) => (
+                  <div key={row.address}>
+                    <RankRow row={row} rank={i + 1} />
+                    {i < ranking.length - 1 && <Divider inset={16} />}
+                  </div>
+                ))
+              )}
+            </Card>
+          </section>
+        </div>
+
+        <aside className="flex flex-col gap-4">
+          <ClaimableBalancesCard
+            balances={splitEarnings.splitEarnings.data?.activeBalances}
+            isDistributing={splitEarnings.isDistributing}
+            onDistribute={(tokenAddress) =>
+              splitEarnings.distribute(tokenAddress as Address)
+            }
+          />
+          <Button asChild variant="secondary">
+            <a
+              href={`https://app.splits.org/accounts/${split?.address}/?chainId=${currentChain.id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Splits.org で開く
+            </a>
+          </Button>
+        </aside>
+      </div>
+    </PageContainer>
+  );
+};
+
+export default SplitDetailPage;
+
+// ─── DonutSummaryCard ──────────────────────────────────────────────────────
+
+interface DonutSummaryCardProps {
+  slices: DonutSlice[];
+  recipientCount: number;
+}
+
+const DonutSummaryCard: FC<DonutSummaryCardProps> = ({
+  slices,
+  recipientCount,
+}) => (
+  <Card className="h-full items-center justify-center px-5 py-5">
+    <DonutChart
+      slices={slices}
+      size={140}
+      center={
+        <>
+          <span className="text-[28px] font-extrabold leading-none tabular-nums">
+            {recipientCount}
+          </span>
+          <span className="mt-0.5 text-[11px] font-bold text-text-secondary">
+            人
+          </span>
+        </>
+      }
+    />
+  </Card>
+);
+
+// ─── RankRow ───────────────────────────────────────────────────────────────
+
+interface RankRowProps {
+  row: {
+    address: string;
+    name: string;
+    avatarUrl?: string;
+    pct: number;
+    color: string;
+  };
+  rank: number;
+}
+
+// Bar width is the recipient's percentage of the whole (0-100). Earlier this
+// was scaled to the top recipient so the leader always showed a full bar; the
+// design wants an absolute scale so reading "30%" matches a bar a third full.
+const RankRow: FC<RankRowProps> = ({ row, rank }) => (
+  <div className="flex items-center gap-3 px-4 py-3">
+    <Typography
+      as="span"
+      variant="caption"
+      weight="bold"
+      tone="secondary"
+      className="w-6 shrink-0"
+    >
+      {rank}
+    </Typography>
+    <Avatar size="default" className="size-8">
+      {row.avatarUrl && <AvatarImage src={row.avatarUrl} alt="" />}
+      <AvatarFallback seed={row.name} />
+    </Avatar>
+    <Typography
+      as="div"
+      variant="bodySm"
+      weight="semibold"
+      truncate
+      className="min-w-0 flex-1"
+    >
+      {row.name}
+    </Typography>
+    <div className="hidden h-1.5 w-20 overflow-hidden rounded-xs bg-[#F0EBE0] sm:block">
+      <div
+        className="h-full"
+        style={{
+          width: `${Math.max(0, Math.min(100, row.pct))}%`,
+          backgroundColor: row.color,
+        }}
+      />
+    </div>
+    <Typography
+      as="span"
+      variant="bodySm"
+      weight="bold"
+      className="w-14 shrink-0 text-right tabular-nums"
+    >
+      {row.pct.toFixed(2)}%
+    </Typography>
+  </div>
+);
+
+// ─── RuleCard ──────────────────────────────────────────────────────────────
+
+interface RuleCardProps {
+  weights?: WeightInfo | null;
+  loading: boolean;
+}
+
+const RuleCard: FC<RuleCardProps> = ({ weights, loading }) => {
+  if (loading) {
+    return (
+      <Card className="px-4 py-6 text-center">
+        <Typography variant="bodySm" tone="secondary">
+          ルールを読み込み中…
+        </Typography>
+      </Card>
+    );
+  }
+  if (!weights) {
+    return (
+      <Card className="px-4 py-6 text-center">
+        <Typography variant="bodySm" tone="secondary">
+          ルール情報を取得できませんでした
+        </Typography>
+      </Card>
+    );
+  }
+
+  const total = weights.roleWeight + weights.thanksTokenWeight;
+  const dutyPct =
+    total > 0 ? Math.round((weights.roleWeight / total) * 100) : 0;
+  const thanksPct =
+    total > 0 ? Math.round((weights.thanksTokenWeight / total) * 100) : 0;
+  const recvTotal =
+    weights.thanksTokenReceivedWeight + weights.thanksTokenSentWeight;
+  const recvPct =
+    recvTotal > 0
+      ? Math.round((weights.thanksTokenReceivedWeight / recvTotal) * 100)
+      : 0;
+  const sentPct =
+    recvTotal > 0
+      ? Math.round((weights.thanksTokenSentWeight / recvTotal) * 100)
+      : 0;
+
+  return (
+    <Card className="gap-4 px-4 py-4">
+      <WeightBar label="当番ベース" pct={dutyPct} color="var(--color-role)" />
+      <WeightBar
+        label="サンクスベース"
+        pct={thanksPct}
+        color="var(--color-contrib)"
+      />
+      <Divider />
+      <div>
+        <Typography
+          as="div"
+          variant="caption"
+          tone="secondary"
+          weight="semibold"
+          className="mb-2"
+        >
+          サンクス内の重み
+        </Typography>
+        <div className="flex gap-2.5">
+          <RuleStat
+            label="受け取り"
+            value={recvPct}
+            color="var(--color-contrib)"
+          />
+          <RuleStat label="送付" value={sentPct} color="var(--color-primary)" />
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+const RuleStat: FC<{ label: string; value: number; color: string }> = ({
+  label,
+  value,
+  color,
+}) => (
+  <div className="flex flex-1 flex-col items-center gap-1 rounded-sm bg-bg px-3 py-3 text-center">
+    <Typography variant="micro" tone="secondary" as="span">
+      {label}
+    </Typography>
+    <Typography
+      as="span"
+      variant="statMd"
+      className="tabular-nums"
+      style={{ color }}
+    >
+      {value}%
+    </Typography>
+  </div>
+);
+
+// ─── AddressRow / CopyIconButton ───────────────────────────────────────────
+//
+// `AddressRow` shows the full contract address as a single tappable mono-text
+// row that copies the address. The ENS sits next to the title as an icon-only
+// button (`CopyIconButton`) so it doesn't fight the address line for space.
+// Together they replace the old foldable "技術情報" card — the chain identity
+// is now always visible.
+
+interface AddressRowProps {
+  address: string;
+}
+
+const AddressRow: FC<AddressRowProps> = ({ address }) => {
+  const { copyToClipboardAction } = useCopyToClipboard(address);
+  const onCopy = () => {
+    copyToClipboardAction().then(
+      () => toast.success("アドレスをコピーしました"),
+      () => toast.error("コピーに失敗しました"),
+    );
+  };
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      className="group inline-flex max-w-full items-center gap-1.5 rounded-sm text-text-secondary transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+      aria-label="アドレスをコピー"
+    >
+      <Typography
+        as="span"
+        variant="micro"
+        truncate
+        className="min-w-0 font-mono"
+      >
+        {address}
+      </Typography>
+      <Icon
+        name="copy"
+        size={12}
+        className="shrink-0 opacity-70 transition-opacity group-hover:opacity-100"
+      />
+    </button>
+  );
+};
+
+interface CopyIconButtonProps {
+  /** Used in the aria label + success toast (e.g. "ENS名"). */
+  label: string;
+  value: string;
+  /** Optional click handler to stop propagation when nested in a clickable parent. */
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+const CopyIconButton: FC<CopyIconButtonProps> = ({ label, value, onClick }) => {
+  const { copyToClipboardAction } = useCopyToClipboard(value);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    copyToClipboardAction().then(
+      () => toast.success(`${label}をコピーしました`),
+      () => toast.error("コピーに失敗しました"),
+    );
+  };
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label={`${label}をコピー`}
+      className="inline-flex size-7 shrink-0 items-center justify-center rounded-full text-text-secondary transition-colors hover:bg-bg hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+    >
+      <Icon name="copy" size={14} />
+    </button>
+  );
+};
+
+// ─── ClaimableBalancesCard ─────────────────────────────────────────────────
+
+interface ClaimableBalancesCardProps {
+  balances?: Record<
+    string,
+    { formattedAmount: string; symbol: string } | undefined
+  >;
+  isDistributing: boolean;
+  onDistribute: (tokenAddress: string) => void;
+}
+
+// Splits SDK's `formattedAmount` is already a precise decimal string
+// (`viem.formatUnits`). The earlier code did `Number(...).toFixed(4)` which
+// silently lost precision for large balances and *rounded* — drifting from
+// splits.org. We keep the string intact and truncate (never round) the
+// fractional tail to `maxDecimals` places so the displayed value matches
+// what splits.org shows.
+const formatTokenAmount = (formatted: string, maxDecimals = 4): string => {
+  if (!formatted.includes(".")) return formatted;
+  const [whole, fracRaw = ""] = formatted.split(".");
+  if (maxDecimals <= 0) return whole;
+  const capped = fracRaw.slice(0, maxDecimals);
+  return capped ? `${whole}.${capped}` : whole;
+};
+
+const ClaimableBalancesCard: FC<ClaimableBalancesCardProps> = ({
+  balances,
+  isDistributing,
+  onDistribute,
+}) => {
+  const rows = useMemo(() => {
+    if (!balances) return [];
+    return Object.entries(balances).filter(
+      ([, b]) => b && Number(b.formattedAmount) > 0,
+    ) as [string, { formattedAmount: string; symbol: string }][];
+  }, [balances]);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <Card className="gap-3 border-primary/30 bg-primary-soft/40 px-4 py-4">
+      <Typography as="div" variant="bodySm" weight="bold">
+        未分配のポイント
+      </Typography>
+      <ul className="flex flex-col gap-2">
+        {rows.map(([tokenAddress, b]) => (
+          <li
+            key={tokenAddress}
+            className="flex items-center justify-between gap-2"
+          >
+            <Typography as="span" variant="bodySm" className="tabular-nums">
+              {formatTokenAmount(b.formattedAmount)} {b.symbol}
+            </Typography>
+            <Button
+              size="sm"
+              variant="primary"
+              disabled={isDistributing}
+              onClick={() => onDistribute(tokenAddress)}
+            >
+              分配する
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+};

--- a/pkgs/frontend/app/routes/$treeId_.splits._index.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.splits._index.tsx
@@ -1,272 +1,740 @@
 import type { Split } from "@0xsplits/splits-sdk";
+import { useQueries } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import { useCopyToClipboard } from "hooks/useCopyToClipboard";
 import { useNamesByAddresses } from "hooks/useENS";
 import {
-  useSplit,
   useSplitsCreatorRelatedSplits,
   useUserEarnings,
 } from "hooks/useSplitsCreator";
 import { publicClient } from "hooks/useViem";
 import { useGetWorkspace } from "hooks/useWorkspace";
 import type { NameData } from "namestone-sdk";
-import {
-  type FC,
-  type MouseEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
-import { FaAngleDown, FaRegCopy } from "react-icons/fa6";
-import { Link, useParams } from "react-router";
+import { type FC, useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router";
+import { toast } from "sonner";
 import { abbreviateAddress } from "utils/wallet";
 import type { Address } from "viem";
-import { StickyNav } from "~/components/StickyNav";
 import {
-  Box,
-  Collapsible,
-  Flex,
-  HStack,
-  Heading,
-  List,
-  Text,
-  VStack,
-} from "~/components/chakra-shim";
-import { CommonButton } from "~/components/common/CommonButton";
-import { SplitDetail } from "~/components/splits/SplitDetail";
-import { SplitRecipientsList } from "~/components/splits/SplitRecipientsList";
+  DONUT_PALETTE,
+  DonutChart,
+  type DonutSlice,
+} from "~/components/composite/donut-chart";
+import { EmptyState } from "~/components/composite/empty-state";
+import { SectionLabel } from "~/components/composite/section-label";
+import { MasterDetailLayout } from "~/components/layout/MasterDetailLayout";
+import { PageContainer } from "~/components/layout/PageContainer";
+import { Button } from "~/components/ui/button";
+import { Card } from "~/components/ui/card";
+import { Heading } from "~/components/ui/heading";
+import { Icon } from "~/components/ui/icon";
+import { Typography } from "~/components/ui/typography";
+import { cn } from "~/lib/utils";
 
-interface SplitInfoItemProps {
-  split: Split;
-  name?: NameData;
+interface ConsolidatedRecipients {
+  list: { address: string; ownership: number }[];
+  totalOwnership: number;
 }
 
-const SplitInfoItem: FC<SplitInfoItemProps> = ({ split, name }) => {
-  const [createdTime, setCreatedTime] = useState<string>();
-
-  const consolidatedRecipients = useMemo(() => {
-    let totalOwnership = 0;
-    const consolidated = split.recipients.reduce(
-      (acc, recipient) => {
-        const address = recipient.recipient.address;
-        acc[address] = (acc[address] || 0) + Number(recipient.ownership);
-        totalOwnership += Number(recipient.ownership);
-        return acc;
-      },
-      {} as Record<string, number>,
-    );
-
-    return {
-      list: Object.entries(consolidated).map(([address, ownership]) => ({
-        address,
-        ownership,
-      })),
-      totalOwnership,
-    };
-  }, [split.recipients]);
-
-  const [open, setOpen] = useState(false);
-  const onOpen = useCallback(() => {
-    setOpen(true);
-  }, []);
-
-  const { copyToClipboardAction } = useCopyToClipboard(split.address);
-
-  const onClickCopyButton = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => {
-      event.preventDefault();
-      copyToClipboardAction();
-    },
-    [copyToClipboardAction],
-  );
-
-  useEffect(() => {
-    const fetch = async () => {
-      const data = await publicClient.getBlock({
-        blockNumber: BigInt(split.createdBlock),
-      });
-
-      setCreatedTime(
-        dayjs(Number(data.timestamp) * 1000).format("YYYY/MM/DD HH:mm:ss"),
-      );
-    };
-    fetch();
-  }, [split]);
-
-  const { splitEarnings, distribute, isDistributing } = useSplit(split.address);
-
-  return (
-    <Box
-      w="100%"
-      px={4}
-      py={4}
-      borderRadius={8}
-      border="1px solid #333"
-      bg="white"
-    >
-      <Collapsible.Root disabled={open} onOpenChange={onOpen}>
-        <Collapsible.Trigger w="full" textAlign={"start"} cursor="pointer">
-          <Flex alignItems="center" justifyContent="space-between">
-            <Text textStyle="md">
-              {name?.name
-                ? `${name.name}.${name.domain}`
-                : abbreviateAddress(split.address)}
-            </Text>
-            <SplitDetail
-              splitAddress={split.address}
-              splitEarnings={splitEarnings.data}
-              distribute={distribute}
-              isDistributing={isDistributing}
-            />
-          </Flex>
-          <Text textStyle="sm">Created at {createdTime}</Text>
-          <Flex mt={4} placeItems="center">
-            <Text textStyle="sm" flexGrow={1} wordBreak="break-all">
-              {split.address}
-            </Text>
-            <CommonButton
-              color="#333"
-              background="transparent"
-              w="auto"
-              h="auto"
-              p="4px"
-              minW="unset"
-              onClick={onClickCopyButton}
-            >
-              <FaRegCopy
-                style={{ width: "16px", height: "16px", objectFit: "cover" }}
-              />
-            </CommonButton>
-          </Flex>
-
-          {open || (
-            <CommonButton
-              color="#333"
-              background="transparent"
-              w="full"
-              h="auto"
-            >
-              <FaAngleDown
-                style={{ width: "16px", height: "16px", objectFit: "cover" }}
-              />
-            </CommonButton>
-          )}
-        </Collapsible.Trigger>
-        <Collapsible.Content>
-          <Box
-            mx={2}
-            my={4}
-            borderTop="1px solid #868e96"
-            role="presentation"
-          />
-          <SplitRecipientsList recipients={consolidatedRecipients} />
-        </Collapsible.Content>
-      </Collapsible.Root>
-    </Box>
-  );
+const consolidateRecipients = (
+  split: Split | undefined,
+): ConsolidatedRecipients => {
+  if (!split) return { list: [], totalOwnership: 0 };
+  const totals = new Map<string, number>();
+  let total = 0;
+  for (const r of split.recipients) {
+    const addr = r.recipient.address.toLowerCase();
+    const value = Number(r.ownership);
+    totals.set(addr, (totals.get(addr) ?? 0) + value);
+    total += value;
+  }
+  return {
+    list: Array.from(totals.entries())
+      .map(([address, ownership]) => ({ address, ownership }))
+      .sort((a, b) => b.ownership - a.ownership),
+    totalOwnership: total,
+  };
 };
+
+const toSlices = (recipients: ConsolidatedRecipients): DonutSlice[] =>
+  recipients.list.map((r) => ({
+    key: r.address,
+    percent:
+      recipients.totalOwnership > 0
+        ? (r.ownership / recipients.totalOwnership) * 100
+        : 0,
+  }));
 
 const SplitsIndex: FC = () => {
   const { treeId } = useParams();
+  const navigate = useNavigate();
 
   const { data } = useGetWorkspace({ workspaceId: treeId || "" });
-
-  const splitCreatorAddress = useMemo(() => {
-    return data?.workspace?.splitCreator as Address;
-  }, [data]);
+  const splitCreatorAddress = data?.workspace?.splitCreator as
+    | Address
+    | undefined;
 
   const { splits, isLoading } =
     useSplitsCreatorRelatedSplits(splitCreatorAddress);
 
-  const splitsAddress = useMemo(() => {
-    return splits.map((split) => split.address);
-  }, [splits]);
-  const { names } = useNamesByAddresses(splitsAddress);
+  // Newest first — matches the legacy ordering and the design's "最終更新"
+  // expectation.
+  const sortedSplits = useMemo(
+    () =>
+      splits
+        .slice()
+        .sort((a, b) => Number(b.createdBlock) - Number(a.createdBlock)),
+    [splits],
+  );
 
-  const { userEarnings, withdraw, isWithdrawing } = useUserEarnings();
-  const activeBalances = useMemo(() => {
-    if (!userEarnings.data) return [];
-    return Object.entries(userEarnings.data?.activeBalances || {}).map(
-      ([address, balance]) => {
-        return { address, balance };
+  // Resolve ENS-style names for each split's controller address — used as the
+  // split name when present, abbreviated address otherwise.
+  const splitsAddresses = useMemo(
+    () => sortedSplits.map((s) => s.address),
+    [sortedSplits],
+  );
+  const { names } = useNamesByAddresses(splitsAddresses);
+  const nameByAddress = useMemo(() => {
+    const m = new Map<string, NameData>();
+    for (const group of names) {
+      const entry = group[0];
+      if (entry?.address) m.set(entry.address.toLowerCase(), entry);
+    }
+    return m;
+  }, [names]);
+
+  // Lookup the recipient ENS names so chips render with display names.
+  const recipientAddresses = useMemo(() => {
+    const set = new Set<string>();
+    for (const s of sortedSplits) {
+      for (const r of s.recipients) set.add(r.recipient.address.toLowerCase());
+    }
+    return Array.from(set);
+  }, [sortedSplits]);
+  const { names: recipientNames } = useNamesByAddresses(recipientAddresses);
+  const recipientNameByAddress = useMemo(() => {
+    const m = new Map<string, NameData>();
+    for (const group of recipientNames) {
+      const entry = group[0];
+      if (entry?.address) m.set(entry.address.toLowerCase(), entry);
+    }
+    return m;
+  }, [recipientNames]);
+
+  // Fetch the createdBlock timestamps in parallel. publicClient.getBlock is
+  // cached at the RPC level; React Query layers a stale-time on top so the
+  // user-facing list doesn't refetch between navigations.
+  const blockQueries = useQueries({
+    queries: sortedSplits.map((s) => ({
+      queryKey: ["split-block", s.createdBlock],
+      queryFn: async () => {
+        const block = await publicClient.getBlock({
+          blockNumber: BigInt(s.createdBlock),
+        });
+        return Number(block.timestamp);
       },
-    );
-  }, [userEarnings]);
+      staleTime: Number.POSITIVE_INFINITY,
+    })),
+  });
+
+  const items = useMemo(() => {
+    return sortedSplits.map((split, i) => {
+      const recipients = consolidateRecipients(split);
+      const created = blockQueries[i]?.data;
+      const ensEntry = nameByAddress.get(split.address.toLowerCase());
+      const ensFullName = ensEntry?.name
+        ? `${ensEntry.name}.${ensEntry.domain}`
+        : undefined;
+      const displayName = ensFullName ?? abbreviateAddress(split.address);
+      return {
+        split,
+        recipients,
+        displayName,
+        ensFullName,
+        recipientCount: recipients.list.length,
+        createdAt: created
+          ? dayjs(created * 1000).format("YYYY/MM/DD")
+          : undefined,
+      };
+    });
+  }, [sortedSplits, blockQueries, nameByAddress]);
+
+  const userEarnings = useUserEarnings();
+  const activeBalances = useMemo(() => {
+    const balances = userEarnings.userEarnings.data?.activeBalances;
+    if (!balances) return [];
+    return Object.entries(balances).map(([address, balance]) => ({
+      address,
+      balance,
+    }));
+  }, [userEarnings.userEarnings.data]);
+
+  const [selectedAddress, setSelectedAddress] = useState<string | undefined>();
+  const selectedItem = useMemo(() => {
+    if (selectedAddress) {
+      const hit = items.find(
+        (i) => i.split.address.toLowerCase() === selectedAddress.toLowerCase(),
+      );
+      if (hit) return hit;
+    }
+    return items[0];
+  }, [items, selectedAddress]);
+
+  const goToDetail = (addr: string) => navigate(`/${treeId}/splits/${addr}`);
 
   return (
     <>
-      <Box w="100%">
-        <Flex mb={4} placeItems="center">
-          <Heading flexGrow={1} pb={4}>
-            Splits
-          </Heading>
-          <Link to={`/${treeId}/splits/new`}>
-            <CommonButton w={"auto"} size="sm">
-              Create New
-            </CommonButton>
-          </Link>
-        </Flex>
+      {/* Mobile / tablet layout. */}
+      <PageContainer className="md:hidden pt-2 pb-10">
+        <header className="mb-4 flex items-end justify-between gap-3 px-1">
+          <div className="min-w-0">
+            <Heading variant="h2" level={1}>
+              分配
+            </Heading>
+            <Typography variant="bodySm" tone="secondary" className="mt-0.5">
+              貢献記録から、納得できる分配へ
+            </Typography>
+          </div>
+          <Button asChild size="sm" variant="primary" className="shrink-0">
+            <Link to={`/${treeId}/splits/new`}>
+              <Icon name="plus" size={16} />
+              新規作成
+            </Link>
+          </Button>
+        </header>
 
         {activeBalances.length > 0 && (
-          <Box p={3} bg="red.100" borderRadius={8} mb={4}>
-            <Heading fontSize="md">未回収の報酬があります</Heading>
-
-            <List.Root listStyle="none">
-              {activeBalances.map((balance) => {
-                return (
-                  <List.Item key={balance.address} mb={2}>
-                    <HStack justifyContent="space-between">
-                      <Text fontSize="md">
-                        {Number(balance.balance.formattedAmount).toFixed(4)}...{" "}
-                        {balance.balance.symbol}
-                      </Text>
-                      <CommonButton
-                        size="xs"
-                        w="100"
-                        onClick={() => {
-                          withdraw(balance.address as Address);
-                        }}
-                        loading={isWithdrawing}
-                      >
-                        引き出す
-                      </CommonButton>
-                    </HStack>
-                  </List.Item>
-                );
-              })}
-            </List.Root>
-          </Box>
+          <UnclaimedRewardsCard
+            balances={activeBalances}
+            onWithdraw={(addr) => userEarnings.withdraw(addr as Address)}
+            isWithdrawing={userEarnings.isWithdrawing}
+            className="mx-1 mb-4"
+          />
         )}
 
-        {isLoading ? (
-          <></>
+        <SectionLabel className="px-1">分配ルール</SectionLabel>
+
+        {isLoading && items.length === 0 ? (
+          <Card className="mx-1 py-8 text-center">
+            <Typography variant="bodySm" tone="secondary">
+              読み込み中…
+            </Typography>
+          </Card>
+        ) : items.length === 0 ? (
+          <Card className="mx-1">
+            <EmptyState
+              icon={<Icon name="pie" size={26} />}
+              title="まだ分配ルールはありません"
+              body="貢献に応じた分配ルールを作成してみましょう。"
+              action={
+                <Button asChild variant="primary">
+                  <Link to={`/${treeId}/splits/new`}>
+                    <Icon name="plus" size={16} />
+                    分配ルールを作成
+                  </Link>
+                </Button>
+              }
+            />
+          </Card>
         ) : (
-          <VStack gap={3} mb={10}>
-            {splits
-              .slice()
-              .sort((a, b) => Number(b.createdBlock) - Number(a.createdBlock))
-              .map((split) => (
-                <SplitInfoItem
-                  key={split.address}
-                  split={split}
-                  name={
-                    names.find((name) =>
-                      name.some(
-                        (n) =>
-                          n.address.toLowerCase() ===
-                          split.address.toLowerCase(),
-                      ),
-                    )?.[0]
-                  }
-                />
-              ))}
-          </VStack>
+          <div className="flex flex-col gap-3 px-1">
+            {items.map((item) => (
+              <SplitListCard
+                key={item.split.address}
+                item={item}
+                recipientNameByAddress={recipientNameByAddress}
+                onClick={() => goToDetail(item.split.address)}
+              />
+            ))}
+          </div>
         )}
-      </Box>
-      <StickyNav />
+      </PageContainer>
+
+      {/* Desktop master-detail. */}
+      <div className="hidden md:block">
+        <MasterDetailLayout
+          master={
+            <div className="flex flex-col gap-3 p-4">
+              <Button asChild variant="primary" full>
+                <Link to={`/${treeId}/splits/new`}>
+                  <Icon name="plus" size={16} />
+                  新規作成
+                </Link>
+              </Button>
+              {isLoading && items.length === 0 ? (
+                <Typography
+                  variant="bodySm"
+                  tone="secondary"
+                  className="px-2 py-4 text-center"
+                >
+                  読み込み中…
+                </Typography>
+              ) : items.length === 0 ? (
+                <Typography
+                  variant="bodySm"
+                  tone="secondary"
+                  className="px-2 py-4 text-center"
+                >
+                  分配ルールはまだありません
+                </Typography>
+              ) : (
+                <ul className="flex flex-col gap-1.5">
+                  {items.map((item) => (
+                    <li key={item.split.address}>
+                      <MasterRow
+                        item={item}
+                        selected={
+                          item.split.address.toLowerCase() ===
+                          selectedItem?.split.address.toLowerCase()
+                        }
+                        onClick={() => setSelectedAddress(item.split.address)}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          }
+          detail={
+            <div className="flex flex-col gap-5">
+              {activeBalances.length > 0 && (
+                <UnclaimedRewardsCard
+                  balances={activeBalances}
+                  onWithdraw={(addr) => userEarnings.withdraw(addr as Address)}
+                  isWithdrawing={userEarnings.isWithdrawing}
+                />
+              )}
+              {selectedItem ? (
+                <DesktopDetailPreview
+                  item={selectedItem}
+                  recipientNameByAddress={recipientNameByAddress}
+                  treeId={treeId ?? ""}
+                />
+              ) : (
+                <Card className="py-12 text-center">
+                  <Typography variant="bodySm" tone="secondary">
+                    分配ルールを選択してください
+                  </Typography>
+                </Card>
+              )}
+            </div>
+          }
+        />
+      </div>
     </>
   );
 };
 
 export default SplitsIndex;
+
+// ──────────────────────────── Sub-components ────────────────────────────
+
+interface SplitListItem {
+  split: Split;
+  recipients: ConsolidatedRecipients;
+  displayName: string;
+  ensFullName?: string;
+  recipientCount: number;
+  createdAt?: string;
+}
+
+const labelFor = (
+  address: string,
+  byAddress: Map<string, NameData>,
+): string => {
+  const entry = byAddress.get(address.toLowerCase());
+  return entry?.name ?? abbreviateAddress(address as `0x${string}`);
+};
+
+interface SplitListCardProps {
+  item: SplitListItem;
+  recipientNameByAddress: Map<string, NameData>;
+  onClick: () => void;
+}
+
+// The mobile card wraps itself in a clickable div (not a button) so the
+// in-card copy buttons can be real `<button>` elements — nesting buttons in
+// HTML is invalid. The outer div carries the role + keyboard handling so the
+// whole row still navigates on Enter/Space, matching the previous behaviour.
+const SplitListCard: FC<SplitListCardProps> = ({
+  item,
+  recipientNameByAddress,
+  onClick,
+}) => {
+  const topShares = useMemo(() => {
+    if (item.recipients.totalOwnership === 0) return [];
+    return item.recipients.list.slice(0, 3).map((r) => ({
+      address: r.address,
+      label: labelFor(r.address, recipientNameByAddress),
+      pct: (r.ownership / item.recipients.totalOwnership) * 100,
+    }));
+  }, [item.recipients, recipientNameByAddress]);
+  const extra = Math.max(0, item.recipients.list.length - topShares.length);
+  const slices = useMemo(() => toSlices(item.recipients), [item.recipients]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: a real <button> would forbid the nested copy buttons (invalid HTML); role=button + keyboard handler keeps it accessible.
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      aria-label={`${item.displayName} の分配詳細を開く`}
+      className="cursor-pointer rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+    >
+      <Card className="flex-row items-start gap-3.5 px-4 py-4 transition-colors hover:bg-bg">
+        <DonutChart slices={slices} size={72} className="mt-0.5" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <Typography
+              as="div"
+              variant="bodySm"
+              weight="bold"
+              truncate
+              className="min-w-0 text-[15px]"
+            >
+              {item.displayName}
+            </Typography>
+            {item.ensFullName && (
+              <CopyIconButton
+                label="ENS名"
+                value={item.ensFullName}
+                size="sm"
+              />
+            )}
+          </div>
+          <CopyableAddress address={item.split.address} />
+          <Typography
+            as="div"
+            variant="caption"
+            tone="secondary"
+            className="mt-1"
+          >
+            {item.recipientCount}人に分配
+            {item.createdAt && ` ・ 最終更新: ${item.createdAt}`}
+          </Typography>
+          {topShares.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {topShares.map((s) => (
+                <span
+                  key={s.address}
+                  className="rounded-full bg-[#F0EBE0] px-2 py-0.5 text-[11px] font-semibold text-text-primary"
+                >
+                  {s.label} {s.pct.toFixed(1)}%
+                </span>
+              ))}
+              {extra > 0 && (
+                <Typography
+                  as="span"
+                  variant="micro"
+                  tone="secondary"
+                  className="self-center"
+                >
+                  +{extra}
+                </Typography>
+              )}
+            </div>
+          )}
+        </div>
+        <Icon
+          name="chevron-right"
+          size={18}
+          className="mt-0.5 shrink-0 text-text-secondary"
+        />
+      </Card>
+    </div>
+  );
+};
+
+interface MasterRowProps {
+  item: SplitListItem;
+  selected: boolean;
+  onClick: () => void;
+}
+
+const MasterRow: FC<MasterRowProps> = ({ item, selected, onClick }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={cn(
+      "flex w-full items-center gap-3 rounded-md border border-transparent p-3 text-left transition-colors hover:bg-surface",
+      selected && "border-border bg-surface shadow-1",
+    )}
+  >
+    <div className="flex size-9 shrink-0 items-center justify-center rounded-sm bg-[#E5F1FB] text-[#5DADEC]">
+      <Icon name="split" size={18} />
+    </div>
+    <div className="min-w-0 flex-1">
+      <Typography as="div" variant="bodySm" weight="bold" truncate>
+        {item.displayName}
+      </Typography>
+      <Typography variant="micro" tone="secondary" as="div" truncate>
+        {item.recipientCount}人に分配
+        {item.createdAt && ` ・ ${item.createdAt}`}
+      </Typography>
+    </div>
+  </button>
+);
+
+interface DesktopDetailPreviewProps {
+  item: SplitListItem;
+  recipientNameByAddress: Map<string, NameData>;
+  treeId: string;
+}
+
+// Lightweight right-pane summary for the master-detail desktop view. The
+// dedicated `/splits/$splitId` route owns the full detail surface (#441),
+// so the preview links into that route for everything beyond the basics.
+const DesktopDetailPreview: FC<DesktopDetailPreviewProps> = ({
+  item,
+  recipientNameByAddress,
+  treeId,
+}) => {
+  const slices = useMemo(() => toSlices(item.recipients), [item.recipients]);
+  const previewRows = useMemo(() => {
+    if (item.recipients.totalOwnership === 0) return [];
+    return item.recipients.list.slice(0, 5).map((r) => ({
+      address: r.address,
+      label: labelFor(r.address, recipientNameByAddress),
+      pct: (r.ownership / item.recipients.totalOwnership) * 100,
+    }));
+  }, [item.recipients, recipientNameByAddress]);
+  const extra = Math.max(0, item.recipients.list.length - previewRows.length);
+
+  return (
+    <Card className="gap-5 px-6 py-5">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <Heading variant="h3" level={2} className="min-w-0 truncate">
+              {item.displayName}
+            </Heading>
+            {item.ensFullName && (
+              <CopyIconButton label="ENS名" value={item.ensFullName} />
+            )}
+          </div>
+          <CopyableAddress address={item.split.address} className="mt-1" />
+          <Typography variant="bodySm" tone="secondary" className="mt-1">
+            合計 100% ・ 対象 {item.recipientCount}人
+            {item.createdAt && ` ・ 作成日 ${item.createdAt}`}
+          </Typography>
+        </div>
+        <Button asChild variant="secondary" size="sm">
+          <Link to={`/${treeId}/splits/${item.split.address}`}>
+            詳細
+            <Icon name="chevron-right" size={14} />
+          </Link>
+        </Button>
+      </div>
+      <div className="flex flex-wrap items-center gap-6">
+        <DonutChart
+          slices={slices}
+          size={140}
+          center={
+            <>
+              <span className="text-[26px] font-extrabold leading-none">
+                {item.recipientCount}
+              </span>
+              <span className="mt-1 text-[10px] font-bold text-text-secondary">
+                人
+              </span>
+            </>
+          }
+        />
+        <ul className="flex min-w-[200px] flex-1 flex-col gap-1.5">
+          {previewRows.map((r, i) => (
+            <li key={r.address} className="flex items-center gap-2 text-[12px]">
+              <span
+                aria-hidden
+                className="size-2.5 shrink-0 rounded-full"
+                style={{
+                  backgroundColor: slicesPaletteColor(i, slices, r.address),
+                }}
+              />
+              <Typography
+                as="span"
+                variant="bodySm"
+                truncate
+                className="min-w-0 flex-1"
+              >
+                {r.label}
+              </Typography>
+              <Typography
+                as="span"
+                variant="bodySm"
+                weight="bold"
+                className="tabular-nums"
+              >
+                {r.pct.toFixed(1)}%
+              </Typography>
+            </li>
+          ))}
+          {extra > 0 && (
+            <li>
+              <Typography
+                as="span"
+                variant="micro"
+                tone="secondary"
+                className="mt-0.5"
+              >
+                +{extra}人
+              </Typography>
+            </li>
+          )}
+        </ul>
+      </div>
+    </Card>
+  );
+};
+
+// Resolve the colour shown next to a legend row to match the DonutChart
+// segment for the same slice. The palette wraps modulo `DONUT_PALETTE.length`,
+// so we look up the slice index — falling back to the row index if the slice
+// list is shorter (defensive; shouldn't trigger in practice).
+const slicesPaletteColor = (
+  index: number,
+  slices: DonutSlice[],
+  address: string,
+): string => {
+  const idx = slices.findIndex(
+    (s) => s.key.toLowerCase() === address.toLowerCase(),
+  );
+  const i = idx >= 0 ? idx : index;
+  return DONUT_PALETTE[i % DONUT_PALETTE.length];
+};
+
+interface UnclaimedRewardsCardProps {
+  balances: {
+    address: string;
+    balance: { formattedAmount: string; symbol: string };
+  }[];
+  onWithdraw: (address: string) => void;
+  isWithdrawing: boolean;
+  className?: string;
+}
+
+const UnclaimedRewardsCard: FC<UnclaimedRewardsCardProps> = ({
+  balances,
+  onWithdraw,
+  isWithdrawing,
+  className,
+}) => (
+  <Card
+    className={cn(
+      "gap-3 border-primary/30 bg-primary-soft/40 px-4 py-4",
+      className,
+    )}
+  >
+    <Typography as="div" variant="bodySm" weight="bold">
+      未回収の報酬があります
+    </Typography>
+    <ul className="flex flex-col gap-2">
+      {balances.map((b) => (
+        <li key={b.address} className="flex items-center justify-between gap-2">
+          <Typography as="span" variant="bodySm">
+            {Number(b.balance.formattedAmount).toFixed(4)} {b.balance.symbol}
+          </Typography>
+          <Button
+            size="sm"
+            variant="primary"
+            onClick={() => onWithdraw(b.address)}
+            disabled={isWithdrawing}
+          >
+            引き出す
+          </Button>
+        </li>
+      ))}
+    </ul>
+  </Card>
+);
+
+// ─── Copy helpers ──────────────────────────────────────────────────────────
+//
+// Tiny duplicates of the ones in `$treeId_.splits.$splitId.tsx` — both routes
+// need the same UX (icon-only ENS copy + mono address row with copy icon).
+// Each button stops propagation so it can live inside the mobile card's
+// clickable wrapper without triggering navigation.
+
+interface CopyIconButtonProps {
+  label: string;
+  value: string;
+  size?: "sm" | "md";
+}
+
+const CopyIconButton: FC<CopyIconButtonProps> = ({
+  label,
+  value,
+  size = "md",
+}) => {
+  const { copyToClipboardAction } = useCopyToClipboard(value);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    event.preventDefault();
+    copyToClipboardAction().then(
+      () => toast.success(`${label}をコピーしました`),
+      () => toast.error("コピーに失敗しました"),
+    );
+  };
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label={`${label}をコピー`}
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-full text-text-secondary transition-colors hover:bg-bg hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+        size === "sm" ? "size-6" : "size-7",
+      )}
+    >
+      <Icon name="copy" size={size === "sm" ? 12 : 14} />
+    </button>
+  );
+};
+
+interface CopyableAddressProps {
+  address: string;
+  className?: string;
+}
+
+const CopyableAddress: FC<CopyableAddressProps> = ({ address, className }) => {
+  const { copyToClipboardAction } = useCopyToClipboard(address);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    event.preventDefault();
+    copyToClipboardAction().then(
+      () => toast.success("アドレスをコピーしました"),
+      () => toast.error("コピーに失敗しました"),
+    );
+  };
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label="アドレスをコピー"
+      className={cn(
+        "group inline-flex max-w-full items-center gap-1.5 rounded-sm text-text-secondary transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+        className,
+      )}
+    >
+      <Typography
+        as="span"
+        variant="micro"
+        truncate
+        className="min-w-0 font-mono"
+      >
+        {address}
+      </Typography>
+      <Icon
+        name="copy"
+        size={12}
+        className="shrink-0 opacity-70 transition-opacity group-hover:opacity-100"
+      />
+    </button>
+  );
+};

--- a/pkgs/frontend/app/routes/$treeId_.splits.new.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.splits.new.tsx
@@ -1,198 +1,98 @@
-import type { Hat, Wearer } from "@hatsprotocol/sdk-v1-subgraph";
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
 import {
   useAddressesByNames,
   useNamesByAddresses,
   useSetName,
 } from "hooks/useENS";
-import { useAssignableHats, useHats } from "hooks/useHats";
+import { useAssignableHats } from "hooks/useHats";
 import { useSplitsCreator } from "hooks/useSplitsCreator";
-import {
-  type ChangeEvent,
-  type FC,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
-import {
-  type FieldArrayWithId,
-  type UseFieldArrayUpdate,
-  useFieldArray,
-  useForm,
-} from "react-hook-form";
+import { type FC, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
+import { toast } from "sonner";
 import type { HatsDetailSchama } from "types/hats";
 import { ipfs2https } from "utils/ipfs";
+import { abbreviateAddress } from "utils/wallet";
 import type { Address } from "viem";
-import { BasicButton } from "~/components/BasicButton";
-import { PageHeader } from "~/components/PageHeader";
 import {
-  Box,
-  Flex,
-  Float,
-  Grid,
-  HStack,
-  List,
-  Separator,
-  Stack,
-  Text,
-  VStack,
-} from "~/components/chakra-shim";
-import { Slider, useSlider } from "~/components/chakra-shim";
-import { CommonDialog } from "~/components/common/CommonDialog";
-import { CommonInput } from "~/components/common/CommonInput";
-import { HatsListItemParser } from "~/components/common/HatsListItemParser";
-import { RoleIcon } from "~/components/icon/RoleIcon";
-import { UserIcon } from "~/components/icon/UserIcon";
-import { SplitRecipientsList } from "~/components/splits/SplitRecipientsList";
-import { Checkbox } from "~/components/ui/checkbox";
-import { Field } from "~/components/ui/field";
+  DonutChart,
+  type DonutSlice,
+} from "~/components/composite/donut-chart";
+import { FieldLabel } from "~/components/composite/field-label";
+import { SectionLabel } from "~/components/composite/section-label";
+import { StepBar } from "~/components/composite/step-bar";
+import { ScreenHeader } from "~/components/layout/ScreenHeader";
+import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
+import { Button } from "~/components/ui/button";
+import { Card } from "~/components/ui/card";
+import { Icon } from "~/components/ui/icon";
+import { Input } from "~/components/ui/input";
+import { Typography } from "~/components/ui/typography";
+import { cn } from "~/lib/utils";
 
-interface RoleItemProps {
-  update: UseFieldArrayUpdate<FormData, "roles">;
-  fieldIndex: number;
-  detail?: HatsDetailSchama;
-  imageUri?: string;
-  field: FieldArrayWithId<FormData, "roles", "id">;
-  wearers: Wearer[];
-}
+type Step = "form" | "preview" | "done";
 
-const RoleItem: FC<RoleItemProps> = ({
-  detail,
-  imageUri,
-  update,
-  fieldIndex,
-  field,
-  wearers,
-}) => {
-  const addresses = useMemo(() => {
-    return wearers.map((w) => w.id);
-  }, [wearers]);
-  const { names } = useNamesByAddresses(addresses);
-
-  const handleOnCheck = (address: Address) => {
-    if (!address) return;
-    const array = field.wearers.includes(address)
-      ? field.wearers.filter((a) => a !== address)
-      : [...field.wearers, address];
-    update(fieldIndex, {
-      ...field,
-      wearers: array,
-    });
-  };
-
-  const handleUpdateMultiplier = (e: ChangeEvent<HTMLInputElement>) => {
-    const value = Number(e.target.value);
-    update(fieldIndex, {
-      ...field,
-      multiplier: value,
-    });
-  };
-
-  return (
-    <List.Item mb={5}>
-      <HStack gap={2}>
-        <Checkbox
-          checked={field.active}
-          onCheckedChange={() => {
-            update(fieldIndex, {
-              ...field,
-              active: !field.active,
-            });
-          }}
-        />
-        <RoleIcon size="70px" roleImageUrl={imageUri} />
-        <Box>
-          <Text>{detail?.data.name}</Text>
-          <Flex alignItems="center" gap={2} mt={2}>
-            <Text fontSize="sm">分配係数</Text>
-            <CommonInput
-              type="number"
-              value={field.multiplier}
-              onChange={handleUpdateMultiplier}
-              placeholder="例: 1, 1.5 10"
-              textAlign="center"
-              w="80px"
-            />
-            <Text as="span">倍</Text>
-          </Flex>
-          <CommonDialog
-            dialogTriggerReactNode={
-              <Text cursor="pointer" fontSize="sm" mt={2} textAlign="right">
-                詳細設定 ▶
-              </Text>
-            }
-          >
-            <Box p={5}>
-              <Text fontSize="lg" mb={5}>
-                分配対象にするメンバーと当番を選択
-              </Text>
-              <Stack rowGap={5}>
-                {names
-                  .filter((name) => name.length > 0)
-                  .map((name) => (
-                    <HStack columnGap={3} key={name[0]?.address}>
-                      <Checkbox
-                        checked={field.wearers.includes(
-                          name[0]?.address.toLowerCase() as Address,
-                        )}
-                        onCheckedChange={() =>
-                          handleOnCheck(
-                            name[0]?.address.toLowerCase() as Address,
-                          )
-                        }
-                      />
-                      <UserIcon
-                        size="40px"
-                        userImageUrl={ipfs2https(name[0]?.text_records?.avatar)}
-                      />
-                      <Box>
-                        <Text wordBreak="break-all">{name[0]?.name}</Text>
-                        <Text wordBreak="break-all">{name[0]?.address}</Text>
-                      </Box>
-                    </HStack>
-                  ))}
-              </Stack>
-
-              {/* <Separator my={5} borderColor="black" />
-
-              <List.Root listStyle="none" mb={10}>
-                <List.Item>
-                  <HStack gap={2}>
-                    <Checkbox checked="indeterminate" />
-                    <RoleIcon size="50px" />
-                    <Box>
-                      <Text>Role Name</Text>
-                    </Box>
-                  </HStack>
-                  <List.Root listStyle="none" pl={10} mt={3}>
-                    <List.Item>
-                      <HStack gap={2}>
-                        <Checkbox />
-                        <UserIcon size="30px" />
-                        <Box>
-                          <Text>User name</Text>
-                          <Text>0x123</Text>
-                        </Box>
-                      </HStack>
-                    </List.Item>
-                  </List.Root>
-                </List.Item>
-              </List.Root> */}
-            </Box>
-          </CommonDialog>
-        </Box>
-      </HStack>
-    </List.Item>
-  );
+const TOTAL_STEPS = 3;
+const STEP_INDEX: Record<Step, number> = {
+  form: 0,
+  preview: 1,
+  done: 2,
 };
 
-interface FormData {
-  roles: RoleInput[];
+interface DutyOption {
+  hatId: Address;
+  detailsUri?: string;
+  imageUri?: string;
+  wearers: Address[];
 }
 
+interface DutyDetail {
+  hatId: Address;
+  name: string;
+  description?: string;
+  imageUrl?: string;
+}
+
+const useDutyDetails = (options: DutyOption[]): DutyDetail[] => {
+  const queries = options.map((o) => o.detailsUri);
+  // One detail blob per duty — small enough to fan out, large enough we want
+  // React Query's cache so the preview→form round-trip doesn't re-fetch.
+  const detailResults = useQuery({
+    queryKey: ["duty-details-batch", queries.join("|")],
+    enabled: options.length > 0,
+    staleTime: 1000 * 60 * 60,
+    queryFn: async () => {
+      const fetched = await Promise.all(
+        options.map(async (o) => {
+          if (!o.detailsUri) return undefined;
+          const url = ipfs2https(o.detailsUri);
+          if (!url) return undefined;
+          try {
+            const { data } = await axios.get<HatsDetailSchama>(url);
+            return data;
+          } catch (error) {
+            console.error("Failed to fetch duty details:", error);
+            return undefined;
+          }
+        }),
+      );
+      return fetched;
+    },
+  });
+  return useMemo(() => {
+    return options.map((o, i): DutyDetail => {
+      const data = detailResults.data?.[i];
+      return {
+        hatId: o.hatId,
+        name: data?.data?.name ?? "当番",
+        description: data?.data?.description,
+        imageUrl: ipfs2https(o.imageUri),
+      };
+    });
+  }, [options, detailResults.data]);
+};
+
 interface RoleInput {
-  hat: Pick<Hat, "details" | "imageUri">;
   hatId: Address;
   active: boolean;
   multiplier: number;
@@ -201,310 +101,633 @@ interface RoleInput {
 
 const SplitterNew: FC = () => {
   const navigate = useNavigate();
-
   const { treeId } = useParams();
 
   const hats = useAssignableHats(Number(treeId));
+  const baseHats = useMemo(
+    () =>
+      hats.filter(
+        (h) => Number(h.levelAtLocalTree) === 2 && (h.wearers?.length ?? 0) > 0,
+      ),
+    [hats],
+  );
 
-  const baseHats = useMemo(() => {
-    return hats.filter(
-      (h) => Number(h.levelAtLocalTree) === 2 && h.wearers?.length,
-    );
-  }, [hats]);
+  const dutyOptions = useMemo<DutyOption[]>(
+    () =>
+      baseHats.map((h) => ({
+        hatId: h.id as Address,
+        detailsUri: h.details,
+        imageUri: h.imageUri,
+        wearers: (h.wearers ?? []).map((w) => w.id as Address),
+      })),
+    [baseHats],
+  );
+  const dutyDetails = useDutyDetails(dutyOptions);
+  const dutyNameById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const d of dutyDetails) m.set(d.hatId.toLowerCase(), d.name);
+    return m;
+  }, [dutyDetails]);
 
-  const [splitterName, setSplitterName] = useState<string>("");
-  const _splitterName = useMemo(() => {
-    return [`${splitterName}.split`];
-  }, [splitterName]);
-  const { addresses } = useAddressesByNames(_splitterName, true);
+  // Flow state.
+  const [step, setStep] = useState<Step>("form");
+
+  // Step 1 — form state.
+  const [splitterName, setSplitterName] = useState("");
+  const _candidateName = useMemo(
+    () => [`${splitterName}.split`],
+    [splitterName],
+  );
+  const { addresses } = useAddressesByNames(_candidateName, true);
   const availableName = useMemo(() => {
     if (!splitterName) return false;
-
     return addresses?.[0]?.length === 0;
   }, [splitterName, addresses]);
 
+  const [dutyWeight, setDutyWeight] = useState(75);
+  const [recvWeight, setRecvWeight] = useState(50);
+  const [roles, setRoles] = useState<Record<string, RoleInput>>({});
+
+  // Seed roles from the assignable hats once they load. Preserve any user
+  // edits by only inserting hats that aren't already in the map.
+  useEffect(() => {
+    if (dutyOptions.length === 0) return;
+    setRoles((current) => {
+      const next = { ...current };
+      let changed = false;
+      for (const o of dutyOptions) {
+        const key = o.hatId.toLowerCase();
+        if (!next[key]) {
+          next[key] = {
+            hatId: o.hatId,
+            active: true,
+            multiplier: 1,
+            wearers: o.wearers,
+          };
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+  }, [dutyOptions]);
+
+  const toggleRole = (hatId: Address) => {
+    const key = hatId.toLowerCase();
+    setRoles((current) => {
+      const existing = current[key];
+      if (!existing) return current;
+      return { ...current, [key]: { ...existing, active: !existing.active } };
+    });
+  };
+
+  // Step 2 — preview state.
   const { createSplits, previewSplits, isLoading } = useSplitsCreator(
     treeId ?? "",
   );
-
-  const { control, getValues } = useForm<FormData>();
-  const { fields, insert, update } = useFieldArray({
-    control,
-    name: "roles",
-  });
-
-  const tobanThanksSlider = useSlider({
-    defaultValue: [50],
-    min: 0,
-    max: 100,
-    thumbAlignment: "center",
-    step: 1,
-  });
-
-  const thanksReceiveSendSlider = useSlider({
-    defaultValue: [50],
-    min: 0,
-    max: 100,
-    thumbAlignment: "center",
-    step: 1,
-  });
-
-  useEffect(() => {
-    const fetch = async () => {
-      if (fields.length === 0) {
-        for (let index = 0; index < baseHats.length; index++) {
-          const hat = baseHats[index];
-          insert(index, {
-            hat,
-            hatId: hat.id,
-            active: true,
-            multiplier: 1,
-            wearers: hat.wearers?.map((w) => w.id) || [],
-          });
-        }
+  const [preview, setPreview] = useState<
+    | {
+        list: { address: Address; ownership: number }[];
+        totalOwnership: number;
       }
-    };
-    fetch();
-  }, [baseHats, fields.length, insert]);
-
-  const [preview, setPreview] = useState<{
-    list: { address: Address; ownership: number }[];
-    totalOwnership: number;
-  }>();
-
-  const calcSplitsParams = useCallback(() => {
-    const data = getValues();
-
-    return data.roles
-      .filter((r) => r.active)
-      .map((role) => {
-        const [multiplierTop, multiplierBottom] = role.multiplier
-          ? String(role.multiplier).includes(".")
-            ? [
-                BigInt(
-                  role.multiplier *
-                    10 ** String(role.multiplier).split(".")[1].length,
-                ),
-                BigInt(10 ** String(role.multiplier).split(".")[1].length),
-              ]
-            : [BigInt(role.multiplier), BigInt(1)]
-          : [BigInt(1), BigInt(1)];
-
-        return {
-          hatId: BigInt(role.hatId),
-          multiplierTop,
-          multiplierBottom,
-          wearers: role.wearers,
-        };
-      });
-  }, [getValues]);
+    | undefined
+  >();
+  const [isPreviewing, setIsPreviewing] = useState(false);
 
   const weightParams = useMemo(() => {
-    const tobanThanksValue = tobanThanksSlider.value[0];
-    const thanksReceiveSendValue = thanksReceiveSendSlider.value[0];
-
-    if (typeof tobanThanksValue !== "number") return;
-    if (typeof thanksReceiveSendValue !== "number") return;
-
     return {
-      roleWeight: BigInt(tobanThanksValue),
-      thanksTokenWeight: BigInt(100 - Number(tobanThanksValue)),
-      thanksTokenReceivedWeight: BigInt(thanksReceiveSendValue),
-      thanksTokenSentWeight: BigInt(100 - Number(thanksReceiveSendValue)),
+      roleWeight: BigInt(dutyWeight),
+      thanksTokenWeight: BigInt(100 - dutyWeight),
+      thanksTokenReceivedWeight: BigInt(recvWeight),
+      thanksTokenSentWeight: BigInt(100 - recvWeight),
     };
-  }, [tobanThanksSlider.value, thanksReceiveSendSlider.value]);
+  }, [dutyWeight, recvWeight]);
+
+  const calcSplitsParams = useCallback(() => {
+    return Object.values(roles)
+      .filter((r) => r.active)
+      .map((r) => {
+        // Preserves the original multiplier-fraction packing: a non-integer
+        // multiplier becomes a `top/bottom` pair so the contract can use
+        // integer math.
+        const [multiplierTop, multiplierBottom] = r.multiplier
+          ? String(r.multiplier).includes(".")
+            ? [
+                BigInt(
+                  r.multiplier *
+                    10 ** String(r.multiplier).split(".")[1].length,
+                ),
+                BigInt(10 ** String(r.multiplier).split(".")[1].length),
+              ]
+            : [BigInt(r.multiplier), BigInt(1)]
+          : [BigInt(1), BigInt(1)];
+        return {
+          hatId: BigInt(r.hatId),
+          multiplierTop,
+          multiplierBottom,
+          wearers: r.wearers,
+        };
+      });
+  }, [roles]);
+
+  const selectedDutyCount = useMemo(
+    () => Object.values(roles).filter((r) => r.active).length,
+    [roles],
+  );
+  const isFormValid = !!splitterName && availableName && selectedDutyCount > 0;
 
   const handlePreview = useCallback(async () => {
-    if (!availableName || !weightParams) return;
-    const splitsParams = calcSplitsParams();
-    const res = await previewSplits([splitsParams, weightParams]);
-
-    let totalOwnership = 0;
-    const consolidatedRecipients = res[0].reduce((acc, address, index) => {
-      const percentAllocation = Number(res[1][index]);
-      totalOwnership += percentAllocation;
-      acc.set(address, (acc.get(address) || 0) + percentAllocation);
-      return acc;
-    }, new Map<Address, number>());
-
-    setPreview({
-      list: Array.from(consolidatedRecipients.entries()).map(
-        ([address, ownership]) => ({
-          address,
-          ownership,
-        }),
-      ),
-      totalOwnership,
-    });
-  }, [availableName, weightParams, previewSplits, calcSplitsParams]);
-
-  const { setName } = useSetName();
-  const handleCreateSplitter = useCallback(async () => {
-    if (!weightParams) return;
+    if (!isFormValid) return;
+    setIsPreviewing(true);
     try {
       const splitsParams = calcSplitsParams();
-      const res = await createSplits({
-        args: [splitsParams, weightParams],
+      const res = await previewSplits([splitsParams, weightParams]);
+      let totalOwnership = 0;
+      const consolidated = res[0].reduce((acc, address, index) => {
+        const value = Number(res[1][index]);
+        totalOwnership += value;
+        acc.set(address, (acc.get(address) ?? 0) + value);
+        return acc;
+      }, new Map<Address, number>());
+      setPreview({
+        list: Array.from(consolidated.entries())
+          .map(([address, ownership]) => ({ address, ownership }))
+          .sort((a, b) => b.ownership - a.ownership),
+        totalOwnership,
       });
-
-      const address = res?.find((res) => res.eventName === "SplitsCreated")
-        ?.args.split;
-      if (address) {
-        await setName({ name: `${splitterName}.split`, address: address });
-      }
-
-      setTimeout(() => {
-        navigate(`/${treeId}/splits`);
-      }, 5000);
+      setStep("preview");
     } catch (error) {
-      console.error(error);
+      console.error("Failed to preview split:", error);
+      toast.error("プレビューの取得に失敗しました");
+    } finally {
+      setIsPreviewing(false);
     }
-  }, [
-    createSplits,
-    calcSplitsParams,
-    navigate,
-    setName,
-    splitterName,
-    treeId,
-    weightParams,
-  ]);
+  }, [calcSplitsParams, isFormValid, previewSplits, weightParams]);
+
+  // Resolve names for the preview rows once we have results.
+  const previewAddresses = useMemo(
+    () => preview?.list.map((r) => r.address) ?? [],
+    [preview],
+  );
+  const { names: previewNames } = useNamesByAddresses(previewAddresses);
+  const previewNameByAddress = useMemo(() => {
+    const m = new Map<string, { name: string; avatar?: string }>();
+    previewNames.forEach((group, i) => {
+      const entry = group[0];
+      const addr = previewAddresses[i]?.toLowerCase();
+      if (!addr) return;
+      if (entry) {
+        m.set(addr, {
+          name: entry.name,
+          avatar: ipfs2https(entry.text_records?.avatar),
+        });
+      }
+    });
+    return m;
+  }, [previewNames, previewAddresses]);
+
+  const { setName } = useSetName();
+  const handleCreate = useCallback(async () => {
+    try {
+      const splitsParams = calcSplitsParams();
+      const res = await createSplits({ args: [splitsParams, weightParams] });
+      const created = res?.find((r) => r.eventName === "SplitsCreated")?.args
+        .split;
+      if (created) {
+        try {
+          await setName({
+            name: `${splitterName}.split`,
+            address: created,
+          });
+        } catch (error) {
+          console.warn("Failed to set ENS name:", error);
+        }
+      }
+      setStep("done");
+    } catch (error) {
+      console.error("Failed to create split:", error);
+      toast.error("分配ルールの作成に失敗しました");
+    }
+  }, [calcSplitsParams, createSplits, setName, splitterName, weightParams]);
+
+  const previewSlices = useMemo<DonutSlice[]>(() => {
+    if (!preview || preview.totalOwnership === 0) return [];
+    return preview.list.map((r) => ({
+      key: r.address,
+      percent: (r.ownership / preview.totalOwnership) * 100,
+    }));
+  }, [preview]);
+
+  const stepIndex = STEP_INDEX[step];
+
+  // ───────── Step Done ─────────
+  if (step === "done") {
+    return (
+      <div className="flex min-h-dvh flex-col bg-bg pb-6">
+        <div className="flex flex-col items-center gap-5 px-6 pt-12 text-center">
+          <div
+            aria-hidden
+            className="flex size-24 items-center justify-center rounded-full"
+            style={{ backgroundColor: "var(--color-split)" }}
+          >
+            <Icon name="pie" size={44} className="text-white" />
+          </div>
+          <div className="space-y-2">
+            <Typography
+              as="div"
+              variant="display"
+              className="text-[22px] tracking-[-0.3px]"
+            >
+              分配ルールを作成しました
+            </Typography>
+            <Typography variant="bodySm" tone="secondary">
+              <strong className="text-text-primary">{splitterName}</strong>{" "}
+              が作成されました。
+            </Typography>
+          </div>
+          <Button
+            variant="primary"
+            full
+            onClick={() => navigate(`/${treeId}/splits`)}
+            className="mt-2"
+          >
+            分配一覧へ戻る
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <Grid
-      minH="calc(100vh - 100px)"
-      gridTemplateRows={preview ? "auto auto 1fr auto" : "auto auto 1fr auto"}
-    >
-      <PageHeader
-        title="スプリッターを作成"
-        backLink={
-          preview
-            ? () => {
-                setPreview(undefined);
-              }
-            : `/${treeId}/splits`
+    <div className="flex min-h-dvh flex-col bg-bg pb-6">
+      <ScreenHeader
+        title={step === "form" ? "分配ルールを作成" : "分配プレビュー"}
+        subtitle={
+          step === "form"
+            ? `${stepIndex + 1} / ${TOTAL_STEPS}`
+            : "この設定での分配結果"
+        }
+        onBack={
+          step === "form"
+            ? () => navigate(`/${treeId}/splits`)
+            : () => setStep("form")
         }
       />
+      <div className="px-5 pb-3">
+        <StepBar
+          total={TOTAL_STEPS}
+          current={stepIndex}
+          ariaLabel={`分配ルール作成 ${stepIndex + 1}/${TOTAL_STEPS}`}
+        />
+      </div>
 
-      {preview ? (
-        <>
-          <Text my={5} fontWeight="bold">
-            スプリッター名: {splitterName}
-          </Text>
-          <SplitRecipientsList recipients={preview} />
-          <BasicButton
-            mb={5}
-            onClick={handleCreateSplitter}
-            loading={isLoading}
-          >
-            作成
-          </BasicButton>
-        </>
-      ) : (
-        <>
-          <Field label="スプリッター名" mt={5}>
-            <CommonInput
+      {step === "form" && (
+        <div className="flex flex-col gap-5">
+          <div className="px-5">
+            <FieldLabel htmlFor="split-name">
+              分配ルール名 <span className="text-danger">*</span>
+            </FieldLabel>
+            <Input
+              id="split-name"
               value={splitterName}
-              onChange={(e) => {
-                setSplitterName(e.target.value);
-              }}
-              placeholder="名前"
+              onChange={(e) => setSplitterName(e.target.value)}
+              placeholder="例：kuu village day 8"
+              aria-invalid={!availableName && splitterName.length > 0}
             />
-            <Text textAlign="right" fontSize="xs" mt={1} w="100%">
-              {availableName
-                ? "この名前は利用可能です"
-                : "この名前は利用できません"}
-            </Text>
-          </Field>
+            <Typography
+              variant="micro"
+              tone="secondary"
+              as="div"
+              className="mt-1 text-right"
+            >
+              {splitterName.length === 0
+                ? "ENS 名として登録されます"
+                : availableName
+                  ? "この名前は利用可能です"
+                  : "この名前は利用できません"}
+            </Typography>
+          </div>
 
-          <Grid gap={4}>
-            <Text fontSize="lg" mt={8} fontWeight="bold">
-              比重設定
-            </Text>
+          <div className="px-5">
+            <FieldLabel>何を重視する？</FieldLabel>
+            <Card className="gap-3 px-4 py-4">
+              <PercentRow
+                label="当番ベース"
+                value={dutyWeight}
+                valueColor="var(--color-role)"
+              />
+              <PercentSlider
+                value={dutyWeight}
+                onChange={setDutyWeight}
+                ariaLabel="当番ベースとサンクスベースの比重"
+              />
+              <PercentRow
+                label="サンクスベース"
+                value={100 - dutyWeight}
+                valueColor="var(--color-contrib)"
+              />
+            </Card>
+          </div>
 
-            <Box>
-              <Text fontSize="md" mt={2}>
-                1. 当番ベースとThanksTokenベースの重み
-              </Text>
+          <div className="px-5">
+            <FieldLabel>サンクスの中で何を重視する？</FieldLabel>
+            <Card className="gap-3 px-4 py-4">
+              <PercentRow
+                label="受け取った量"
+                value={recvWeight}
+                valueColor="var(--color-contrib)"
+              />
+              <PercentSlider
+                value={recvWeight}
+                onChange={setRecvWeight}
+                ariaLabel="サンクス受取量と送付量の比重"
+                accentColor="var(--color-contrib)"
+              />
+              <PercentRow
+                label="送った量"
+                value={100 - recvWeight}
+                valueColor="var(--color-primary)"
+              />
+            </Card>
+          </div>
 
-              <Flex alignItems="center" justifyContent="space-between" mt={2}>
-                <Text fontSize="xs" color="gray.600" textAlign="center">
-                  当番ベース
-                  <br />
-                  {tobanThanksSlider.value[0]}
-                </Text>
-                <Text fontSize="xs" color="gray.600" textAlign="center">
-                  Thanksトークンベース
-                  <br />
-                  {100 - Number(tobanThanksSlider.value[0])}
-                </Text>
-              </Flex>
-              <Slider.RootProvider value={tobanThanksSlider} size="lg">
-                <Slider.Control>
-                  <Slider.Track backgroundColor="green.400">
-                    <Slider.Range backgroundColor="yellow.400" />
-                  </Slider.Track>
-                  <Slider.Thumbs borderColor="blue.400" />
-                </Slider.Control>
-              </Slider.RootProvider>
-            </Box>
+          <div className="px-5">
+            <FieldLabel>対象にする当番</FieldLabel>
+            {dutyDetails.length === 0 ? (
+              <Card className="px-4 py-6 text-center">
+                <Typography variant="bodySm" tone="secondary">
+                  対象にできる当番がありません
+                </Typography>
+              </Card>
+            ) : (
+              <Card className="gap-0 p-0">
+                {dutyDetails.map((duty, i) => {
+                  const key = duty.hatId.toLowerCase();
+                  const role = roles[key];
+                  const checked = role?.active ?? false;
+                  return (
+                    <button
+                      type="button"
+                      key={duty.hatId}
+                      onClick={() => toggleRole(duty.hatId)}
+                      className={cn(
+                        "flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-bg",
+                        i > 0 && "border-t border-border",
+                      )}
+                      aria-pressed={checked}
+                    >
+                      <div
+                        className={cn(
+                          "flex size-[22px] shrink-0 items-center justify-center rounded-[6px] border-[1.5px] transition-colors",
+                          checked
+                            ? "border-primary bg-primary text-primary-foreground"
+                            : "border-border bg-surface",
+                        )}
+                      >
+                        {checked && <Icon name="check" size={14} />}
+                      </div>
+                      <div className="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-sm bg-[#F2EAD9]">
+                        {duty.imageUrl ? (
+                          <img
+                            src={duty.imageUrl}
+                            alt=""
+                            className="size-full object-cover"
+                          />
+                        ) : (
+                          <Icon
+                            name="duty"
+                            size={18}
+                            className="text-[#7A5A2E]"
+                          />
+                        )}
+                      </div>
+                      <Typography
+                        as="span"
+                        variant="bodySm"
+                        weight="semibold"
+                        truncate
+                        className="min-w-0 flex-1"
+                      >
+                        {duty.name}
+                      </Typography>
+                    </button>
+                  );
+                })}
+              </Card>
+            )}
+          </div>
 
-            <Box>
-              <Text fontSize="md" mt={2}>
-                2. ThanksTokenの受取量と送付量の重み
-              </Text>
-              <Flex alignItems="center" justifyContent="space-between" mt={2}>
-                <Text fontSize="xs" color="gray.600" textAlign="center">
-                  受取量
-                  <br />
-                  {thanksReceiveSendSlider.value[0]}
-                </Text>
-                <Text fontSize="xs" color="gray.600" textAlign="center">
-                  送付量
-                  <br />
-                  {100 - Number(thanksReceiveSendSlider.value[0])}
-                </Text>
-              </Flex>
-              <Slider.RootProvider value={thanksReceiveSendSlider} size="lg">
-                <Slider.Control>
-                  <Slider.Track backgroundColor="green.400">
-                    <Slider.Range backgroundColor="yellow.400" />
-                  </Slider.Track>
-                  <Slider.Thumbs borderColor="blue.400" />
-                </Slider.Control>
-              </Slider.RootProvider>
-            </Box>
-          </Grid>
-
-          <Grid gap={4} mt={10} mb={10}>
-            <Text fontSize="lg" fontWeight="bold">
-              当番ごとの設定
-            </Text>
-            <List.Root listStyle="none">
-              {fields.map((field, index) => (
-                <HatsListItemParser
-                  key={field.hatId}
-                  detailUri={field.hat.details}
-                  imageUri={field.hat.imageUri}
-                >
-                  <RoleItem
-                    update={update}
-                    fieldIndex={index}
-                    field={field}
-                    wearers={
-                      baseHats.find((h) => h.id === field.hatId)?.wearers || []
-                    }
-                  />
-                </HatsListItemParser>
-              ))}
-            </List.Root>
-          </Grid>
-          <BasicButton onClick={handlePreview} mb={5} disabled={!availableName}>
-            プレビュー
-          </BasicButton>
-        </>
+          <div className="px-4 pt-4">
+            <Button
+              variant="primary"
+              full
+              disabled={!isFormValid || isPreviewing}
+              onClick={handlePreview}
+            >
+              <Icon name="pie" size={16} />
+              {isPreviewing ? "プレビューを準備中…" : "プレビューを見る"}
+            </Button>
+          </div>
+        </div>
       )}
-    </Grid>
+
+      {step === "preview" && preview && (
+        <div className="flex flex-col gap-5">
+          <div className="px-4">
+            <Card
+              className="items-center gap-3 px-5 py-5 text-center"
+              style={{
+                background: "#F0F6FB",
+                borderColor: "rgba(93, 173, 236, 0.27)",
+              }}
+            >
+              <DonutChart
+                slices={previewSlices}
+                size={140}
+                center={
+                  <>
+                    <span className="text-[22px] font-extrabold leading-none">
+                      {preview.list.length}
+                    </span>
+                    <span className="mt-1 text-[11px] font-bold text-text-secondary">
+                      人
+                    </span>
+                  </>
+                }
+              />
+              <Typography variant="caption" tone="secondary">
+                {splitterName}
+              </Typography>
+            </Card>
+          </div>
+
+          <SectionLabel className="px-5">分配の内訳</SectionLabel>
+          <div className="px-4">
+            <Card className="gap-0 p-0">
+              {preview.list.map((r, i) => {
+                const entry = previewNameByAddress.get(r.address.toLowerCase());
+                const name = entry?.name ?? abbreviateAddress(r.address);
+                const pct =
+                  preview.totalOwnership > 0
+                    ? (r.ownership / preview.totalOwnership) * 100
+                    : 0;
+                return (
+                  <div
+                    key={r.address}
+                    className={cn(
+                      "flex items-center gap-3 px-4 py-3",
+                      i > 0 && "border-t border-border",
+                    )}
+                  >
+                    <Avatar size="default" className="size-8">
+                      {entry?.avatar && (
+                        <AvatarImage src={entry.avatar} alt="" />
+                      )}
+                      <AvatarFallback seed={name} />
+                    </Avatar>
+                    <Typography
+                      as="div"
+                      variant="bodySm"
+                      weight="semibold"
+                      truncate
+                      className="min-w-0 flex-1"
+                    >
+                      {name}
+                    </Typography>
+                    <Typography
+                      as="span"
+                      variant="bodySm"
+                      weight="bold"
+                      className="tabular-nums"
+                    >
+                      {pct.toFixed(2)}%
+                    </Typography>
+                  </div>
+                );
+              })}
+            </Card>
+          </div>
+
+          <div className="px-4">
+            <Card
+              className="gap-1 px-3.5 py-3"
+              style={{
+                background: "var(--color-primary-soft)",
+                borderColor: "rgba(245, 184, 46, 0.33)",
+              }}
+            >
+              <Typography
+                as="div"
+                variant="caption"
+                weight="bold"
+                className="text-[#7A5A2E]"
+              >
+                分配のもとになった要素
+              </Typography>
+              <Typography
+                as="div"
+                variant="caption"
+                className="leading-relaxed"
+              >
+                ・ 当番への参加（{dutyWeight}%）
+                <br />・ サンクスの受け取り・送付（{100 - dutyWeight}%）
+              </Typography>
+              <Typography
+                as="div"
+                variant="micro"
+                tone="secondary"
+                className="mt-1"
+              >
+                対象の当番:{" "}
+                {Object.values(roles)
+                  .filter((r) => r.active)
+                  .map((r) => dutyNameById.get(r.hatId.toLowerCase()) ?? "当番")
+                  .join("、")}
+              </Typography>
+            </Card>
+          </div>
+
+          <div className="flex gap-2.5 px-4 pt-2">
+            <Button
+              variant="secondary"
+              onClick={() => setStep("form")}
+              disabled={isLoading}
+              className="shrink-0"
+            >
+              戻って修正
+            </Button>
+            <Button
+              variant="primary"
+              onClick={handleCreate}
+              disabled={isLoading}
+              className="flex-1"
+            >
+              {isLoading ? "作成中…" : "作成する"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
   );
 };
 
 export default SplitterNew;
+
+// ─── PercentRow ────────────────────────────────────────────────────────────
+
+interface PercentRowProps {
+  label: string;
+  value: number;
+  valueColor: string;
+}
+
+const PercentRow: FC<PercentRowProps> = ({ label, value, valueColor }) => (
+  <div className="flex items-baseline justify-between text-[13px]">
+    <Typography as="span" variant="bodySm" weight="semibold">
+      {label}
+    </Typography>
+    <Typography
+      as="span"
+      variant="bodySm"
+      weight="bold"
+      className="tabular-nums"
+      style={{ color: valueColor }}
+    >
+      {value}%
+    </Typography>
+  </div>
+);
+
+// ─── PercentSlider ─────────────────────────────────────────────────────────
+
+interface PercentSliderProps {
+  value: number;
+  onChange: (next: number) => void;
+  ariaLabel: string;
+  accentColor?: string;
+}
+
+// Native range styled to fit the design tokens — same accent as the legacy
+// Chakra slider, but tiny enough to avoid introducing a new dependency.
+const PercentSlider: FC<PercentSliderProps> = ({
+  value,
+  onChange,
+  ariaLabel,
+  accentColor = "var(--color-primary)",
+}) => (
+  <input
+    type="range"
+    min={0}
+    max={100}
+    step={1}
+    value={value}
+    onChange={(e) => onChange(Number(e.target.value))}
+    aria-label={ariaLabel}
+    className="h-2 w-full cursor-pointer appearance-none rounded-full bg-[#F0EBE0] outline-none focus-visible:ring-2 focus-visible:ring-ring/40 [&::-moz-range-thumb]:size-5 [&::-moz-range-thumb]:cursor-pointer [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-white [&::-moz-range-thumb]:shadow-2 [&::-webkit-slider-thumb]:size-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:shadow-2"
+    style={
+      {
+        accentColor,
+        "--thumb-color": accentColor,
+      } as React.CSSProperties
+    }
+  />
+);

--- a/pkgs/frontend/app/routes/$treeId_.splits.new.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.splits.new.tsx
@@ -7,7 +7,14 @@ import {
 } from "hooks/useENS";
 import { useAssignableHats } from "hooks/useHats";
 import { useSplitsCreator } from "hooks/useSplitsCreator";
-import { type FC, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import type { HatsDetailSchama } from "types/hats";
@@ -22,9 +29,19 @@ import { FieldLabel } from "~/components/composite/field-label";
 import { SectionLabel } from "~/components/composite/section-label";
 import { StepBar } from "~/components/composite/step-bar";
 import { ScreenHeader } from "~/components/layout/ScreenHeader";
+import { RuleCard, type WeightInfo } from "~/components/splits/RuleCard";
+import { SplitBreakdownCard } from "~/components/splits/SplitBreakdownCard";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
+import { Checkbox } from "~/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
 import { Icon } from "~/components/ui/icon";
 import { Input } from "~/components/ui/input";
 import { Typography } from "~/components/ui/typography";
@@ -132,6 +149,28 @@ const SplitterNew: FC = () => {
   // Flow state.
   const [step, setStep] = useState<Step>("form");
 
+  // Each step change resets the scroll position to the top. AppShell wraps
+  // routes in its own `<main>` with `overflow-y-auto`, so `window.scrollTo`
+  // is a no-op here — we walk up from this component's root and ask the
+  // ancestor scroll container to reset.
+  const rootRef = useRef<HTMLDivElement>(null);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll-on-step-change is the entire point of this effect; `step` must stay in the deps array even though the body doesn't read it.
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    let node: HTMLElement | null = el;
+    while (node) {
+      if (node.scrollHeight > node.clientHeight) {
+        node.scrollTo({ top: 0, behavior: "auto" });
+        break;
+      }
+      node = node.parentElement;
+    }
+    if (typeof window !== "undefined") {
+      window.scrollTo({ top: 0, behavior: "auto" });
+    }
+  }, [step]);
+
   // Step 1 — form state.
   const [splitterName, setSplitterName] = useState("");
   const _candidateName = useMemo(
@@ -180,6 +219,62 @@ const SplitterNew: FC = () => {
     });
   };
 
+  // Flip an individual wearer in / out of the per-duty selection. The duty row
+  // toggles inclusion of the duty as a whole; this toggles which wearers count
+  // when the duty IS included (mirrors the legacy "詳細設定" dialog).
+  const toggleWearer = (hatId: Address, wearer: Address) => {
+    const key = hatId.toLowerCase();
+    const wearerLower = wearer.toLowerCase() as Address;
+    setRoles((current) => {
+      const existing = current[key];
+      if (!existing) return current;
+      const has = existing.wearers.some((w) => w.toLowerCase() === wearerLower);
+      const wearers = has
+        ? existing.wearers.filter((w) => w.toLowerCase() !== wearerLower)
+        : [...existing.wearers, wearer];
+      return { ...current, [key]: { ...existing, wearers } };
+    });
+  };
+
+  // Resolve display names + avatars for every wearer across every duty in one
+  // batched Namestone call so the per-duty detail dialog renders without an
+  // extra round-trip when opened.
+  const allWearerAddresses = useMemo(() => {
+    const set = new Set<string>();
+    for (const o of dutyOptions) {
+      for (const w of o.wearers) set.add(w.toLowerCase());
+    }
+    return Array.from(set);
+  }, [dutyOptions]);
+  const { names: wearerNames } = useNamesByAddresses(allWearerAddresses);
+  const wearerInfoByAddress = useMemo(() => {
+    const m = new Map<string, { name: string; avatar?: string }>();
+    wearerNames.forEach((group, i) => {
+      const addr = allWearerAddresses[i];
+      const entry = group[0];
+      if (!addr) return;
+      if (entry?.name) {
+        m.set(addr, {
+          name: entry.name,
+          avatar: ipfs2https(entry.text_records?.avatar),
+        });
+      }
+    });
+    return m;
+  }, [wearerNames, allWearerAddresses]);
+
+  // Which duty's per-wearer detail dialog is open. null = closed.
+  const [openDetailHatId, setOpenDetailHatId] = useState<Address | null>(null);
+  const openDetailDuty = useMemo(() => {
+    if (!openDetailHatId) return undefined;
+    const target = openDetailHatId.toLowerCase();
+    return {
+      detail: dutyDetails.find((d) => d.hatId.toLowerCase() === target),
+      option: dutyOptions.find((o) => o.hatId.toLowerCase() === target),
+      role: roles[target],
+    };
+  }, [openDetailHatId, dutyDetails, dutyOptions, roles]);
+
   // Step 2 — preview state.
   const { createSplits, previewSplits, isLoading } = useSplitsCreator(
     treeId ?? "",
@@ -201,6 +296,18 @@ const SplitterNew: FC = () => {
       thanksTokenSentWeight: BigInt(100 - recvWeight),
     };
   }, [dutyWeight, recvWeight]);
+
+  // Same shape the detail page's `RuleCard` expects — share the component
+  // between authoring and viewing so the rule layout stays identical.
+  const previewWeights = useMemo<WeightInfo>(
+    () => ({
+      roleWeight: dutyWeight,
+      thanksTokenWeight: 100 - dutyWeight,
+      thanksTokenReceivedWeight: recvWeight,
+      thanksTokenSentWeight: 100 - recvWeight,
+    }),
+    [dutyWeight, recvWeight],
+  );
 
   const calcSplitsParams = useCallback(() => {
     return Object.values(roles)
@@ -263,14 +370,16 @@ const SplitterNew: FC = () => {
     }
   }, [calcSplitsParams, isFormValid, previewSplits, weightParams]);
 
-  // Resolve names for the preview rows once we have results.
+  // Resolve names for the preview rows once we have results. Shape matches
+  // `SplitBreakdownCard`'s `BreakdownNameInfo` so the same map can be passed
+  // through directly.
   const previewAddresses = useMemo(
     () => preview?.list.map((r) => r.address) ?? [],
     [preview],
   );
   const { names: previewNames } = useNamesByAddresses(previewAddresses);
   const previewNameByAddress = useMemo(() => {
-    const m = new Map<string, { name: string; avatar?: string }>();
+    const m = new Map<string, { name?: string; avatarUrl?: string }>();
     previewNames.forEach((group, i) => {
       const entry = group[0];
       const addr = previewAddresses[i]?.toLowerCase();
@@ -278,12 +387,21 @@ const SplitterNew: FC = () => {
       if (entry) {
         m.set(addr, {
           name: entry.name,
-          avatar: ipfs2https(entry.text_records?.avatar),
+          avatarUrl: ipfs2https(entry.text_records?.avatar),
         });
       }
     });
     return m;
   }, [previewNames, previewAddresses]);
+
+  // Pre-computed rows for the shared SplitBreakdownCard.
+  const previewBreakdownRows = useMemo(() => {
+    if (!preview || preview.totalOwnership === 0) return [];
+    return preview.list.map((r) => ({
+      address: r.address,
+      pct: (r.ownership / preview.totalOwnership) * 100,
+    }));
+  }, [preview]);
 
   const { setName } = useSetName();
   const handleCreate = useCallback(async () => {
@@ -358,7 +476,10 @@ const SplitterNew: FC = () => {
   }
 
   return (
-    <div className="flex min-h-dvh flex-col bg-bg pb-6">
+    <div
+      ref={rootRef}
+      className="flex min-h-dvh flex-col bg-bg pt-4 pb-6 md:pt-6"
+    >
       <ScreenHeader
         title={step === "form" ? "分配ルールを作成" : "分配プレビュー"}
         subtitle={
@@ -410,20 +531,20 @@ const SplitterNew: FC = () => {
           <div className="px-5">
             <FieldLabel>何を重視する？</FieldLabel>
             <Card className="gap-3 px-4 py-4">
-              <PercentRow
-                label="当番ベース"
-                value={dutyWeight}
-                valueColor="var(--color-role)"
+              <WeightLabels
+                leftLabel="当番ベース"
+                leftValue={dutyWeight}
+                leftColor="var(--color-role)"
+                rightLabel="サンクスベース"
+                rightValue={100 - dutyWeight}
+                rightColor="var(--color-contrib)"
               />
               <PercentSlider
                 value={dutyWeight}
                 onChange={setDutyWeight}
                 ariaLabel="当番ベースとサンクスベースの比重"
-              />
-              <PercentRow
-                label="サンクスベース"
-                value={100 - dutyWeight}
-                valueColor="var(--color-contrib)"
+                leftColor="var(--color-role)"
+                rightColor="var(--color-contrib)"
               />
             </Card>
           </div>
@@ -431,21 +552,20 @@ const SplitterNew: FC = () => {
           <div className="px-5">
             <FieldLabel>サンクスの中で何を重視する？</FieldLabel>
             <Card className="gap-3 px-4 py-4">
-              <PercentRow
-                label="受け取った量"
-                value={recvWeight}
-                valueColor="var(--color-contrib)"
+              <WeightLabels
+                leftLabel="受け取った量"
+                leftValue={recvWeight}
+                leftColor="var(--color-contrib)"
+                rightLabel="送った量"
+                rightValue={100 - recvWeight}
+                rightColor="var(--color-primary)"
               />
               <PercentSlider
                 value={recvWeight}
                 onChange={setRecvWeight}
                 ariaLabel="サンクス受取量と送付量の比重"
-                accentColor="var(--color-contrib)"
-              />
-              <PercentRow
-                label="送った量"
-                value={100 - recvWeight}
-                valueColor="var(--color-primary)"
+                leftColor="var(--color-contrib)"
+                rightColor="var(--color-primary)"
               />
             </Card>
           </div>
@@ -464,52 +584,91 @@ const SplitterNew: FC = () => {
                   const key = duty.hatId.toLowerCase();
                   const role = roles[key];
                   const checked = role?.active ?? false;
+                  const totalWearers =
+                    dutyOptions.find((o) => o.hatId.toLowerCase() === key)
+                      ?.wearers.length ?? 0;
+                  const selectedWearers = role?.wearers.length ?? 0;
+                  const allSelected =
+                    totalWearers > 0 && selectedWearers === totalWearers;
                   return (
-                    <button
-                      type="button"
+                    <div
                       key={duty.hatId}
-                      onClick={() => toggleRole(duty.hatId)}
                       className={cn(
-                        "flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-bg",
+                        "flex items-center gap-3 px-4 py-3 transition-colors",
                         i > 0 && "border-t border-border",
+                        checked && "hover:bg-bg",
                       )}
-                      aria-pressed={checked}
                     >
-                      <div
+                      <button
+                        type="button"
+                        onClick={() => toggleRole(duty.hatId)}
+                        aria-pressed={checked}
+                        aria-label={`${duty.name}を${checked ? "外す" : "選ぶ"}`}
                         className={cn(
-                          "flex size-[22px] shrink-0 items-center justify-center rounded-[6px] border-[1.5px] transition-colors",
+                          "flex size-[22px] shrink-0 items-center justify-center rounded-[6px] border-[1.5px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
                           checked
                             ? "border-primary bg-primary text-primary-foreground"
                             : "border-border bg-surface",
                         )}
                       >
                         {checked && <Icon name="check" size={14} />}
-                      </div>
-                      <div className="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-sm bg-[#F2EAD9]">
-                        {duty.imageUrl ? (
-                          <img
-                            src={duty.imageUrl}
-                            alt=""
-                            className="size-full object-cover"
-                          />
-                        ) : (
-                          <Icon
-                            name="duty"
-                            size={18}
-                            className="text-[#7A5A2E]"
-                          />
-                        )}
-                      </div>
-                      <Typography
-                        as="span"
-                        variant="bodySm"
-                        weight="semibold"
-                        truncate
-                        className="min-w-0 flex-1"
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => toggleRole(duty.hatId)}
+                        className="flex min-w-0 flex-1 items-center gap-3 text-left"
                       >
-                        {duty.name}
-                      </Typography>
-                    </button>
+                        <div className="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-sm bg-[#F2EAD9]">
+                          {duty.imageUrl ? (
+                            <img
+                              src={duty.imageUrl}
+                              alt=""
+                              className="size-full object-cover"
+                            />
+                          ) : (
+                            <Icon
+                              name="duty"
+                              size={18}
+                              className="text-[#7A5A2E]"
+                            />
+                          )}
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <Typography
+                            as="div"
+                            variant="bodySm"
+                            weight="semibold"
+                            truncate
+                          >
+                            {duty.name}
+                          </Typography>
+                          {totalWearers > 0 && (
+                            <Typography
+                              as="div"
+                              variant="micro"
+                              tone="secondary"
+                              className="mt-0.5"
+                            >
+                              対象メンバー{" "}
+                              {allSelected
+                                ? `全${totalWearers}人`
+                                : `${selectedWearers} / ${totalWearers}人`}
+                            </Typography>
+                          )}
+                        </div>
+                      </button>
+                      {totalWearers > 0 && (
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          disabled={!checked}
+                          onClick={() => setOpenDetailHatId(duty.hatId)}
+                        >
+                          詳細
+                        </Button>
+                      )}
+                    </div>
                   );
                 })}
               </Card>
@@ -527,12 +686,96 @@ const SplitterNew: FC = () => {
               {isPreviewing ? "プレビューを準備中…" : "プレビューを見る"}
             </Button>
           </div>
+
+          <Dialog
+            open={!!openDetailHatId}
+            onOpenChange={(next) => {
+              if (!next) setOpenDetailHatId(null);
+            }}
+          >
+            <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle>
+                  {openDetailDuty?.detail?.name ?? "当番"} の対象メンバー
+                </DialogTitle>
+                <DialogDescription>
+                  この当番で分配対象にするメンバーを選択します。
+                </DialogDescription>
+              </DialogHeader>
+              {openDetailDuty?.option && openDetailDuty.role ? (
+                <ul className="flex flex-col">
+                  {openDetailDuty.option.wearers.map((wearer, i) => {
+                    const lower = wearer.toLowerCase();
+                    const info = wearerInfoByAddress.get(lower);
+                    const name = info?.name ?? abbreviateAddress(wearer);
+                    const checked = openDetailDuty.role?.wearers.some(
+                      (w) => w.toLowerCase() === lower,
+                    );
+                    return (
+                      <li
+                        key={wearer}
+                        className={cn(
+                          "flex items-center gap-3 py-2.5",
+                          i > 0 && "border-t border-border",
+                        )}
+                      >
+                        <Checkbox
+                          id={`wearer-${wearer}`}
+                          checked={checked}
+                          onCheckedChange={() =>
+                            openDetailDuty.option &&
+                            toggleWearer(openDetailDuty.option.hatId, wearer)
+                          }
+                        />
+                        <Avatar size="default" className="size-9">
+                          {info?.avatar && (
+                            <AvatarImage src={info.avatar} alt="" />
+                          )}
+                          <AvatarFallback seed={name} />
+                        </Avatar>
+                        <label
+                          htmlFor={`wearer-${wearer}`}
+                          className="flex min-w-0 flex-1 cursor-pointer flex-col"
+                        >
+                          <Typography
+                            as="span"
+                            variant="bodySm"
+                            weight="semibold"
+                            truncate
+                          >
+                            {name}
+                          </Typography>
+                          <Typography
+                            as="span"
+                            variant="micro"
+                            tone="secondary"
+                            className="truncate font-mono"
+                          >
+                            {abbreviateAddress(wearer)}
+                          </Typography>
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <Typography
+                  variant="bodySm"
+                  tone="secondary"
+                  className="py-4 text-center"
+                >
+                  メンバー情報を読み込み中…
+                </Typography>
+              )}
+            </DialogContent>
+          </Dialog>
         </div>
       )}
 
       {step === "preview" && preview && (
-        <div className="flex flex-col gap-5">
-          <div className="px-4">
+        <div className="flex flex-col gap-5 px-4 md:grid md:grid-cols-[2fr_1fr] md:gap-6 md:px-6">
+          {/* Left column (mobile = full width, desktop = 2/3): donut + breakdown */}
+          <div className="flex min-w-0 flex-col gap-5 md:gap-4">
             <Card
               className="items-center gap-3 px-5 py-5 text-center"
               style={{
@@ -558,56 +801,23 @@ const SplitterNew: FC = () => {
                 {splitterName}
               </Typography>
             </Card>
+
+            <section className="flex flex-col gap-2">
+              <SectionLabel className="px-0">分配の内訳</SectionLabel>
+              <SplitBreakdownCard
+                recipients={previewBreakdownRows}
+                nameByAddress={previewNameByAddress}
+              />
+            </section>
           </div>
 
-          <SectionLabel className="px-5">分配の内訳</SectionLabel>
-          <div className="px-4">
-            <Card className="gap-0 p-0">
-              {preview.list.map((r, i) => {
-                const entry = previewNameByAddress.get(r.address.toLowerCase());
-                const name = entry?.name ?? abbreviateAddress(r.address);
-                const pct =
-                  preview.totalOwnership > 0
-                    ? (r.ownership / preview.totalOwnership) * 100
-                    : 0;
-                return (
-                  <div
-                    key={r.address}
-                    className={cn(
-                      "flex items-center gap-3 px-4 py-3",
-                      i > 0 && "border-t border-border",
-                    )}
-                  >
-                    <Avatar size="default" className="size-8">
-                      {entry?.avatar && (
-                        <AvatarImage src={entry.avatar} alt="" />
-                      )}
-                      <AvatarFallback seed={name} />
-                    </Avatar>
-                    <Typography
-                      as="div"
-                      variant="bodySm"
-                      weight="semibold"
-                      truncate
-                      className="min-w-0 flex-1"
-                    >
-                      {name}
-                    </Typography>
-                    <Typography
-                      as="span"
-                      variant="bodySm"
-                      weight="bold"
-                      className="tabular-nums"
-                    >
-                      {pct.toFixed(2)}%
-                    </Typography>
-                  </div>
-                );
-              })}
-            </Card>
-          </div>
+          {/* Right column (mobile = below, desktop = 1/3): rule + actions */}
+          <aside className="flex flex-col gap-4">
+            <section className="flex flex-col gap-2">
+              <SectionLabel className="px-0">分配ルール</SectionLabel>
+              <RuleCard weights={previewWeights} />
+            </section>
 
-          <div className="px-4">
             <Card
               className="gap-1 px-3.5 py-3"
               style={{
@@ -621,49 +831,42 @@ const SplitterNew: FC = () => {
                 weight="bold"
                 className="text-[#7A5A2E]"
               >
-                分配のもとになった要素
-              </Typography>
-              <Typography
-                as="div"
-                variant="caption"
-                className="leading-relaxed"
-              >
-                ・ 当番への参加（{dutyWeight}%）
-                <br />・ サンクスの受け取り・送付（{100 - dutyWeight}%）
+                対象にした当番
               </Typography>
               <Typography
                 as="div"
                 variant="micro"
                 tone="secondary"
-                className="mt-1"
+                className="mt-0.5 leading-relaxed"
               >
-                対象の当番:{" "}
                 {Object.values(roles)
                   .filter((r) => r.active)
                   .map((r) => dutyNameById.get(r.hatId.toLowerCase()) ?? "当番")
                   .join("、")}
               </Typography>
             </Card>
-          </div>
 
-          <div className="flex gap-2.5 px-4 pt-2">
-            <Button
-              variant="secondary"
-              onClick={() => setStep("form")}
-              disabled={isLoading}
-              className="shrink-0"
-            >
-              戻って修正
-            </Button>
-            <Button
-              variant="primary"
-              onClick={handleCreate}
-              disabled={isLoading}
-              className="flex-1"
-            >
-              {isLoading ? "作成中…" : "作成する"}
-            </Button>
-          </div>
+            <div className="flex gap-2.5 pt-1 md:flex-col md:gap-2">
+              <Button
+                variant="primary"
+                onClick={handleCreate}
+                disabled={isLoading}
+                full
+                className="md:order-1"
+              >
+                {isLoading ? "作成中…" : "作成する"}
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={() => setStep("form")}
+                disabled={isLoading}
+                full
+                className="md:order-2"
+              >
+                戻って修正
+              </Button>
+            </div>
+          </aside>
         </div>
       )}
     </div>
@@ -672,28 +875,67 @@ const SplitterNew: FC = () => {
 
 export default SplitterNew;
 
-// ─── PercentRow ────────────────────────────────────────────────────────────
+// ─── WeightLabels ──────────────────────────────────────────────────────────
 
-interface PercentRowProps {
-  label: string;
-  value: number;
-  valueColor: string;
+interface WeightLabelsProps {
+  leftLabel: string;
+  leftValue: number;
+  leftColor: string;
+  rightLabel: string;
+  rightValue: number;
+  rightColor: string;
 }
 
-const PercentRow: FC<PercentRowProps> = ({ label, value, valueColor }) => (
-  <div className="flex items-baseline justify-between text-[13px]">
-    <Typography as="span" variant="bodySm" weight="semibold">
-      {label}
-    </Typography>
-    <Typography
-      as="span"
-      variant="bodySm"
-      weight="bold"
-      className="tabular-nums"
-      style={{ color: valueColor }}
-    >
-      {value}%
-    </Typography>
+// One opposing-ends row above the slider: left side hugs the start of the
+// track, right side hugs the end. Each side stacks its percentage above the
+// label so the colour-coded value sits visually closer to the slider.
+const WeightLabels: FC<WeightLabelsProps> = ({
+  leftLabel,
+  leftValue,
+  leftColor,
+  rightLabel,
+  rightValue,
+  rightColor,
+}) => (
+  <div className="flex items-end justify-between gap-2 text-[13px]">
+    <div className="flex flex-col items-start">
+      <Typography
+        as="span"
+        variant="bodySm"
+        weight="bold"
+        className="tabular-nums leading-none"
+        style={{ color: leftColor }}
+      >
+        {leftValue}%
+      </Typography>
+      <Typography
+        as="span"
+        variant="caption"
+        weight="semibold"
+        className="mt-0.5"
+      >
+        {leftLabel}
+      </Typography>
+    </div>
+    <div className="flex flex-col items-end">
+      <Typography
+        as="span"
+        variant="bodySm"
+        weight="bold"
+        className="tabular-nums leading-none"
+        style={{ color: rightColor }}
+      >
+        {rightValue}%
+      </Typography>
+      <Typography
+        as="span"
+        variant="caption"
+        weight="semibold"
+        className="mt-0.5"
+      >
+        {rightLabel}
+      </Typography>
+    </div>
   </div>
 );
 
@@ -703,16 +945,23 @@ interface PercentSliderProps {
   value: number;
   onChange: (next: number) => void;
   ariaLabel: string;
-  accentColor?: string;
+  /** Colour of the track left of the thumb (the "left label" side). */
+  leftColor: string;
+  /** Colour of the track right of the thumb (the "right label" side). */
+  rightColor: string;
 }
 
-// Native range styled to fit the design tokens — same accent as the legacy
-// Chakra slider, but tiny enough to avoid introducing a new dependency.
+// Native range whose track is painted via a linear-gradient — splitting at the
+// current value — so each side carries its label's brand colour. The thumb is
+// solid white with a dark border so it stays visible against either side of
+// the track. (Native `::-webkit-slider-runnable-track` styling is unreliable
+// across browsers; a gradient background sidesteps the inconsistency.)
 const PercentSlider: FC<PercentSliderProps> = ({
   value,
   onChange,
   ariaLabel,
-  accentColor = "var(--color-primary)",
+  leftColor,
+  rightColor,
 }) => (
   <input
     type="range"
@@ -722,12 +971,9 @@ const PercentSlider: FC<PercentSliderProps> = ({
     value={value}
     onChange={(e) => onChange(Number(e.target.value))}
     aria-label={ariaLabel}
-    className="h-2 w-full cursor-pointer appearance-none rounded-full bg-[#F0EBE0] outline-none focus-visible:ring-2 focus-visible:ring-ring/40 [&::-moz-range-thumb]:size-5 [&::-moz-range-thumb]:cursor-pointer [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-white [&::-moz-range-thumb]:shadow-2 [&::-webkit-slider-thumb]:size-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:shadow-2"
-    style={
-      {
-        accentColor,
-        "--thumb-color": accentColor,
-      } as React.CSSProperties
-    }
+    className="h-2 w-full cursor-pointer appearance-none rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring/40 [&::-moz-range-thumb]:size-5 [&::-moz-range-thumb]:cursor-pointer [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border [&::-moz-range-thumb]:border-text-secondary/40 [&::-moz-range-thumb]:bg-white [&::-moz-range-thumb]:shadow-2 [&::-webkit-slider-thumb]:size-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border [&::-webkit-slider-thumb]:border-text-secondary/40 [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow-2"
+    style={{
+      background: `linear-gradient(to right, ${leftColor} 0%, ${leftColor} ${value}%, ${rightColor} ${value}%, ${rightColor} 100%)`,
+    }}
   />
 );

--- a/pkgs/frontend/app/routes/$treeId_.thankstoken.send.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.thankstoken.send.tsx
@@ -6,11 +6,6 @@ import type { NameData } from "namestone-sdk";
 import { type FC, type ReactNode, useMemo, useState } from "react";
 import { LuCheck } from "react-icons/lu";
 import { useNavigate, useParams } from "react-router";
-// Sonner — appends its stylesheet to the END of <head> on module eval, so
-// loading it at route-module level is safe for hydration. react-toastify
-// uses `insertBefore(..., firstChild)` which shifts every expected <meta>
-// position and breaks SSR hydration on direct loads (see commit dfd24c0
-// + #422 migration).
 import { toast } from "sonner";
 import { ipfs2https } from "utils/ipfs";
 import { abbreviateAddress } from "utils/wallet";

--- a/pkgs/frontend/app/routes/transaction.tsx
+++ b/pkgs/frontend/app/routes/transaction.tsx
@@ -3,7 +3,7 @@ import { publicClient } from "hooks/useViem";
 import { useActiveWallet } from "hooks/useWallet";
 import { type FC, useCallback, useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 import { parseEther } from "viem";
 import { BasicButton } from "~/components/BasicButton";
 import { PageHeader } from "~/components/PageHeader";

--- a/pkgs/frontend/hooks/useSplitsCreator.ts
+++ b/pkgs/frontend/hooks/useSplitsCreator.ts
@@ -2,7 +2,7 @@ import type { Split } from "@0xsplits/splits-sdk";
 import { useQuery } from "@tanstack/react-query";
 import { SPLITS_CREATOR_ABI } from "abi/splits";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 import { getSplitsWriteClient, splitsDataClient } from "utils/splits";
 import { type AbiItemArgs, type Address, parseEventLogs } from "viem";
 import { currentChain, publicClient } from "./useViem";
@@ -113,23 +113,28 @@ export const useSplitsCreatorRelatedSplits = (splitsCreator?: Address) => {
   return { isLoading, splits };
 };
 
-export const useSplit = (contractAddress: Address) => {
+export const useSplit = (contractAddress: Address | undefined) => {
   const { wallet } = useActiveWallet();
 
   const splitEarnings = useQuery({
     queryKey: ["split", contractAddress],
+    // React Query forbids `undefined` returns from a queryFn — gate via
+    // `enabled` so we never enter the function without a real address.
+    enabled: !!contractAddress && !!splitsDataClient,
     queryFn: async () => {
-      if (!contractAddress || !splitsDataClient) return;
+      if (!contractAddress || !splitsDataClient) return null;
       try {
+        // Omit `erc20TokenList` so the SDK auto-discovers every ERC20 ever
+        // transferred to this split via `getLogs` (requires the Alchemy-backed
+        // public client, wired up in `utils/splits.ts`).
         const res = await splitsDataClient.getSplitEarnings({
           chainId: currentChain.id,
           splitAddress: contractAddress.toLocaleLowerCase(),
-          erc20TokenList: ["0x652b67d6BA758CC604940FAd585DC638C3F4a6A6"],
         });
-        return res;
+        return res ?? null;
       } catch (error) {
         console.log(error);
-        return;
+        return null;
       }
     },
     staleTime: 1000 * 60 * 5,
@@ -138,11 +143,11 @@ export const useSplit = (contractAddress: Address) => {
   const [isDistributing, setIsDistributing] = useState(false);
   const distribute = useCallback(
     async (tokenAddress: Address) => {
-      if (!wallet) return;
+      if (!wallet || !contractAddress) return;
       setIsDistributing(true);
       const client = getSplitsWriteClient(wallet);
       await client.splitV2.distribute({
-        splitAddress: contractAddress as Address,
+        splitAddress: contractAddress,
         tokenAddress,
         distributorAddress: wallet.account.address,
       });
@@ -164,16 +169,16 @@ export const useUserEarnings = () => {
   const userEarnings = useQuery({
     queryKey: ["userEarnings"],
     queryFn: async () => {
-      if (!wallet || !splitsDataClient) return;
+      if (!wallet || !splitsDataClient) return null;
       try {
         const res = await splitsDataClient.getUserEarnings({
           chainId: currentChain.id,
           userAddress: wallet.account.address,
         });
-        return res;
+        return res ?? null;
       } catch (error) {
         console.log(error);
-        return;
+        return null;
       }
     },
     enabled: !!wallet && !!splitsDataClient,

--- a/pkgs/frontend/hooks/useViem.ts
+++ b/pkgs/frontend/hooks/useViem.ts
@@ -14,32 +14,22 @@ export const currentChain =
           ? base
           : sepolia;
 
-export const currentChainRPCBaseURL =
+// Chain-specific Alchemy RPC URL. Centralised so both `publicClient` (fallback
+// transport, used by the rest of the app) and `alchemyPublicClient` (single
+// transport, used by the Splits SDK so its Alchemy detection works) share the
+// exact same URL string. See `alchemyPublicClient` below for the why.
+const alchemyRpcUrl =
   chainId === 1
-    ? [http(`https://eth.g.alchemy.com/v2/${import.meta.env.VITE_ALCHEMY_KEY}`)]
+    ? `https://eth.g.alchemy.com/v2/${import.meta.env.VITE_ALCHEMY_KEY}`
     : chainId === 11155111
-      ? [
-          http(
-            `https://eth-sepolia.g.alchemy.com/v2/${import.meta.env.VITE_ALCHEMY_KEY}`,
-          ),
-        ]
+      ? `https://eth-sepolia.g.alchemy.com/v2/${import.meta.env.VITE_ALCHEMY_KEY}`
       : chainId === 10
-        ? [
-            http(
-              `https://opt-mainnet.g.alchemy.com/v2/${import.meta.env.VITE_ALCHEMY_KEY}`,
-            ),
-          ]
+        ? `https://opt-mainnet.g.alchemy.com/v2/${import.meta.env.VITE_ALCHEMY_KEY}`
         : chainId === 8453
-          ? [
-              http(
-                `https://base-mainnet.g.alchemy.com/v2/${import.meta.env.VITE_ALCHEMY_KEY}`,
-              ),
-            ]
-          : [
-              http(
-                `https://eth-sepolia.g.alchemy.com/v2/${import.meta.env.VITE_ALCHEMY_KEY}`,
-              ),
-            ];
+          ? `https://base-mainnet.g.alchemy.com/v2/${import.meta.env.VITE_ALCHEMY_KEY}`
+          : `https://eth-sepolia.g.alchemy.com/v2/${import.meta.env.VITE_ALCHEMY_KEY}`;
+
+export const currentChainRPCBaseURL = [http(alchemyRpcUrl)];
 
 /**
  * Public client for fetching data from the blockchain
@@ -47,4 +37,18 @@ export const currentChainRPCBaseURL =
 export const publicClient = createPublicClient({
   chain: currentChain,
   transport: fallback([http(), ...currentChainRPCBaseURL]),
+});
+
+// The Splits SDK auto-discovers ERC20s deposited to a Split via `getLogs` when
+// `erc20TokenList` is omitted, but it only takes that path after sniffing the
+// public client's `transport.url` for `.alchemy.` / `.infura.` (see
+// `@0xsplits/splits-sdk/dist/src/utils/requests.js:isAlchemyPublicClient`).
+// viem's `fallback` transport has no top-level `url`, so the sniff fails on
+// `publicClient` and the SDK throws "Token list required if public client is
+// not alchemy or infura". This single-transport client exposes the Alchemy URL
+// directly so the SDK takes the discovery path. Use it only for the Splits
+// SDK; everything else should keep using `publicClient` for fallback redundancy.
+export const alchemyPublicClient = createPublicClient({
+  chain: currentChain,
+  transport: http(alchemyRpcUrl),
 });

--- a/pkgs/frontend/package.json
+++ b/pkgs/frontend/package.json
@@ -57,7 +57,6 @@
     "react-icons": "^5.4.0",
     "react-router": "^7.15.0",
     "react-router-dom": "^7.15.0",
-    "react-toastify": "^11.0.3",
     "sonner": "^2.0.7",
     "swiper": "^11.2.6",
     "tailwind-merge": "^3.0.1",

--- a/pkgs/frontend/utils/splits.ts
+++ b/pkgs/frontend/utils/splits.ts
@@ -1,13 +1,16 @@
 import { SplitsClient } from "@0xsplits/splits-sdk";
-import { currentChain, publicClient } from "hooks/useViem";
+import { alchemyPublicClient, currentChain } from "hooks/useViem";
 
+// Pass the Alchemy-only client (not the fallback `publicClient`) so the SDK's
+// auto-discovery of ERC20s deposited to a Split works — see the comment on
+// `alchemyPublicClient` in `hooks/useViem.ts`.
 export const splitsDataClient = new SplitsClient({
   chainId: currentChain.id,
   apiConfig: {
     apiKey: import.meta.env.VITE_SPLITS_API_KEY,
   },
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-  publicClient: publicClient as any,
+  publicClient: alchemyPublicClient as any,
 }).dataClient;
 
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -20,6 +23,6 @@ export const getSplitsWriteClient = (walletClient: any) => {
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     walletClient: walletClient as any,
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-    publicClient: publicClient as any,
+    publicClient: alchemyPublicClient as any,
   });
 };

--- a/pkgs/frontend/vite.config.ts
+++ b/pkgs/frontend/vite.config.ts
@@ -118,7 +118,6 @@ export default defineConfig({
   optimizeDeps: {
     include: [
       "@privy-io/react-auth",
-      "react-toastify",
       "react-i18next",
       "@apollo/client",
       "@tanstack/react-query",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,9 +292,6 @@ importers:
       react-router-dom:
         specifier: ^7.15.0
         version: 7.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-toastify:
-        specifier: ^11.0.3
-        version: 11.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -11882,12 +11879,6 @@ packages:
       '@types/react':
         optional: true
 
-  react-toastify@11.0.5:
-    resolution: {integrity: sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==}
-    peerDependencies:
-      react: ^18 || ^19
-      react-dom: ^18 || ^19
-
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -15337,7 +15328,7 @@ snapshots:
   '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
     transitivePeerDependencies:
@@ -16125,9 +16116,9 @@ snapshots:
 
   '@babel/preset-env@7.27.2(@babel/core@7.29.0)':
     dependencies:
-      '@babel/compat-data': 7.27.3
+      '@babel/compat-data': 7.29.3
       '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
       '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.27.1(@babel/core@7.29.0)
@@ -23251,7 +23242,7 @@ snapshots:
 
   axios@1.6.7:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.3.4)
+      follow-redirects: 1.15.9
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -23259,7 +23250,7 @@ snapshots:
 
   axios@1.9.0:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.3.4)
+      follow-redirects: 1.15.9
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -23313,7 +23304,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.13(@babel/core@7.29.0):
     dependencies:
-      '@babel/compat-data': 7.27.3
+      '@babel/compat-data': 7.29.3
       '@babel/core': 7.29.0
       '@babel/helper-define-polyfill-provider': 0.6.4(@babel/core@7.29.0)
       semver: 6.3.1
@@ -25859,6 +25850,8 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.15.9: {}
+
   follow-redirects@1.15.9(debug@4.3.4):
     optionalDependencies:
       debug: 4.3.4
@@ -26842,7 +26835,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.9(debug@4.3.4)
+      follow-redirects: 1.15.9
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -30222,12 +30215,6 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.23
-
-  react-toastify@11.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:


### PR DESCRIPTION
## Summary

Phase 3 renewal of the split (分配) screens — parent tracking issue [#418](https://github.com/hackdays-io/toban/issues/418).

- [#440](https://github.com/hackdays-io/toban/issues/440) — 分配一覧画面のリニューアル
- [#441](https://github.com/hackdays-io/toban/issues/441) — 分配詳細画面の追加（新規ルート \`/splits/\$splitId\`）
- [#442](https://github.com/hackdays-io/toban/issues/442) — 分配ルール作成フロー（form → preview → done）

### What changed

- **Splits list (\`/splits\`)** — mobile card list with DonutChart + recipient chips, desktop master-detail. ENS + address copy buttons on each item.
- **Split detail (\`/splits/\$splitId\`)** — new route. DonutChart + RuleCard 2-column, ranking list ("分配の内訳"), claimable balances, address/ENS copy under title.
- **Split creation (\`/splits/new\`)** — 3-step flow (form → preview → done) with StepBar. Sliders with two-tone tracks (left side = left label colour, right side = right label colour) and pure-white thumbs. Per-duty wearer selection via dialog. PC preview is 2-column (donut + breakdown on the left, rule + actions on the right).
- **Shared composites** — \`composite/donut-chart.tsx\` (with Ladle story), \`splits/RuleCard.tsx\`, \`splits/SplitBreakdownCard.tsx\`. Detail and preview now render the same rule card and breakdown list.
- **Splits SDK wiring** — extracted an Alchemy-only \`alchemyPublicClient\` in \`hooks/useViem.ts\` and passed it to the Splits SDK so its \`getLogs\`-based auto-discovery of deposited ERC20s actually fires. Dropped the hardcoded \`erc20TokenList\`.
- **Unclaimed-token amount fix** — switched from \`Number(formattedAmount).toFixed(4)\` (lossy + rounds) to a 4-decimal *truncation* of the SDK's precise decimal string so the displayed value matches splits.org.
- **react-toastify → sonner** — finished the migration started in #422. Dropped \`react-toastify\` from \`package.json\`, removed \`<ToastContainer />\` and the CSS \`<link>\`, updated 7 import sites.
- **Bug fix** — \`useSplit\` / \`useUserEarnings\` queryFn returning \`undefined\` raised "Query data cannot be undefined" on direct loads of the detail route. Added \`enabled\` gates + \`return null\` paths.

## Test plan

- [ ] \`/splits\` renders DonutCards on mobile and the master-detail preview on desktop
- [ ] Address + ENS copy buttons toast on success
- [ ] \`/splits/\$splitId\` loads, rule card resolves weights (decoded from creation calldata via Alchemy)
- [ ] 未分配のポイント matches splits.org for the same split
- [ ] \`/splits/new\` form → preview → done flow completes, scroll returns to top on each step
- [ ] Per-duty 詳細 dialog toggles wearers immediately on check/uncheck (no commit button)
- [ ] Sliders show two-tone tracks (toban=role / thanks=contrib, recv=contrib / sent=primary)
- [ ] Cypress E2E for the existing split creation path still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)