### PR TITLE
feat(frontend): renew duty create/edit form and assignment flow (#436, #437)

### DIFF
--- a/pkgs/frontend/app/components/roles/DutyForm.tsx
+++ b/pkgs/frontend/app/components/roles/DutyForm.tsx
@@ -1,9 +1,8 @@
-import { type FC, useId, useState } from "react";
+import { type FC, useId } from "react";
 import type { HatsDetailsAttributes } from "types/hats";
-import { Chip } from "~/components/composite/chip";
 import { FieldLabel } from "~/components/composite/field-label";
+import { RoleAttributesEditor } from "~/components/roles/RoleAttributesEditor";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
-import { Button } from "~/components/ui/button";
 import { Icon, type IconName } from "~/components/ui/icon";
 import { Input } from "~/components/ui/input";
 import { Textarea } from "~/components/ui/textarea";
@@ -54,40 +53,12 @@ export const DutyForm: FC<DutyFormProps> = ({
 }) => {
   const nameInputId = useId();
   const descriptionInputId = useId();
-  const [draftResponsibility, setDraftResponsibility] = useState("");
-  const [draftAuthority, setDraftAuthority] = useState("");
 
   const update = <K extends keyof DutyFormValues>(
     key: K,
     next: DutyFormValues[K],
   ) => {
     onChange({ ...value, [key]: next });
-  };
-
-  const addResponsibility = () => {
-    const label = draftResponsibility.trim();
-    if (!label) return;
-    update("responsibilities", [...value.responsibilities, { label }]);
-    setDraftResponsibility("");
-  };
-  const removeResponsibility = (index: number) => {
-    update(
-      "responsibilities",
-      value.responsibilities.filter((_, i) => i !== index),
-    );
-  };
-
-  const addAuthority = () => {
-    const label = draftAuthority.trim();
-    if (!label) return;
-    update("authorities", [...value.authorities, { label }]);
-    setDraftAuthority("");
-  };
-  const removeAuthority = (index: number) => {
-    update(
-      "authorities",
-      value.authorities.filter((_, i) => i !== index),
-    );
   };
 
   const fallbackIconName = FALLBACK_PREVIEW_ICON[fallbackIcon];
@@ -175,86 +146,26 @@ export const DutyForm: FC<DutyFormProps> = ({
       </div>
 
       {/* Responsibilities */}
-      <div className="px-5">
-        <FieldLabel>責任</FieldLabel>
-        {value.responsibilities.length > 0 && (
-          <div className="mb-2 flex flex-wrap gap-2">
-            {value.responsibilities.map((item, index) => (
-              <Chip
-                key={`${item.label}-${index}`}
-                onClick={() => removeResponsibility(index)}
-                aria-label={`${item.label} を削除`}
-              >
-                {item.label}
-                <Icon name="close" size={12} />
-              </Chip>
-            ))}
-          </div>
-        )}
-        <div className="flex gap-2">
-          <Input
-            value={draftResponsibility}
-            onChange={(e) => setDraftResponsibility(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.nativeEvent.isComposing) {
-                e.preventDefault();
-                addResponsibility();
-              }
-            }}
-            placeholder="例：当番表をまとめる"
-            data-testid="responsibility-input"
-          />
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={addResponsibility}
-            disabled={!draftResponsibility.trim()}
-          >
-            追加
-          </Button>
-        </div>
-      </div>
+      <RoleAttributesEditor
+        noun="責任"
+        items={value.responsibilities}
+        onChange={(next) => update("responsibilities", next)}
+        disabled={disabled}
+        labelPlaceholder="例：当番表をまとめる"
+        descriptionPlaceholder="この責任の進め方や範囲を入力"
+        testIdPrefix="responsibility"
+      />
 
       {/* Authorities */}
-      <div className="px-5">
-        <FieldLabel>権限</FieldLabel>
-        {value.authorities.length > 0 && (
-          <div className="mb-2 flex flex-wrap gap-2">
-            {value.authorities.map((item, index) => (
-              <Chip
-                key={`${item.label}-${index}`}
-                onClick={() => removeAuthority(index)}
-                aria-label={`${item.label} を削除`}
-              >
-                {item.label}
-                <Icon name="close" size={12} />
-              </Chip>
-            ))}
-          </div>
-        )}
-        <div className="flex gap-2">
-          <Input
-            value={draftAuthority}
-            onChange={(e) => setDraftAuthority(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.nativeEvent.isComposing) {
-                e.preventDefault();
-                addAuthority();
-              }
-            }}
-            placeholder="例：メンバーを招待"
-            data-testid="authority-input"
-          />
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={addAuthority}
-            disabled={!draftAuthority.trim()}
-          >
-            追加
-          </Button>
-        </div>
-      </div>
+      <RoleAttributesEditor
+        noun="権限"
+        items={value.authorities}
+        onChange={(next) => update("authorities", next)}
+        disabled={disabled}
+        labelPlaceholder="例：メンバーを招待"
+        descriptionPlaceholder="この権限でできることを入力"
+        testIdPrefix="authority"
+      />
     </div>
   );
 };

--- a/pkgs/frontend/app/components/roles/RoleAttributeDialog.tsx
+++ b/pkgs/frontend/app/components/roles/RoleAttributeDialog.tsx
@@ -1,0 +1,140 @@
+import { type FC, useEffect, useId, useState } from "react";
+import { FieldLabel } from "~/components/composite/field-label";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import {
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "~/components/ui/sheet";
+import { Textarea } from "~/components/ui/textarea";
+
+export interface RoleAttributeValue {
+  label: string;
+  description?: string;
+}
+
+interface RoleAttributeDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** `add` starts from an empty form; `edit` pre-fills from `value`. */
+  mode: "add" | "edit";
+  /** Noun shown in the title, e.g. "責任" / "権限". */
+  noun: string;
+  /** Initial value — required for `mode="edit"`. */
+  value?: RoleAttributeValue;
+  onSubmit: (value: RoleAttributeValue) => void;
+  labelPlaceholder?: string;
+  descriptionPlaceholder?: string;
+}
+
+// Add / edit dialog for a single role attribute (責任 or 権限). Renders as a
+// bottom Sheet on mobile and a centered panel on desktop — the Sheet+`md:`
+// override pattern already used by the parked delete sheet in the duty edit
+// route, so it stays SSR-safe (pure CSS, no media-query hook).
+export const RoleAttributeDialog: FC<RoleAttributeDialogProps> = ({
+  open,
+  onOpenChange,
+  mode,
+  noun,
+  value,
+  onSubmit,
+  labelPlaceholder,
+  descriptionPlaceholder,
+}) => {
+  const labelId = useId();
+  const descriptionId = useId();
+  const [label, setLabel] = useState("");
+  const [description, setDescription] = useState("");
+
+  // Sync the form to the incoming value each time the dialog opens — covers
+  // both add (empty) and edit (pre-filled) without leaking the previous edit.
+  useEffect(() => {
+    if (open) {
+      setLabel(value?.label ?? "");
+      setDescription(value?.description ?? "");
+    }
+  }, [open, value]);
+
+  const trimmedLabel = label.trim();
+  const canSubmit = trimmedLabel.length > 0;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    onSubmit({
+      label: trimmedLabel,
+      description: description.trim() || undefined,
+    });
+    onOpenChange(false);
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className="md:left-1/2 md:right-auto md:w-full md:max-w-md md:-translate-x-1/2"
+      >
+        <SheetHeader>
+          <SheetTitle>
+            {noun}を{mode === "add" ? "追加" : "編集"}
+          </SheetTitle>
+        </SheetHeader>
+
+        <div className="flex flex-col gap-4 px-5 pt-1 pb-2">
+          <div>
+            <FieldLabel htmlFor={labelId}>
+              ラベル <span className="text-danger">*</span>
+            </FieldLabel>
+            <Input
+              id={labelId}
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+                  e.preventDefault();
+                  handleSubmit();
+                }
+              }}
+              placeholder={labelPlaceholder}
+              data-testid="role-attribute-label-input"
+            />
+          </div>
+          <div>
+            <FieldLabel htmlFor={descriptionId}>説明</FieldLabel>
+            <Textarea
+              id={descriptionId}
+              rows={3}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={descriptionPlaceholder}
+              data-testid="role-attribute-description-input"
+            />
+          </div>
+        </div>
+
+        <SheetFooter className="flex-row gap-2.5">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            className="shrink-0"
+          >
+            キャンセル
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            data-testid="role-attribute-submit"
+            className="flex-1"
+          >
+            {mode === "add" ? "追加" : "保存"}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/pkgs/frontend/app/components/roles/RoleAttributesEditor.tsx
+++ b/pkgs/frontend/app/components/roles/RoleAttributesEditor.tsx
@@ -1,0 +1,207 @@
+import { type FC, useState } from "react";
+import type { HatsDetailsAttributes } from "types/hats";
+import { Divider } from "~/components/composite/divider";
+import { FieldLabel } from "~/components/composite/field-label";
+import { Button } from "~/components/ui/button";
+import { Card } from "~/components/ui/card";
+import { Icon } from "~/components/ui/icon";
+import {
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "~/components/ui/sheet";
+import { Typography } from "~/components/ui/typography";
+import {
+  RoleAttributeDialog,
+  type RoleAttributeValue,
+} from "./RoleAttributeDialog";
+
+interface RoleAttributesEditorProps {
+  /** Section heading and dialog noun, e.g. "責任" / "権限". */
+  noun: string;
+  items: HatsDetailsAttributes;
+  onChange: (next: HatsDetailsAttributes) => void;
+  disabled?: boolean;
+  labelPlaceholder?: string;
+  descriptionPlaceholder?: string;
+  /** Stable prefix for test ids, e.g. "responsibility". */
+  testIdPrefix?: string;
+}
+
+// Editable list of role attributes ({ label, description } pairs) used inside
+// the duty create/edit form for 責任 and 権限. Each row carries inline edit /
+// delete actions; add + edit happen through a shared `RoleAttributeDialog`,
+// delete through a confirmation Sheet.
+export const RoleAttributesEditor: FC<RoleAttributesEditorProps> = ({
+  noun,
+  items,
+  onChange,
+  disabled,
+  labelPlaceholder,
+  descriptionPlaceholder,
+  testIdPrefix,
+}) => {
+  // `dialogMode` / `dialogIndex` persist while the Sheet animates closed so
+  // the title and pre-filled values don't flicker mid-transition.
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogMode, setDialogMode] = useState<"add" | "edit">("add");
+  const [dialogIndex, setDialogIndex] = useState<number | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
+
+  const openAdd = () => {
+    setDialogMode("add");
+    setDialogIndex(null);
+    setDialogOpen(true);
+  };
+  const openEdit = (index: number) => {
+    setDialogMode("edit");
+    setDialogIndex(index);
+    setDialogOpen(true);
+  };
+  const openDelete = (index: number) => {
+    setDeleteIndex(index);
+    setDeleteOpen(true);
+  };
+
+  const handleSubmit = (value: RoleAttributeValue) => {
+    if (dialogMode === "add") {
+      onChange([...items, value]);
+    } else if (dialogIndex !== null) {
+      // Spread the existing item so non-edited fields (link / imageUrl / gate)
+      // survive the edit.
+      onChange(
+        items.map((item, i) =>
+          i === dialogIndex ? { ...item, ...value } : item,
+        ),
+      );
+    }
+  };
+
+  const handleDelete = () => {
+    if (deleteIndex !== null) {
+      onChange(items.filter((_, i) => i !== deleteIndex));
+    }
+    setDeleteOpen(false);
+  };
+
+  const editingItem =
+    dialogMode === "edit" && dialogIndex !== null
+      ? items[dialogIndex]
+      : undefined;
+  const deletingItem = deleteIndex !== null ? items[deleteIndex] : undefined;
+
+  return (
+    <div className="px-5">
+      <FieldLabel>{noun}</FieldLabel>
+
+      {items.length > 0 && (
+        <Card className="mb-2.5 gap-0 p-0">
+          {items.map((item, index) => (
+            <div key={`${item.label}-${index}`}>
+              {index > 0 && <Divider />}
+              <div className="flex items-start gap-1 py-2 pr-1.5 pl-4">
+                <div className="min-w-0 flex-1 py-1.5">
+                  <Typography as="div" variant="bodySm" weight="semibold">
+                    {item.label}
+                  </Typography>
+                  {item.description && (
+                    <Typography
+                      as="div"
+                      variant="caption"
+                      tone="secondary"
+                      className="mt-0.5 leading-snug"
+                    >
+                      {item.description}
+                    </Typography>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => openEdit(index)}
+                  disabled={disabled}
+                  aria-label={`${item.label} を編集`}
+                  className="flex size-8 shrink-0 items-center justify-center rounded-full text-text-secondary transition-colors hover:bg-bg hover:text-text-primary disabled:opacity-50"
+                >
+                  <Icon name="edit" size={15} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => openDelete(index)}
+                  disabled={disabled}
+                  aria-label={`${item.label} を削除`}
+                  className="flex size-8 shrink-0 items-center justify-center rounded-full text-text-secondary transition-colors hover:bg-[#FBE5E2] hover:text-danger disabled:opacity-50"
+                >
+                  <Icon name="close" size={15} />
+                </button>
+              </div>
+            </div>
+          ))}
+        </Card>
+      )}
+
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={openAdd}
+        disabled={disabled}
+        data-testid={testIdPrefix ? `${testIdPrefix}-add` : undefined}
+      >
+        <Icon name="plus" size={14} />
+        {noun}を追加
+      </Button>
+
+      <RoleAttributeDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        mode={dialogMode}
+        noun={noun}
+        value={editingItem}
+        onSubmit={handleSubmit}
+        labelPlaceholder={labelPlaceholder}
+        descriptionPlaceholder={descriptionPlaceholder}
+      />
+
+      <Sheet open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <SheetContent
+          side="bottom"
+          className="md:left-1/2 md:right-auto md:w-full md:max-w-md md:-translate-x-1/2"
+        >
+          <SheetHeader>
+            <SheetTitle>{noun}を削除しますか？</SheetTitle>
+          </SheetHeader>
+          <div className="px-5">
+            <Typography
+              variant="bodySm"
+              tone="secondary"
+              className="leading-relaxed"
+            >
+              「{deletingItem?.label}」を削除します。この操作は取り消せません。
+            </Typography>
+          </div>
+          <SheetFooter className="flex-row gap-2.5">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setDeleteOpen(false)}
+              className="shrink-0"
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="button"
+              variant="dark"
+              onClick={handleDelete}
+              className="flex-1 bg-danger hover:brightness-110"
+            >
+              削除する
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+};

--- a/pkgs/frontend/app/routes/$treeId_.$hatId_.assign.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.$hatId_.assign.tsx
@@ -1,9 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
-import { useAddressesByNames } from "hooks/useENS";
-import { useGetHat } from "hooks/useHats";
+import { useNamesByAddresses } from "hooks/useENS";
+import { useGetHat, useTreeInfo } from "hooks/useHats";
 import { useMintHatFromTimeFrameModule } from "hooks/useHatsTimeFrameModule";
 import { useGetWorkspace } from "hooks/useWorkspace";
+import type { NameData } from "namestone-sdk";
 import {
   type FC,
   useCallback,
@@ -19,19 +20,23 @@ import { ipfs2https } from "utils/ipfs";
 import { abbreviateAddress, isValidEthAddress } from "utils/wallet";
 import type { Address } from "viem";
 import { Divider } from "~/components/composite/divider";
+import { EmptyState } from "~/components/composite/empty-state";
 import { FieldLabel } from "~/components/composite/field-label";
 import { Row } from "~/components/composite/row";
+import { SectionLabel } from "~/components/composite/section-label";
+import { SummaryRow } from "~/components/composite/summary-row";
 import { ScreenHeader } from "~/components/layout/ScreenHeader";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
+import { Heading } from "~/components/ui/heading";
 import { Icon } from "~/components/ui/icon";
 import { Input } from "~/components/ui/input";
 import { Typography } from "~/components/ui/typography";
 
-const SUGGESTION_LIMIT = 5;
+type Step = "select" | "settings" | "confirm" | "done";
 
-interface Suggestion {
+interface SelectedMember {
   address: Address;
   name?: string;
   avatarUrl?: string;
@@ -52,6 +57,50 @@ const useDutyDetail = (detailsUri?: string) => {
   return data;
 };
 
+// Format a `datetime-local` value (`YYYY-MM-DDTHH:mm`) for display, falling
+// back to a note when the user left the start date unset.
+const formatStart = (value: string): string => {
+  if (!value) return "トランザクション確定時";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "トランザクション確定時";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}/${pad(date.getMonth() + 1)}/${pad(
+    date.getDate(),
+  )} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};
+
+const avatarInitials = (member: SelectedMember): string =>
+  (member.name ?? member.address.slice(2)).slice(0, 2).toUpperCase();
+
+const MemberAvatar: FC<{
+  member: SelectedMember;
+  size?: "default" | "sm" | "lg" | "xl";
+}> = ({ member, size }) => (
+  <Avatar size={size}>
+    {member.avatarUrl && (
+      <AvatarImage src={member.avatarUrl} alt={member.name ?? member.address} />
+    )}
+    <AvatarFallback>{avatarInitials(member)}</AvatarFallback>
+  </Avatar>
+);
+
+const MemberListSkeleton: FC = () => (
+  <Card className="gap-0 overflow-hidden p-0">
+    {["a", "b", "c", "d"].map((k, i) => (
+      <div key={k}>
+        {i > 0 && <Divider inset={64} />}
+        <div className="flex items-center gap-3 px-4 py-3">
+          <div className="size-9 shrink-0 animate-pulse rounded-full bg-[#F0EBDE]" />
+          <div className="flex-1">
+            <div className="h-3 w-24 animate-pulse rounded bg-[#F0EBDE]" />
+            <div className="mt-2 h-2.5 w-32 animate-pulse rounded bg-[#F0EBDE]" />
+          </div>
+        </div>
+      </div>
+    ))}
+  </Card>
+);
+
 const AssignDuty: FC = () => {
   const { treeId, hatId } = useParams();
   const navigate = useNavigate();
@@ -59,7 +108,7 @@ const AssignDuty: FC = () => {
   const { data: workspaceData } = useGetWorkspace({
     workspaceId: treeId || "",
   });
-  const { mintHat, isLoading: isMinting } = useMintHatFromTimeFrameModule(
+  const { mintHat } = useMintHatFromTimeFrameModule(
     workspaceData?.workspace?.hatsTimeFrameModule as Address,
   );
   const { hat } = useGetHat(hatId ?? "");
@@ -68,75 +117,94 @@ const AssignDuty: FC = () => {
   const dutyDescription = detail?.data?.description;
   const dutyImageUrl = ipfs2https(hat?.imageUri);
 
-  // ── Form state ─────────────────────────────────────────────
-  const [input, setInput] = useState("");
-  const [pickedAddress, setPickedAddress] = useState<Address | undefined>();
+  // ── Step machine ───────────────────────────────────────────
+  const [step, setStep] = useState<Step>("select");
+  const [selected, setSelected] = useState<SelectedMember | undefined>();
   const [startDatetime, setStartDatetime] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
 
+  // ── Member directory (select step) ─────────────────────────
+  const tree = useTreeInfo(Number(treeId));
+
+  // Addresses already wearing this duty — excluded from the picker so the
+  // same person can't be assigned twice.
+  const assignedAddresses = useMemo(
+    () =>
+      new Set(
+        (hat?.wearers ?? [])
+          .map((w) => w.id?.toLowerCase())
+          .filter((a): a is string => !!a),
+      ),
+    [hat?.wearers],
+  );
+
+  // Every workspace member (wearers of role hats at level >= 2), deduped and
+  // minus the addresses already assigned to this duty.
+  const memberAddresses = useMemo(() => {
+    if (!tree?.hats) return [];
+    const wearers = tree.hats
+      .filter((h) => h.levelAtLocalTree && h.levelAtLocalTree >= 2)
+      .flatMap((h) => h.wearers ?? [])
+      .map((w) => w.id?.toLowerCase())
+      .filter((a): a is string => !!a);
+    return Array.from(new Set(wearers)).filter(
+      (a) => !assignedAddresses.has(a),
+    );
+  }, [tree, assignedAddresses]);
+
+  const { names: memberNames, isLoading: isMembersLoading } =
+    useNamesByAddresses(memberAddresses);
+
+  // ── Search ─────────────────────────────────────────────────
+  const [input, setInput] = useState("");
   const trimmed = input.trim();
   const isAddressInput = isValidEthAddress(trimmed);
 
-  // Debounce the Namestone resolve so we don't fire on every keystroke.
-  const [debouncedQuery, setDebouncedQuery] = useState("");
-  useEffect(() => {
-    const handle = setTimeout(() => setDebouncedQuery(trimmed), 250);
-    return () => clearTimeout(handle);
-  }, [trimmed]);
-
-  const namestoneTerms = useMemo(() => {
-    if (!debouncedQuery) return undefined;
-    if (isValidEthAddress(debouncedQuery)) return undefined;
-    if (debouncedQuery.startsWith("0x")) return undefined;
-    return [debouncedQuery];
-  }, [debouncedQuery]);
-  const { addresses, isLoading: isSearching } = useAddressesByNames(
-    namestoneTerms,
-    false,
+  // Full resolved directory (search-independent).
+  const allMembers = useMemo<SelectedMember[]>(
+    () =>
+      memberNames
+        .map((g) => g[0])
+        .filter((u): u is NameData => !!u && !!u.address)
+        .map((u) => ({
+          address: u.address as Address,
+          name: u.name || undefined,
+          avatarUrl: ipfs2https(u.text_records?.avatar),
+        })),
+    [memberNames],
   );
 
-  const suggestions = useMemo<Suggestion[]>(() => {
-    if (!namestoneTerms || !addresses?.length) return [];
-    return (addresses[0] ?? [])
-      .filter((entry) => entry.name && entry.address)
-      .slice(0, SUGGESTION_LIMIT)
-      .map(
-        (entry): Suggestion => ({
-          address: entry.address as Address,
-          name: entry.name,
-          avatarUrl: ipfs2https(entry.text_records?.avatar),
-        }),
-      );
-  }, [namestoneTerms, addresses]);
-
-  // Once the user picks a suggestion, collapse the dropdown to that single
-  // row so the others stop drawing the eye. Typing again clears `pickedAddress`
-  // (see the input's onChange) and re-opens the full list.
-  const visibleSuggestions = useMemo<Suggestion[]>(() => {
-    if (!pickedAddress) return suggestions;
-    const picked = suggestions.find(
-      (s) => s.address.toLowerCase() === pickedAddress.toLowerCase(),
+  // Client-side substring filter — matches the thankstoken send picker.
+  const visibleMembers = useMemo<SelectedMember[]>(() => {
+    const q = trimmed.toLowerCase();
+    if (!q) return allMembers;
+    return allMembers.filter(
+      (m) =>
+        m.name?.toLowerCase().includes(q) ||
+        m.address.toLowerCase().includes(q),
     );
-    return picked ? [picked] : [];
-  }, [suggestions, pickedAddress]);
+  }, [allMembers, trimmed]);
 
-  // Resolve the final address: explicit user picks beat exact-match Namestone
-  // hits beat raw address input.
-  const resolvedAddress = useMemo<Address | undefined>(() => {
-    if (isAddressInput) return trimmed as Address;
-    if (pickedAddress) return pickedAddress;
-    const exact = suggestions.find(
-      (s) => s.name?.toLowerCase() === trimmed.toLowerCase(),
-    );
-    return exact?.address;
-  }, [isAddressInput, trimmed, pickedAddress, suggestions]);
+  const directoryLoading = !tree || isMembersLoading;
 
-  const handleSelectSuggestion = useCallback((s: Suggestion) => {
-    if (s.name) setInput(s.name);
-    setPickedAddress(s.address);
-  }, []);
+  // When the user pastes a raw address, resolve it against the directory so a
+  // known member still shows their name, while a non-member can be onboarded
+  // directly.
+  const addressAssigned =
+    isAddressInput && assignedAddresses.has(trimmed.toLowerCase());
+  const addressMember = useMemo(() => {
+    if (!isAddressInput) return undefined;
+    const lower = trimmed.toLowerCase();
+    return allMembers.find((m) => m.address.toLowerCase() === lower);
+  }, [isAddressInput, trimmed, allMembers]);
+  const addressCandidate: SelectedMember = addressMember ?? {
+    address: trimmed as Address,
+  };
 
-  // Reset scroll on mount — AppShell wraps routes in `<main overflow-y-auto>`
-  // so window.scrollTo is a no-op; walk up the DOM to the scroll container.
+  // Reset the scroll container to the top on mount — AppShell wraps routes in
+  // `<main overflow-y-auto>`, so window.scrollTo alone is a no-op; walk up the
+  // DOM to find the actual scroll container. Later steps are short enough that
+  // the browser clamps the scroll position on its own when content shrinks.
   const rootRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const el = rootRef.current;
@@ -154,209 +222,331 @@ const AssignDuty: FC = () => {
     }
   }, []);
 
+  const goToDetail = useCallback(
+    () => navigate(`/${treeId}/${hatId}`),
+    [navigate, treeId, hatId],
+  );
+
+  const chooseMember = useCallback((member: SelectedMember) => {
+    setSelected(member);
+    setStep("settings");
+  }, []);
+
   const handleAssign = useCallback(async () => {
-    if (!hatId) return;
-    if (!resolvedAddress) {
-      toast.error("ユーザー名またはウォレットアドレスを入力してください。");
-      return;
-    }
+    if (!hatId || !selected) return;
     const time = startDatetime
       ? BigInt(Math.floor(new Date(startDatetime).getTime() / 1000))
       : BigInt(0);
+    setSubmitting(true);
     try {
-      await mintHat(BigInt(hatId), resolvedAddress, time);
+      await mintHat(BigInt(hatId), selected.address, time);
       // The receipt resolves the moment the block lands, but the Hats subgraph
-      // still needs a beat to index the new wearer. `useTreeInfo` re-fetches on
-      // mount (no Apollo cache to invalidate), so without this pause we'd
-      // navigate to a detail page whose wearer list hasn't picked up the new
-      // entry yet. 3s matches the duty-create flow in `$treeId_.roles_.new.tsx`.
+      // still needs a beat to index the new wearer. The duty detail page
+      // fetches once on mount, so pause before unlocking the "done" step.
       await new Promise((resolve) => setTimeout(resolve, 3000));
-      toast.success("担当を追加しました。");
-      navigate(`/${treeId}/${hatId}`);
+      setStep("done");
     } catch (error) {
       // viem's UserOperationExecutionError dumps callData + paymaster blobs
       // into `error.message`; surfacing it as a toast is useless to the user.
-      // Log it for debugging but show a short message.
       console.error(error);
       toast.error("エラーが起きました。");
+    } finally {
+      setSubmitting(false);
     }
-  }, [hatId, resolvedAddress, startDatetime, mintHat, navigate, treeId]);
+  }, [hatId, selected, startDatetime, mintHat]);
 
-  const goBack = () => navigate(`/${treeId}/${hatId}`);
-  const showSuggestions =
-    !isAddressInput && trimmed.length > 0 && visibleSuggestions.length > 0;
-  const showNoMatch =
-    !isAddressInput &&
-    trimmed.length > 0 &&
-    !isSearching &&
-    suggestions.length === 0;
+  const memberName = selected
+    ? (selected.name ?? abbreviateAddress(selected.address))
+    : "";
 
   return (
     <div ref={rootRef} className="flex min-h-dvh flex-col bg-bg">
-      <ScreenHeader title="担当を追加" onBack={goBack} />
-
-      {/* Duty preview card */}
-      <div className="px-4 pb-4">
-        <Card className="gap-0 p-4">
-          <div className="flex items-start gap-3">
-            <Avatar size="xl" className="size-16 shrink-0">
-              {dutyImageUrl && (
-                <AvatarImage src={dutyImageUrl} alt={dutyName} />
-              )}
-              <AvatarFallback className="bg-primary-soft text-text-primary">
-                <Icon name="duty" size={24} />
-              </AvatarFallback>
-            </Avatar>
-            <div className="min-w-0 flex-1">
-              <Typography as="div" variant="body" weight="bold" truncate>
-                {dutyName}
-              </Typography>
-              {dutyDescription && (
-                <Typography
-                  as="div"
-                  variant="caption"
-                  tone="secondary"
-                  className="mt-0.5 leading-snug"
-                >
-                  {dutyDescription}
-                </Typography>
-              )}
-            </div>
-          </div>
-        </Card>
-      </div>
-
-      {/* Member input */}
-      <div className="flex flex-col gap-5 pb-6">
-        <div className="px-5">
-          <FieldLabel htmlFor="assign-member">
-            ユーザー名 or ウォレットアドレス
-          </FieldLabel>
-          <Input
-            id="assign-member"
-            value={input}
-            onChange={(e) => {
-              setInput(e.target.value);
-              setPickedAddress(undefined);
-            }}
-            placeholder="例：alice or 0x..."
-            autoComplete="off"
+      {/* ── Step 1: select ──────────────────────────────────── */}
+      {step === "select" && (
+        <>
+          <ScreenHeader
+            title="担当を追加"
+            subtitle={dutyName}
+            onBack={goToDetail}
           />
 
-          {showSuggestions && (
-            <Card className="mt-2 gap-0 overflow-hidden p-0">
-              {visibleSuggestions.map((s, i) => {
-                const isPicked =
-                  pickedAddress?.toLowerCase() === s.address.toLowerCase();
-                return (
-                  <div key={s.address}>
-                    <Row
-                      left={
-                        <Avatar>
-                          {s.avatarUrl && (
-                            <AvatarImage
-                              src={s.avatarUrl}
-                              alt={s.name ?? s.address}
-                            />
-                          )}
-                          <AvatarFallback>
-                            {(s.name ?? s.address).slice(0, 2).toUpperCase()}
-                          </AvatarFallback>
-                        </Avatar>
-                      }
-                      title={s.name ?? abbreviateAddress(s.address)}
-                      subtitle={abbreviateAddress(s.address)}
-                      right={
-                        isPicked ? (
-                          <Icon
-                            name="check"
-                            size={16}
-                            className="text-primary"
-                          />
-                        ) : (
-                          <Icon
-                            name="chevron-right"
-                            size={16}
-                            className="text-text-secondary"
-                          />
-                        )
-                      }
-                      onClick={() => handleSelectSuggestion(s)}
-                      className={isPicked ? "bg-primary-soft/40" : undefined}
-                    />
-                    {i < visibleSuggestions.length - 1 && (
-                      <Divider inset={64} />
-                    )}
-                  </div>
-                );
-              })}
+          <div className="px-4 pb-4">
+            <Card className="gap-0 p-4">
+              <div className="flex items-start gap-3">
+                <Avatar size="xl" className="size-16 shrink-0">
+                  {dutyImageUrl && (
+                    <AvatarImage src={dutyImageUrl} alt={dutyName} />
+                  )}
+                  <AvatarFallback className="bg-primary-soft text-text-primary">
+                    <Icon name="duty" size={24} />
+                  </AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <Typography as="div" variant="body" weight="bold" truncate>
+                    {dutyName}
+                  </Typography>
+                  {dutyDescription && (
+                    <Typography
+                      as="div"
+                      variant="caption"
+                      tone="secondary"
+                      className="mt-0.5 leading-snug"
+                    >
+                      {dutyDescription}
+                    </Typography>
+                  )}
+                </div>
+              </div>
             </Card>
-          )}
+          </div>
 
-          {showNoMatch && (
+          <div className="flex flex-col gap-4 px-4 pb-8">
+            <Input
+              icon={<Icon name="search" size={18} />}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="名前 or ウォレットアドレスで検索"
+              autoComplete="off"
+            />
+
+            {isAddressInput ? (
+              <section>
+                <SectionLabel>指定したアドレス</SectionLabel>
+                {addressAssigned ? (
+                  <Card className="gap-0 p-4">
+                    <Typography
+                      variant="bodySm"
+                      tone="secondary"
+                      className="leading-relaxed"
+                    >
+                      このアドレスはすでにこの当番に割り当てられています。
+                    </Typography>
+                  </Card>
+                ) : (
+                  <Card className="gap-0 overflow-hidden p-0">
+                    <Row
+                      left={<MemberAvatar member={addressCandidate} />}
+                      title={
+                        addressMember?.name ??
+                        abbreviateAddress(trimmed as Address)
+                      }
+                      subtitle={
+                        addressMember
+                          ? abbreviateAddress(trimmed as Address)
+                          : "このアドレスを担当者にする"
+                      }
+                      right={
+                        <Icon
+                          name="chevron-right"
+                          size={16}
+                          className="text-text-secondary"
+                        />
+                      }
+                      onClick={() => chooseMember(addressCandidate)}
+                    />
+                  </Card>
+                )}
+              </section>
+            ) : (
+              <section>
+                <SectionLabel>
+                  {trimmed ? "検索結果" : "メンバー一覧"}
+                </SectionLabel>
+                {directoryLoading ? (
+                  <MemberListSkeleton />
+                ) : visibleMembers.length === 0 ? (
+                  <EmptyState
+                    icon={<Icon name="search" size={22} />}
+                    title={
+                      trimmed
+                        ? "見つかりませんでした"
+                        : "追加できるメンバーがいません"
+                    }
+                    body={
+                      trimmed
+                        ? "別のキーワードで検索するか、ウォレットアドレスを直接入力してください"
+                        : "この当番に追加できるメンバーがいません。ウォレットアドレスを入力すれば直接追加できます。"
+                    }
+                  />
+                ) : (
+                  <Card className="gap-0 overflow-hidden p-0">
+                    {visibleMembers.map((m, i) => (
+                      <div key={m.address}>
+                        {i > 0 && <Divider inset={64} />}
+                        <Row
+                          left={<MemberAvatar member={m} />}
+                          title={m.name ?? abbreviateAddress(m.address)}
+                          subtitle={abbreviateAddress(m.address)}
+                          right={
+                            <Icon
+                              name="chevron-right"
+                              size={16}
+                              className="text-text-secondary"
+                            />
+                          }
+                          onClick={() => chooseMember(m)}
+                        />
+                      </div>
+                    ))}
+                  </Card>
+                )}
+              </section>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* ── Step 2: settings ────────────────────────────────── */}
+      {step === "settings" && selected && (
+        <>
+          <ScreenHeader
+            title="開始日を設定"
+            subtitle={dutyName}
+            onBack={() => setStep("select")}
+          />
+
+          <div className="px-5 pb-4">
+            <FieldLabel>担当者</FieldLabel>
+            <Card className="gap-0 p-3">
+              <div className="flex items-center gap-3">
+                <MemberAvatar member={selected} size="lg" />
+                <div className="min-w-0 flex-1">
+                  <Typography as="div" variant="body" weight="bold" truncate>
+                    {memberName}
+                  </Typography>
+                  <Typography
+                    as="div"
+                    variant="caption"
+                    tone="secondary"
+                    truncate
+                  >
+                    {abbreviateAddress(selected.address)}
+                  </Typography>
+                </div>
+              </div>
+            </Card>
+          </div>
+
+          <div className="px-5 pb-8">
+            <FieldLabel htmlFor="assign-start">開始日</FieldLabel>
+            <Input
+              id="assign-start"
+              type="datetime-local"
+              value={startDatetime}
+              onChange={(e) => setStartDatetime(e.target.value)}
+            />
             <Typography
               as="div"
               variant="caption"
               tone="secondary"
-              className="mt-1.5"
+              className="mt-1.5 leading-snug"
             >
-              該当するユーザーが見つかりませんでした
+              未指定の場合、トランザクション確定時を開始日とします。
             </Typography>
-          )}
+          </div>
 
-          {resolvedAddress && !isAddressInput && (
-            <div className="mt-1.5 flex items-center justify-end gap-1">
-              <Icon name="check" size={14} className="text-success" />
-              <Typography variant="caption" tone="secondary">
-                {abbreviateAddress(resolvedAddress)}
-              </Typography>
-            </div>
-          )}
-        </div>
+          <div className="px-4 pb-8">
+            <Button
+              type="button"
+              variant="primary"
+              full
+              onClick={() => setStep("confirm")}
+            >
+              確認へ
+            </Button>
+          </div>
+        </>
+      )}
 
-        {/* Start date */}
-        <div className="px-5">
-          <FieldLabel htmlFor="assign-start">開始日</FieldLabel>
-          <Input
-            id="assign-start"
-            type="datetime-local"
-            value={startDatetime}
-            onChange={(e) => setStartDatetime(e.target.value)}
+      {/* ── Step 3: confirm ─────────────────────────────────── */}
+      {step === "confirm" && selected && (
+        <>
+          <ScreenHeader
+            title="内容を確認"
+            subtitle={dutyName}
+            onBack={() => setStep("settings")}
           />
-          <Typography
-            as="div"
-            variant="caption"
-            tone="secondary"
-            className="mt-1.5 leading-snug"
-          >
-            未指定の場合、トランザクション確定時を開始日とします。
-          </Typography>
-        </div>
 
-        {/* CTA — sits directly under the date field, not pinned to the bottom */}
-        <div className="flex gap-2.5 px-4 pt-2">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={goBack}
-            disabled={isMinting}
-            className="shrink-0"
-          >
-            キャンセル
-          </Button>
-          <Button
-            type="button"
-            variant="primary"
-            onClick={handleAssign}
-            disabled={!resolvedAddress || isMinting}
-            data-testid="assign-submit"
-            className="flex-1"
-          >
-            <Icon name="plus" size={16} />
-            {isMinting ? "送信中..." : "担当を追加"}
-          </Button>
-        </div>
-      </div>
+          <div className="px-4 pb-4">
+            <Card className="gap-0 p-0">
+              <SummaryRow label="当番" value={dutyName} />
+              <Divider />
+              <SummaryRow
+                label="メンバー"
+                value={
+                  <span className="inline-flex items-center gap-2">
+                    <MemberAvatar member={selected} size="sm" />
+                    {memberName}
+                  </span>
+                }
+              />
+              <Divider />
+              <SummaryRow label="開始日" value={formatStart(startDatetime)} />
+            </Card>
+          </div>
+
+          <div className="flex gap-2.5 px-4 pb-8">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setStep("settings")}
+              disabled={submitting}
+              className="shrink-0"
+            >
+              戻って修正
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              onClick={handleAssign}
+              disabled={submitting}
+              data-testid="assign-submit"
+              className="flex-1"
+            >
+              <Icon name="plus" size={16} />
+              {submitting ? "追加中..." : "追加する"}
+            </Button>
+          </div>
+        </>
+      )}
+
+      {/* ── Step 4: done ────────────────────────────────────── */}
+      {step === "done" && selected && (
+        <>
+          <ScreenHeader title="完了" onBack={goToDetail} />
+
+          <div className="flex flex-col items-center px-6 pt-10 pb-8 text-center">
+            <div className="flex size-20 items-center justify-center rounded-full bg-[#E5F5EC]">
+              <Icon name="check" size={36} className="text-success" />
+            </div>
+            <Heading variant="h3" level={2} className="mt-5">
+              担当を追加しました
+            </Heading>
+            <Typography
+              as="p"
+              variant="bodySm"
+              tone="secondary"
+              className="mt-2 leading-relaxed"
+            >
+              <Typography
+                as="span"
+                variant="bodySm"
+                weight="bold"
+                tone="primary"
+              >
+                {memberName}
+              </Typography>{" "}
+              が「{dutyName}」の担当になりました。
+            </Typography>
+          </div>
+
+          <div className="px-4 pb-8">
+            <Button type="button" variant="primary" full onClick={goToDetail}>
+              当番詳細へ戻る
+            </Button>
+          </div>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Phase 3 UI renewal for two issues. Scope follows the project rule that the design handoff is reference-only — design elements with no contract/subgraph backing (icon/color picker, 頻度, サポーター募集 toggle, duty-delete sheet, 役割 segmented, memo field) are intentionally omitted.

### #436 — Duty create/edit form: 責任/権限 renewal
Replaces the label-only Chip inputs for 責任/権限 with a `{label, description}` list editor.

- **New** `RoleAttributeDialog` — shared add/edit dialog (bottom Sheet on mobile, centered on desktop via the existing `md:` override pattern).
- **New** `RoleAttributesEditor` — list section with inline edit/delete rows, an add button, and a delete-confirmation Sheet.
- `DutyForm` composes two editors for 責任 and 権限.
- No schema changes: `HatsDetailSchama` already carries `description`; the IPFS upload hook and edit-route hydration already round-trip it.

### #437 — Duty assignment: 4-step flow
Rewrites the assign route into **select → settings → confirm → done**, keeping the existing `mintHat` + start-date logic.

The **select step** shows the workspace member directory by default, mirroring the thankstoken send picker:
- Empty search → full member directory (wearers of role hats at level ≥ 2).
- Members already wearing this duty are excluded.
- Search filters by name or address (client-side).
- Pasting a raw address resolves to a known member, or offers to onboard a non-member directly.

## Test plan
- [x] `pnpm frontend typecheck`
- [x] `pnpm biome:check` (one pre-existing, unrelated warning in `app/components/ui/field.tsx` from #426)
- [ ] Manual: create/edit a duty, add/edit/delete 責任 and 権限
- [ ] Manual: assign a duty via all 4 steps; confirm already-assigned members are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)