### PR TITLE
fix(frontend): sync BigBang ABI with hatsQuestModule (#503)

### DIFF
--- a/pkgs/frontend/abi/bigbang.ts
+++ b/pkgs/frontend/abi/bigbang.ts
@@ -151,6 +151,12 @@ export const BIGBANG_ABI = [
       {
         indexed: false,
         internalType: "address",
+        name: "hatsQuestModule",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
         name: "splitCreator",
         type: "address",
       },
@@ -254,6 +260,19 @@ export const BIGBANG_ABI = [
     outputs: [
       {
         internalType: "contract IHatsModuleFactory",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "HatsQuestModule_IMPL",
+    outputs: [
+      {
+        internalType: "address",
         name: "",
         type: "address",
       },
@@ -409,6 +428,11 @@ export const BIGBANG_ABI = [
       },
       {
         internalType: "address",
+        name: "_hatsQuestModule_IMPL",
+        type: "address",
+      },
+      {
+        internalType: "address",
         name: "_splitsCreatorFactory",
         type: "address",
       },
@@ -509,6 +533,19 @@ export const BIGBANG_ABI = [
       },
     ],
     name: "setHatsModuleFactory",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_hatsQuestModuleImpl",
+        type: "address",
+      },
+    ],
+    name: "setHatsQuestModuleImpl",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",


### PR DESCRIPTION
## Summary
- Closes #503. New-workspace creation surfaced "BigBang の実行に失敗しました" even though the tx succeeded.
- The deployed BigBang contract emits a 14-arg `Executed` event (added `hatsQuestModule` between `hatsFractionTokenModule` and `splitCreator`) — both `pkgs/contract/contracts/bigbang/BigBang.sol` and the Sepolia/Base subgraph configs already use this signature — but `pkgs/frontend/abi/bigbang.ts` was still on the 13-arg shape.
- `useBigBang` calls `parseEventLogs({ abi: BIGBANG_ABI, eventName: "Executed", strict: true })`. With the mismatched topic hash that returns no log, so `workspace.new.tsx` threw.
- Regenerated the ABI from the current `BigBang.json` artifact so the Executed event, `HatsQuestModule_IMPL` view, `setHatsQuestModuleImpl` setter, and the `_hatsQuestModule_IMPL` arg on `initialize` are all included.
- Pure additions (+37 lines, 0 removed); existing call sites only consume `parsedLog.args.topHatId` so behavior is unchanged on success paths.

## Test plan
- [x] `pnpm biome check pkgs/frontend/abi/bigbang.ts`
- [x] `pnpm frontend typecheck`
- [ ] Manual: create a new workspace on Sepolia and confirm the flow advances to the "done" step + navigates to `/{treeId}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)