### PR TITLE
fix(frontend): resolve local dev failures with @toban/identity SSR bundling

### DIFF
--- a/pkgs/extensions/identity/package.json
+++ b/pkgs/extensions/identity/package.json
@@ -11,7 +11,8 @@
     ".": "./src/index.ts",
     "./schema": "./src/schema.ts",
     "./providers": "./src/providers/index.ts",
-    "./eip712": "./src/eip712/identity-binding.ts"
+    "./eip712": "./src/eip712/identity-binding.ts",
+    "./eip712/hash": "./src/eip712/hash-verifier-token.ts"
   },
   "scripts": {
     "build": "tsc",

--- a/pkgs/extensions/identity/src/__tests__/connect.test.ts
+++ b/pkgs/extensions/identity/src/__tests__/connect.test.ts
@@ -1,7 +1,7 @@
 import type { Hex } from "viem";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { hashVerifierToken } from "../eip712/identity-binding.js";
+import { hashVerifierToken } from "../eip712/hash-verifier-token.js";
 import { handleConnect } from "../handlers/connect.js";
 import {
   DISCORD_PROVIDER_NAME,

--- a/pkgs/extensions/identity/src/__tests__/eip712.test.ts
+++ b/pkgs/extensions/identity/src/__tests__/eip712.test.ts
@@ -6,8 +6,8 @@ import {
   IDENTITY_BINDING_PRIMARY_TYPE,
   IDENTITY_BINDING_TYPES,
   buildIdentityBindingDomain,
-  hashVerifierToken,
 } from "../eip712/identity-binding.js";
+import { hashVerifierToken } from "../eip712/hash-verifier-token.js";
 
 describe("eip712/identity-binding", () => {
   it("buildIdentityBindingDomain pins name/version and omits verifyingContract", () => {

--- a/pkgs/extensions/identity/src/__tests__/fixtures.ts
+++ b/pkgs/extensions/identity/src/__tests__/fixtures.ts
@@ -15,8 +15,8 @@ import {
   IDENTITY_BINDING_PRIMARY_TYPE,
   IDENTITY_BINDING_TYPES,
   buildIdentityBindingDomain,
-  hashVerifierToken,
 } from "../eip712/identity-binding.js";
+import { hashVerifierToken } from "../eip712/hash-verifier-token.js";
 import type { IdentityBindingTypedData } from "../eip712/identity-binding.js";
 import type { IdentityBindingVerifier } from "../handlers/connect.js";
 import { DISCORD_VERIFIER_ISSUER } from "../providers/discord.js";

--- a/pkgs/extensions/identity/src/eip712/hash-verifier-token.ts
+++ b/pkgs/extensions/identity/src/eip712/hash-verifier-token.ts
@@ -1,0 +1,12 @@
+import { keccak256, toBytes } from "viem";
+import type { Hex } from "viem";
+
+/**
+ * `verifierTokenHash = keccak256(utf8Bytes(verifier_token))`.
+ *
+ * Returned as a `0x`-prefixed 32-byte hex string (the `bytes32` field
+ * of `IdentityBinding`).
+ */
+export function hashVerifierToken(verifierToken: string): Hex {
+  return keccak256(toBytes(verifierToken));
+}

--- a/pkgs/extensions/identity/src/eip712/identity-binding.ts
+++ b/pkgs/extensions/identity/src/eip712/identity-binding.ts
@@ -1,5 +1,7 @@
-import { keccak256, toBytes } from "viem";
-import type { Address, Hex } from "viem";
+/** viem-compatible address / bytes hex brands — kept local so SSR consumers
+ *  (frontend) don't pull viem in through this boundary-contract module. */
+type Address = `0x${string}`;
+type Hex = `0x${string}`;
 
 /**
  * EIP-712 `IdentityBinding` boundary contract.
@@ -62,14 +64,4 @@ export function buildIdentityBindingDomain(
     version: IDENTITY_BINDING_DOMAIN_VERSION,
     chainId,
   };
-}
-
-/**
- * `verifierTokenHash = keccak256(utf8Bytes(verifier_token))`.
- *
- * Returned as a `0x`-prefixed 32-byte hex string (the `bytes32` field
- * of `IdentityBinding`).
- */
-export function hashVerifierToken(verifierToken: string): Hex {
-  return keccak256(toBytes(verifierToken));
 }

--- a/pkgs/extensions/identity/src/handlers/connect.ts
+++ b/pkgs/extensions/identity/src/handlers/connect.ts
@@ -5,8 +5,8 @@ import {
   IDENTITY_BINDING_DOMAIN_NAME,
   IDENTITY_BINDING_DOMAIN_VERSION,
   IDENTITY_BINDING_PRIMARY_TYPE,
-  hashVerifierToken,
 } from "../eip712/identity-binding.js";
+import { hashVerifierToken } from "../eip712/hash-verifier-token.js";
 import type { IdentityBindingTypedData } from "../eip712/identity-binding.js";
 import { DiscordProviderError } from "../providers/discord.js";
 import { providers } from "../providers/index.js";

--- a/pkgs/extensions/identity/src/index.ts
+++ b/pkgs/extensions/identity/src/index.ts
@@ -4,12 +4,12 @@
 
 export {
   buildIdentityBindingDomain,
-  hashVerifierToken,
   IDENTITY_BINDING_DOMAIN_NAME,
   IDENTITY_BINDING_DOMAIN_VERSION,
   IDENTITY_BINDING_PRIMARY_TYPE,
   IDENTITY_BINDING_TYPES,
 } from "./eip712/identity-binding.js";
+export { hashVerifierToken } from "./eip712/hash-verifier-token.js";
 export type {
   IdentityBindingDomain,
   IdentityBindingMessage,

--- a/pkgs/frontend/app/routes/connect.discord.tsx
+++ b/pkgs/frontend/app/routes/connect.discord.tsx
@@ -9,7 +9,6 @@ import {
   IDENTITY_BINDING_DOMAIN_VERSION,
   IDENTITY_BINDING_PRIMARY_TYPE,
   IDENTITY_BINDING_TYPES,
-  hashVerifierToken,
 } from "@toban/identity/eip712";
 import { currentChain } from "hooks/useViem";
 import { useActiveWallet } from "hooks/useWallet";
@@ -39,10 +38,7 @@ function decodeVerifierClaims(token: string): VerifierClaims | null {
   try {
     const padded = parts[1].replace(/-/g, "+").replace(/_/g, "/");
     const padding = "=".repeat((4 - (padded.length % 4)) % 4);
-    const json =
-      typeof atob === "function"
-        ? atob(padded + padding)
-        : Buffer.from(padded + padding, "base64").toString("utf-8");
+    const json = atob(padded + padding);
     return JSON.parse(json) as VerifierClaims;
   } catch {
     return null;
@@ -188,6 +184,7 @@ const ConnectDiscord: FC = () => {
       const nonceBytes = new Uint8Array(32);
       crypto.getRandomValues(nonceBytes);
       const nonce = bytesToHex(nonceBytes);
+      const { hashVerifierToken } = await import("@toban/identity/eip712/hash");
       const verifierTokenHash = hashVerifierToken(token);
       const expires = BigInt(Math.floor(Date.now() / 1000) + 30 * 60);
       const walletAddress = wallet.account.address as Address;

--- a/pkgs/frontend/app/vite-polyfills/ssr-buffer.ts
+++ b/pkgs/frontend/app/vite-polyfills/ssr-buffer.ts
@@ -1,0 +1,4 @@
+import { Buffer } from "node:buffer";
+
+export { Buffer };
+export default Buffer;

--- a/pkgs/frontend/app/vite-polyfills/ssr-global.ts
+++ b/pkgs/frontend/app/vite-polyfills/ssr-global.ts
@@ -1,0 +1,4 @@
+const global = globalThis;
+
+export { global };
+export default global;

--- a/pkgs/frontend/app/vite-polyfills/ssr-process.ts
+++ b/pkgs/frontend/app/vite-polyfills/ssr-process.ts
@@ -1,0 +1,4 @@
+import process from "node:process";
+
+export { process };
+export default process;

--- a/pkgs/frontend/vite.config.ts
+++ b/pkgs/frontend/vite.config.ts
@@ -1,9 +1,20 @@
+import { fileURLToPath } from "node:url";
 import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { type Plugin, defineConfig } from "vite";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import { VitePWA } from "vite-plugin-pwa";
 import tsconfigPaths from "vite-tsconfig-paths";
+
+const ssrBufferShim = fileURLToPath(
+  new URL("./app/vite-polyfills/ssr-buffer.ts", import.meta.url),
+);
+const ssrProcessShim = fileURLToPath(
+  new URL("./app/vite-polyfills/ssr-process.ts", import.meta.url),
+);
+const ssrGlobalShim = fileURLToPath(
+  new URL("./app/vite-polyfills/ssr-global.ts", import.meta.url),
+);
 
 const ignoreWellKnown = (): Plugin => ({
   name: "ignore-well-known",
@@ -19,12 +30,37 @@ const ignoreWellKnown = (): Plugin => ({
   },
 });
 
+// Client polyfills inject `vite-plugin-node-polyfills/shims/*` imports (via
+// esbuild banner / dep optimizer). Those paths are not resolvable from
+// workspace packages during SSR — serve Node builtins instead.
+const ssrPolyfillShims = (): Plugin => ({
+  name: "ssr-polyfill-shims",
+  enforce: "pre",
+  applyToEnvironment(env) {
+    return env.name === "ssr";
+  },
+  config() {
+    return {
+      resolve: {
+        alias: {
+          "vite-plugin-node-polyfills/shims/buffer": ssrBufferShim,
+          "vite-plugin-node-polyfills/shims/process": ssrProcessShim,
+          "vite-plugin-node-polyfills/shims/global": ssrGlobalShim,
+        },
+      },
+    };
+  },
+});
+
 // Apply node polyfills only to the client bundle. SSR keeps native Node
 // modules (avoids stream-browserify breaking `node:stream` etc).
 const clientNodePolyfills = (): Plugin[] => {
   const result = nodePolyfills({
     include: ["buffer", "process"],
-    globals: { Buffer: true, global: true, process: true },
+    // Inject Buffer/process/global only at build time. Dev-time banner injection
+    // trips TDZ errors ("Cannot access '__buffer_polyfill' before initialization")
+    // when React Router eagerly evaluates route modules in the bootstrap script.
+    globals: { Buffer: "build", global: "build", process: "build" },
     protocolImports: false,
   });
   const list = (Array.isArray(result) ? result : [result]) as Plugin[];
@@ -101,6 +137,7 @@ const pwa = (): Plugin[] =>
 
 export default defineConfig({
   plugins: [
+    ssrPolyfillShims(),
     ...clientNodePolyfills(),
     ignoreWellKnown(),
     tailwindcss(),


### PR DESCRIPTION
## Summary
- `@toban/identity/eip712` から viem 依存を分離し、SSR バンドル時の polyfill shim 解決エラーを解消
- SSR 環境向けに `vite-plugin-node-polyfills/shims/*` のエイリアスを追加
- 開発時の polyfill グローバル注入をビルド時のみに限定し、ルートモジュール読み込み時の TDZ エラー（白画面）を防止

## Test plan
- [ ] `pnpm install --frozen-lockfile` 後に `pnpm frontend dev` が起動する
- [ ] http://localhost:5173/ でランディングページが表示される
- [ ] http://localhost:5173/connect/discord が SSR エラーなく表示される
- [ ] `pnpm --filter @toban/identity test` が通る
- [ ] `pnpm frontend typecheck` が通る