### PR TITLE
fix(frontend): プロファイル保存後にNamestone IDキャッシュを再取得する

### DIFF
--- a/pkgs/frontend/app/components/members/MemberDetailContent.tsx
+++ b/pkgs/frontend/app/components/members/MemberDetailContent.tsx
@@ -62,7 +62,7 @@ export const MemberDetailContent: FC<MemberDetailContentProps> = ({
   const lowerAddress = address.toLowerCase();
   const { wallet } = useActiveWallet();
   const isMe = wallet?.account?.address?.toLowerCase() === lowerAddress;
-  const { identity } = useIdentity(address);
+  const { identity, refetch: refetchIdentity } = useIdentity(address);
   const [editOpen, setEditOpen] = useState(false);
 
   // Duty hats (role branch, level >= 2) this member wears.
@@ -249,6 +249,7 @@ export const MemberDetailContent: FC<MemberDetailContentProps> = ({
           onOpenChange={setEditOpen}
           address={address}
           identity={identity}
+          onSaved={refetchIdentity}
         />
       )}
     </div>

--- a/pkgs/frontend/hooks/useENS.ts
+++ b/pkgs/frontend/hooks/useENS.ts
@@ -104,6 +104,7 @@ export const useActiveWalletIdentity = () => {
 };
 
 export const useIdentity = (address?: string) => {
+  const queryClient = useQueryClient();
   const addressArray = useMemo(() => {
     if (!address) return [];
     return [address];
@@ -115,7 +116,19 @@ export const useIdentity = (address?: string) => {
     return names[0][0];
   }, [names]);
 
-  return { identity };
+  const refetch = useCallback(async () => {
+    if (!address) return;
+    const normalized = normalizeAddress(address);
+    // Remove the per-address cache so resolveBatchViaCache goes to the API next time.
+    queryClient.removeQueries({
+      queryKey: [NAMES_QUERY_KEY, "addr", normalized],
+    });
+    await queryClient.invalidateQueries({
+      queryKey: [NAMES_QUERY_KEY, "batch"],
+    });
+  }, [address, queryClient]);
+
+  return { identity, refetch };
 };
 
 export const useNamesByAddresses = (addresses?: string[]) => {


### PR DESCRIPTION
Closes #533 .
## Summary

- `useIdentity` に `refetch` を追加し、プロフィール保存後に Namestone のキャッシュを更新できるようにしました
- メンバー詳細画面（`MemberDetailContent`）で、プロフィール編集ダイアログ保存後に `refetch` を呼び出すよう接続してます
- http://localhost:5173/1879
にアクセスして、プロフィール編集後、表示が更新されるかテストしてください。

## 背景

メンバー詳細でプロフィール（表示名など）を保存しても、React Query にキャッシュされた Namestone の identity がそのまま残り、画面に古い表示名が出続けていました。

## 変更内容

### `hooks/useENS.ts`

- `useIdentity` から `refetch` を返すように変更
- `refetch` 実行時に以下を実行:
  - 当該アドレスの per-address キャッシュ（`[NAMES_QUERY_KEY, "addr", ...]`）を `removeQueries` で削除
  - バッチクエリ（`[NAMES_QUERY_KEY, "batch", ...]`）を `invalidateQueries` し、API から最新データを再取得

### `MemberDetailContent.tsx`

- `useIdentity` から `refetch` を受け取り、`MemberProfileEditDialog` の `onSaved` に渡す

## Test plan

- [ ] メンバー詳細（`/{treeId}/member/{address}`）を自分のアドレスで開く
- [ ] プロフィール編集ダイアログで表示名を変更して保存する
- [ ] ページをリロードせずに、メンバー詳細の表示名が新しい値に更新されること
- [ ] 他メンバーの詳細を開いたとき、従来どおり identity が表示されること（既存動作の退行なし）
- [ ] `pnpm frontend typecheck` が通ること