### PR TITLE
fix(frontend): ワークスペース一覧に所有しているワークスペースを表示する

### DIFF
--- a/pkgs/frontend/app/routes/workspace._index.tsx
+++ b/pkgs/frontend/app/routes/workspace._index.tsx
@@ -2,8 +2,12 @@ import { treeIdHexToDecimal } from "@hatsprotocol/sdk-v1-core";
 import axios from "axios";
 import { useActiveWalletIdentity } from "hooks/useENS";
 import { useGetBalanceOfFractionTokens } from "hooks/useFractionToken";
-import { useGetHatsByWorkspaceIds, useGetWorkspaces } from "hooks/useHats";
+import {
+  useGetHatsByWorkspaceIds,
+  useGetWorkspaces as useGetJoinedWorkspaces,
+} from "hooks/useHats";
 import { useGetHoldingThanksTokens } from "hooks/useThanksToken";
+import { useGetWorkspaces as useGetTobanWorkspaces } from "hooks/useWorkspace";
 import { useActiveWallet } from "hooks/useWallet";
 import { type FC, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
@@ -93,17 +97,48 @@ const Workspace: FC = () => {
 
   // Joined workspaces — the user wears at least one hat in them.
   const { workspaces: joinedWorkspaces, loading: loadingJoined } =
-    useGetWorkspaces({ id: me });
+    useGetJoinedWorkspaces({ id: me });
   const joinedWorkspaceIds = useMemo(
     () => joinedWorkspaces.map((w) => w.id),
     [joinedWorkspaces],
   );
 
+  // Workspaces the user created or owns (TopHat holder). Toban subgraph
+  // indexes these from BigBang immediately; the Hats subgraph wearer query
+  // can miss TopHat-only wearers right after creation.
+  const { data: tobanWorkspacesData, loading: loadingOwned } =
+    useGetTobanWorkspaces({
+      where: me ? { or: [{ owner: me }, { creator: me }] } : undefined,
+    });
+  const ownedWorkspaceIds = useMemo(
+    () => tobanWorkspacesData?.workspaces.map((w) => w.id) ?? [],
+    [tobanWorkspacesData],
+  );
+  const ownedIdsToResolve = useMemo(
+    () => ownedWorkspaceIds.filter((id) => !joinedWorkspaceIds.includes(id)),
+    [ownedWorkspaceIds, joinedWorkspaceIds],
+  );
+  const { hats: ownedHats } = useGetHatsByWorkspaceIds(ownedIdsToResolve);
+  const ownedWorkspaces = useMemo<Workspace[]>(
+    () =>
+      ownedHats.map((h) => ({
+        id: String(treeIdHexToDecimal(h.tree.id)),
+        details: h.details,
+        imageUri: h.imageUri,
+      })),
+    [ownedHats],
+  );
+
+  const knownWorkspaceIds = useMemo(() => {
+    if (loadingJoined || loadingOwned) return [];
+    return [...new Set([...joinedWorkspaceIds, ...ownedWorkspaceIds])];
+  }, [joinedWorkspaceIds, ownedWorkspaceIds, loadingJoined, loadingOwned]);
+
   // Workspaces where the user holds assist credit but no hat.
   const { data: fractionTokensData } = useGetBalanceOfFractionTokens({
     where: {
       owner: me,
-      workspaceId_not_in: loadingJoined ? [] : joinedWorkspaceIds,
+      workspaceId_not_in: knownWorkspaceIds.length > 0 ? knownWorkspaceIds : [],
     },
   });
   const assistedWorkspaceIds = useMemo(() => {
@@ -123,9 +158,13 @@ const Workspace: FC = () => {
 
   // Workspaces where the user has only received Thanks tokens.
   const excludeWorkspaceIds = useMemo(() => {
-    const ids = [...joinedWorkspaceIds, ...assistedWorkspaceIds];
+    const ids = [
+      ...joinedWorkspaceIds,
+      ...ownedWorkspaceIds,
+      ...assistedWorkspaceIds,
+    ];
     return ids.length > 0 ? ids : undefined;
-  }, [joinedWorkspaceIds, assistedWorkspaceIds]);
+  }, [joinedWorkspaceIds, ownedWorkspaceIds, assistedWorkspaceIds]);
   const holdingThanksToken = useGetHoldingThanksTokens(me as Address, {
     where: { workspaceId_not_in: excludeWorkspaceIds },
   });
@@ -148,6 +187,7 @@ const Workspace: FC = () => {
     const merged: Workspace[] = [];
     for (const w of [
       ...joinedWorkspaces,
+      ...ownedWorkspaces,
       ...assistedWorkspaces,
       ...thankedWorkspaces,
     ]) {
@@ -156,7 +196,7 @@ const Workspace: FC = () => {
       merged.push(w);
     }
     return merged;
-  }, [joinedWorkspaces, assistedWorkspaces, thankedWorkspaces]);
+  }, [joinedWorkspaces, ownedWorkspaces, assistedWorkspaces, thankedWorkspaces]);
 
   const detailsMap = useWorkspaceDetails(allWorkspaces);
 

--- a/pkgs/frontend/app/routes/workspace._index.tsx
+++ b/pkgs/frontend/app/routes/workspace._index.tsx
@@ -107,9 +107,10 @@ const Workspace: FC = () => {
   // indexes these from BigBang immediately; the Hats subgraph wearer query
   // can miss TopHat-only wearers right after creation.
   const { data: tobanWorkspacesData, loading: loadingOwned } =
-    useGetTobanWorkspaces({
-      where: me ? { or: [{ owner: me }, { creator: me }] } : undefined,
-    });
+    useGetTobanWorkspaces(
+      me ? { where: { or: [{ owner: me }, { creator: me }] } } : undefined,
+      { skip: !me },
+    );
   const ownedWorkspaceIds = useMemo(
     () => tobanWorkspacesData?.workspaces.map((w) => w.id) ?? [],
     [tobanWorkspacesData],
@@ -118,16 +119,23 @@ const Workspace: FC = () => {
     () => ownedWorkspaceIds.filter((id) => !joinedWorkspaceIds.includes(id)),
     [ownedWorkspaceIds, joinedWorkspaceIds],
   );
-  const { hats: ownedHats } = useGetHatsByWorkspaceIds(ownedIdsToResolve);
-  const ownedWorkspaces = useMemo<Workspace[]>(
-    () =>
-      ownedHats.map((h) => ({
-        id: String(treeIdHexToDecimal(h.tree.id)),
-        details: h.details,
-        imageUri: h.imageUri,
-      })),
-    [ownedHats],
-  );
+  const { hats: ownedHats, loading: loadingOwnedHats } =
+    useGetHatsByWorkspaceIds(ownedIdsToResolve);
+  const ownedWorkspaces = useMemo<Workspace[]>(() => {
+    const hatByTreeId = new Map(
+      ownedHats.map((h) => [String(treeIdHexToDecimal(h.tree.id)), h]),
+    );
+    // Keep Toban-indexed ids even when Hats metadata is unavailable (e.g.
+    // invalid VITE_THEGRAPH_API_KEY). Cards fall back to "Workspace #id".
+    return ownedIdsToResolve.map((id) => {
+      const hat = hatByTreeId.get(id);
+      return {
+        id,
+        details: hat?.details ?? "",
+        imageUri: hat?.imageUri ?? "",
+      };
+    });
+  }, [ownedHats, ownedIdsToResolve]);
 
   const knownWorkspaceIds = useMemo(() => {
     if (loadingJoined || loadingOwned) return [];
@@ -219,6 +227,10 @@ const Workspace: FC = () => {
     navigate(`/${workspaceId}`);
   };
 
+  const isListLoading =
+    Boolean(me) &&
+    (loadingJoined || loadingOwned || (ownedIdsToResolve.length > 0 && loadingOwnedHats));
+
   return (
     <PageContainer
       data-testid="workspace-page"
@@ -246,7 +258,11 @@ const Workspace: FC = () => {
 
       <section className="-mx-1">
         <SectionLabel className="px-1">参加中</SectionLabel>
-        {filteredWorkspaces.length > 0 ? (
+        {isListLoading ? (
+          <Typography variant="bodySm" tone="secondary" className="px-1 py-6 text-center">
+            読み込み中...
+          </Typography>
+        ) : filteredWorkspaces.length > 0 ? (
           <div className="flex flex-col gap-2.5 px-1">
             {filteredWorkspaces.map((w) => {
               const d = detailsMap[w.id];

--- a/pkgs/frontend/app/routes/workspace.new.tsx
+++ b/pkgs/frontend/app/routes/workspace.new.tsx
@@ -30,6 +30,7 @@ import { Icon } from "~/components/ui/icon";
 import { Input } from "~/components/ui/input";
 import { Textarea } from "~/components/ui/textarea";
 import { buildFallbackSvgFile, pickRandomColor } from "~/lib/avatar-fallback";
+import { useWorkspaceStore } from "~/stores/workspace";
 
 type Step = "basic" | "initial" | "confirm" | "done";
 
@@ -43,6 +44,7 @@ const STEP_INDEX: Record<Step, number> = {
 
 const WorkspaceNew: FC = () => {
   const navigate = useNavigate();
+  const switchWorkspace = useWorkspaceStore((s) => s.switch);
   const { wallet } = useActiveWallet();
   const { bigbang, isLoading: isCreating } = useBigBang();
   const { uploadHatsDetailsToIpfs, isLoading: isUploadingDetails } =
@@ -189,6 +191,7 @@ const WorkspaceNew: FC = () => {
       const { topHatId } = parsedLog.args;
       const treeId = String(hatIdToTreeId(topHatId));
       setCreatedTreeId(treeId);
+      switchWorkspace(treeId);
       // wait briefly so the subgraph has a chance to index the new workspace
       await new Promise((resolve) => setTimeout(resolve, 3000));
       setStep("done");

--- a/pkgs/frontend/hooks/useWorkspace.ts
+++ b/pkgs/frontend/hooks/useWorkspace.ts
@@ -70,10 +70,13 @@ export const useGetWorkspace = (variables?: GetWorkspaceQueryVariables) => {
   return result;
 };
 
-export const useGetWorkspaces = (variables?: GetWorkspacesQueryVariables) => {
+export const useGetWorkspaces = (
+  variables?: GetWorkspacesQueryVariables,
+  options?: { skip?: boolean },
+) => {
   const result = useQuery<GetWorkspacesQuery, GetWorkspacesQueryVariables>(
     queryGetWorkspaces,
-    { variables },
+    { variables, skip: options?.skip },
   );
 
   return result;


### PR DESCRIPTION
## Summary

- BigBang で WS 作成後、`/workspace` 一覧に表示されない問題を修正
- Toban subgraph の `owner` / `creator` から WS を取得し、Hats subgraph の wearer クエリとマージ
- Hats メタデータ取得失敗時も ID ベースで一覧表示（名前は `Workspace #id` にフォールバック）
- WS 作成成功時に `useWorkspaceStore().switch(treeId)` を呼び出し
- 読み込み中の空状態表示を改善

テストをされる場合は、The Graph Studio の API キーを取得し、.envファイルのVITE_THEGRAPH_API_KEYでお使いください。

Fixes #537

## Test plan

- [ ] Base で WS 作成後、`/workspace` に作成 WS が表示される
- [ ] 既存の参加 WS（当番着用・アシストクレジット・サンクス受取）も引き続き表示される
- [ ] `VITE_THEGRAPH_API_KEY` が有効な場合、WS 名・アイコンが表示される
- [ ] 作成直後に WS 切り替えメニューから選択できる