### PR TITLE
feat(frontend): ワークスペース切替メニューから新規作成へ遷移 (#541)

### DIFF
--- a/pkgs/frontend/app/components/layout/AppShellLayout.tsx
+++ b/pkgs/frontend/app/components/layout/AppShellLayout.tsx
@@ -167,6 +167,7 @@ function ShellView({ treeId }: ShellViewProps) {
         onOpenChange={setSwitcherOpen}
         workspaceName={displayWorkspaceName}
         onSwitchWorkspace={() => navigate("/workspace")}
+        onCreateWorkspace={() => navigate("/workspace/new")}
         onOpenSettings={() => navigate(`/${treeId}/settings`)}
       />
     </>

--- a/pkgs/frontend/app/components/layout/WorkspaceSwitcherMenu.stories.tsx
+++ b/pkgs/frontend/app/components/layout/WorkspaceSwitcherMenu.stories.tsx
@@ -17,6 +17,7 @@ export const Controlled: Story = () => {
         onOpenChange={setOpen}
         workspaceName="ひがしのシェアハウス"
         onSwitchWorkspace={() => console.log("[story] navigate /workspace")}
+        onCreateWorkspace={() => console.log("[story] navigate /workspace/new")}
         onOpenSettings={() => console.log("[story] navigate /:treeId/settings")}
       />
     </div>

--- a/pkgs/frontend/app/components/layout/WorkspaceSwitcherMenu.tsx
+++ b/pkgs/frontend/app/components/layout/WorkspaceSwitcherMenu.tsx
@@ -24,6 +24,8 @@ interface WorkspaceSwitcherMenuProps {
   workspaceName: string;
   /** Switch to the workspace list (`/workspace`). */
   onSwitchWorkspace: () => void;
+  /** Start the workspace creation flow (`/workspace/new`). */
+  onCreateWorkspace: () => void;
   /** Open workspace settings (`/{treeId}/settings`). */
   onOpenSettings: () => void;
   /** Invite link copied to clipboard — defaults to `window.location.href`. */
@@ -35,7 +37,7 @@ interface WorkspaceSwitcherMenuProps {
 // - Desktop (`>=md`): Popover anchored near the Sidebar workspace button via
 //   a `PopoverAnchor` positioned at the top-left of the viewport (matches the
 //   design source `desktop.jsx:72-101`).
-// Both surfaces render the same three actions (switch / invite / settings).
+// Both surfaces render the same four actions (switch / create / invite / settings).
 // Only one primitive is mounted per viewport — both Popover and Sheet portal
 // to the body, so a CSS-only `md:hidden` gate would let both open at once
 // and their focus traps would fight (the Sheet flashed shut).
@@ -44,6 +46,7 @@ function WorkspaceSwitcherMenu({
   onOpenChange,
   workspaceName,
   onSwitchWorkspace,
+  onCreateWorkspace,
   onOpenSettings,
   inviteLink,
 }: WorkspaceSwitcherMenuProps) {
@@ -86,6 +89,15 @@ function WorkspaceSwitcherMenu({
         subtitle="参加中の一覧から選ぶ"
         onClick={() => {
           onSwitchWorkspace();
+          onOpenChange(false);
+        }}
+      />
+      <Row
+        left={<Icon name="plus" />}
+        title="新しいワークスペースを作成"
+        subtitle="必要事項を入力して作成"
+        onClick={() => {
+          onCreateWorkspace();
           onOpenChange(false);
         }}
       />


### PR DESCRIPTION
## Summary
- ワークスペース切替メニュー（`WorkspaceSwitcherMenu`）に「新しいワークスペースを作成」項目を追加
- クリックで既存の作成フロー `/workspace/new` へ遷移
- モバイル（Sheet）・デスクトップ（Popover）の両方で同じ4項目を表示

Closes #541

## Test plan
- [ ] ワークスペース内でワークスペース名のドロップダウンを開き、「新しいワークスペースを作成」が表示される
- [ ] クリックで `/workspace/new` に遷移し、既存の3ステップ作成フローが表示される
- [ ] デスクトップ（Popover）・モバイル（Sheet）の両方で動作を確認
- [ ] 他のメニュー項目（切り替え・招待・設定）が従来どおり動作する