### PR TITLE
feat(frontend): サンクストークン送信後に「最近のアクティビティ」を自動更新 (#534)

### DIFF
--- a/pkgs/frontend/app/routes/$treeId._index.tsx
+++ b/pkgs/frontend/app/routes/$treeId._index.tsx
@@ -5,6 +5,7 @@ import { useTreeInfo } from "hooks/useHats";
 import { useQuestMetadata } from "hooks/useQuestMetadata";
 import { type Quest, useQuests } from "hooks/useQuests";
 import {
+  HOME_ACTIVITY_MINTS_LIMIT,
   useThanksToken,
   useThanksTokenActivity,
   useUserThanksTokenBalance,
@@ -108,7 +109,7 @@ const WorkspaceHome: FC = () => {
   const { balance: receivedBalance } = useUserThanksTokenBalance(treeId);
   const { mints, isLoading: isActivityLoading } = useThanksTokenActivity(
     treeId,
-    20,
+    HOME_ACTIVITY_MINTS_LIMIT,
   );
   const recentMints = mints?.mintThanksTokens ?? [];
 

--- a/pkgs/frontend/app/routes/$treeId_.thankstoken.send.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.thankstoken.send.tsx
@@ -1,4 +1,3 @@
-import { useApolloClient } from "@apollo/client/react";
 import { MintThanksToken_OrderBy, type OrderDirection } from "gql/graphql";
 import { useActiveWalletIdentity, useNamesByAddresses } from "hooks/useENS";
 import { useTreeInfo } from "hooks/useHats";
@@ -19,6 +18,7 @@ import {
 import { LuCheck } from "react-icons/lu";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 import { toast } from "sonner";
+import { goldskyClient } from "utils/apollo";
 import { ipfs2https } from "utils/ipfs";
 import { abbreviateAddress, isValidEthAddress } from "utils/wallet";
 import { type Address, formatEther, parseEther, stringToHex } from "viem";
@@ -65,7 +65,6 @@ const sameAddress = (a?: string, b?: string) =>
 const ThanksTokenSend: FC = () => {
   const { treeId } = useParams();
   const navigate = useNavigate();
-  const apolloClient = useApolloClient();
   const me = useActiveWalletIdentity();
   const { mintableAmount, mintThanksToken, batchMintThanksToken, isLoading } =
     useThanksToken(treeId as string);
@@ -304,7 +303,7 @@ const ThanksTokenSend: FC = () => {
       toast.success("サンクスを送りました");
       const sender = me.identity?.address;
       if (treeId && sender && blockNumber !== undefined) {
-        void pollActivityMintsAfterSend(apolloClient, {
+        void pollActivityMintsAfterSend(goldskyClient, {
           workspaceId: treeId,
           fromAddress: sender,
           blockNumber,

--- a/pkgs/frontend/app/routes/$treeId_.thankstoken.send.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.thankstoken.send.tsx
@@ -1,7 +1,12 @@
+import { useApolloClient } from "@apollo/client/react";
 import { MintThanksToken_OrderBy, type OrderDirection } from "gql/graphql";
 import { useActiveWalletIdentity, useNamesByAddresses } from "hooks/useENS";
 import { useTreeInfo } from "hooks/useHats";
-import { useGetMintThanksTokens, useThanksToken } from "hooks/useThanksToken";
+import {
+  pollActivityMintsAfterSend,
+  useGetMintThanksTokens,
+  useThanksToken,
+} from "hooks/useThanksToken";
 import type { NameData } from "namestone-sdk";
 import {
   type FC,
@@ -60,6 +65,7 @@ const sameAddress = (a?: string, b?: string) =>
 const ThanksTokenSend: FC = () => {
   const { treeId } = useParams();
   const navigate = useNavigate();
+  const apolloClient = useApolloClient();
   const me = useActiveWalletIdentity();
   const { mintableAmount, mintThanksToken, batchMintThanksToken, isLoading } =
     useThanksToken(treeId as string);
@@ -278,6 +284,7 @@ const ThanksTokenSend: FC = () => {
     setStep("sending");
     try {
       const extra = message ? stringToHex(message) : undefined;
+      let blockNumber: bigint | undefined;
       if (recipients.length === 1) {
         const res = await mintThanksToken(
           recipients[0].address as Address,
@@ -285,14 +292,27 @@ const ThanksTokenSend: FC = () => {
           extra,
         );
         if (res?.error) throw new Error(res.error);
+        blockNumber = res?.blockNumber;
       } else {
         const tos = recipients.map((r) => r.address as Address);
         const amounts = recipients.map(() => parseEther(amount.toString()));
         const res = await batchMintThanksToken(tos, amounts, extra);
         if (res?.error) throw new Error(res.error);
+        blockNumber = res?.blockNumber;
       }
       setStep("done");
       toast.success("サンクスを送りました");
+      const sender = me.identity?.address;
+      if (treeId && sender && blockNumber !== undefined) {
+        void pollActivityMintsAfterSend(apolloClient, {
+          workspaceId: treeId,
+          fromAddress: sender,
+          blockNumber,
+          toAddresses: recipients.map((r) => r.address),
+        }).catch((err) => {
+          console.error("Activity mint poll failed:", err);
+        });
+      }
     } catch (e) {
       console.error("Thanks send error:", e);
       toast.error("送信に失敗しました");

--- a/pkgs/frontend/hooks/useThanksToken.ts
+++ b/pkgs/frontend/hooks/useThanksToken.ts
@@ -1,3 +1,4 @@
+import type { ApolloClient } from "@apollo/client/core";
 import { gql } from "@apollo/client/core";
 import { useQuery } from "@apollo/client/react/hooks";
 import {
@@ -22,6 +23,97 @@ import { useTreeInfo } from "./useHats";
 import { publicClient } from "./useViem";
 import { useActiveWallet } from "./useWallet";
 import { useGetWorkspace } from "./useWorkspace";
+
+/** Matches `$treeId._index` — keep poll refetches aligned with the home feed. */
+export const HOME_ACTIVITY_MINTS_LIMIT = 20;
+
+const ACTIVITY_MINTS_POLL_INTERVAL_MS = 3000;
+const ACTIVITY_MINTS_POLL_MAX_MS = 30_000;
+
+const activityMintsQueryVariables = (
+  workspaceId: string,
+  limit = HOME_ACTIVITY_MINTS_LIMIT,
+): GetThanksTokenMintsQueryVariables => ({
+  where: { workspaceId },
+  orderBy: MintThanksToken_OrderBy.BlockTimestamp,
+  orderDirection: "desc" as OrderDirection,
+  first: limit,
+});
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+export type ActivityMintPollCriteria = {
+  workspaceId: string;
+  fromAddress: string;
+  blockNumber: bigint;
+  /** Lowercase or checksummed — one entry per recipient (batch mint). */
+  toAddresses: string[];
+};
+
+const mintMatchesSend = (
+  mint: { from: string; to: string; blockNumber: unknown },
+  criteria: ActivityMintPollCriteria,
+): boolean => {
+  if (mint.from.toLowerCase() !== criteria.fromAddress.toLowerCase()) {
+    return false;
+  }
+  if (BigInt(String(mint.blockNumber)) !== criteria.blockNumber) {
+    return false;
+  }
+  return criteria.toAddresses.some(
+    (to) => to.toLowerCase() === mint.to.toLowerCase(),
+  );
+};
+
+const allRecipientsIndexed = (
+  mints: Array<{ from: string; to: string; blockNumber: unknown }>,
+  criteria: ActivityMintPollCriteria,
+): boolean => {
+  const indexedTos = new Set(
+    mints
+      .filter((m) => mintMatchesSend(m, criteria))
+      .map((m) => m.to.toLowerCase()),
+  );
+  return criteria.toAddresses.every((to) =>
+    indexedTos.has(to.toLowerCase()),
+  );
+};
+
+/**
+ * After a successful thanks mint, refetch workspace mints immediately then poll
+ * every 3s (max 30s) until the subgraph indexes this send. Updates Apollo
+ * cache for `useThanksTokenActivity` / home "最近のアクティビティ".
+ */
+export async function pollActivityMintsAfterSend(
+  client: ApolloClient<object>,
+  criteria: ActivityMintPollCriteria,
+): Promise<void> {
+  const variables = activityMintsQueryVariables(criteria.workspaceId);
+
+  const fetchMints = () =>
+    client.query<GetThanksTokenMintsQuery, GetThanksTokenMintsQueryVariables>({
+      query: queryGetThanksTokenMints,
+      variables,
+      fetchPolicy: "network-only",
+    });
+
+  const deadline = Date.now() + ACTIVITY_MINTS_POLL_MAX_MS;
+
+  while (Date.now() <= deadline) {
+    const { data } = await fetchMints();
+    const mints = data?.mintThanksTokens ?? [];
+    if (allRecipientsIndexed(mints, criteria)) {
+      return;
+    }
+    if (Date.now() + ACTIVITY_MINTS_POLL_INTERVAL_MS > deadline) {
+      return;
+    }
+    await sleep(ACTIVITY_MINTS_POLL_INTERVAL_MS);
+  }
+}
 
 // GraphQL queries for ThanksToken data from Goldsky
 const queryGetThanksTokenBalances = gql(`
@@ -265,6 +357,7 @@ export const useThanksToken = (treeId: string) => {
       setIsLoading(true);
 
       let txHash: `0x${string}` | undefined = undefined;
+      let blockNumber: bigint | undefined = undefined;
       let error = "";
 
       try {
@@ -275,14 +368,17 @@ export const useThanksToken = (treeId: string) => {
           functionName: "mint",
           args: [to, amount, relatedRoles, extraData],
         });
-        await publicClient.waitForTransactionReceipt({ hash: txHash });
+        const receipt = await publicClient.waitForTransactionReceipt({
+          hash: txHash,
+        });
+        blockNumber = receipt.blockNumber;
         setIsLoading(false);
       } catch (_) {
         error = "トークンの送信に失敗しました";
         setIsLoading(false);
       }
 
-      return { txHash, error };
+      return { txHash, blockNumber, error };
     },
     [relatedRoles, wallet, data?.workspace?.thanksToken.id],
   );
@@ -297,6 +393,7 @@ export const useThanksToken = (treeId: string) => {
       setIsLoading(true);
 
       let txHash: `0x${string}` | undefined = undefined;
+      let blockNumber: bigint | undefined = undefined;
       let error = "";
 
       try {
@@ -307,14 +404,17 @@ export const useThanksToken = (treeId: string) => {
           functionName: "batchMint",
           args: [tos, amount, relatedRoles, extraData],
         });
-        await publicClient.waitForTransactionReceipt({ hash: txHash });
+        const receipt = await publicClient.waitForTransactionReceipt({
+          hash: txHash,
+        });
+        blockNumber = receipt.blockNumber;
         setIsLoading(false);
       } catch (_) {
         error = "トークンの送信に失敗しました";
         setIsLoading(false);
       }
 
-      return { txHash, error };
+      return { txHash, blockNumber, error };
     },
     [relatedRoles, wallet, data?.workspace?.thanksToken.id],
   );
@@ -364,12 +464,9 @@ export const useThanksTokenActivity = (workspaceId?: string, limit = 10) => {
     GetThanksTokenMintsQuery,
     GetThanksTokenMintsQueryVariables
   >(queryGetThanksTokenMints, {
-    variables: {
-      where: { workspaceId },
-      orderBy: MintThanksToken_OrderBy.BlockTimestamp,
-      orderDirection: "desc" as OrderDirection,
-      first: limit,
-    },
+    variables: workspaceId
+      ? activityMintsQueryVariables(workspaceId, limit)
+      : undefined,
     skip: !workspaceId,
   });
 


### PR DESCRIPTION
Closes #534

## Summary

ワークスペースホームの「最近のアクティビティ」は、サンクストークン（THX）の mint 成功後もサブグラフのインデックス遅延のため即時反映されていませんでした。本 PR では、**自分がサンクスを送信した直後のみ**、Goldsky サブグラフの mint 一覧を refetch + 短時間ポーリングし、Apollo キャッシュ経由でホームの表示を自動更新します。

- サブグラフ・コントラクトの変更はなし（フロントエンドのみ）
- 常時ポーリングは行わず、送信者本人の操作に限定
- `GetThanksTokenMints` のみ refetch（transfers は対象外）

## 背景・Issue

[#534 サンクストークンの授受の際に、自動で最近のアクティビティが更新されるようにする](https://github.com/hackdays-io/toban/issues/534) への対応です。

現状、ホーム（`$treeId._index.tsx`）は `useThanksTokenActivity` で `mintThanksTokens` を取得していますが、Apollo のデフォルト `cache-first` ポリシーにより、サンクス送信後にホームへ戻ってもキャッシュが更新されず、新しい授受が一覧に現れない問題がありました。

## 設計判断の経緯

### 1. 実装可能かの調査結果

- サブグラフは `MintThanksToken` / `TransferThanksToken` をすでにインデックス済み
- フロントは Goldsky GraphQL（Apollo `goldskyClient`）で取得可能
- 不足していたのは「送信後にキャッシュを再取得する」仕組みのみ

→ **フロントエンドのみの変更で実現可能**と判断しました。

### 2. Goldsky の課金・レート制限を踏まえた方針

[Goldsky のサブグラフ課金](https://docs.goldsky.com/pricing/summary)は **クエリ数従量課金ではなく**、worker 時間とエンティティ保存量が対象です（FAQ でも per-query 課金なしと明記）。そのため、refetch / ポーリングで **請求額が直接増える心配は小さい**です。

一方、GraphQL エンドポイントには [デフォルトで 10 秒あたり 50 リクエスト](https://docs.goldsky.com/subgraphs/graphql-endpoints) のレート制限があり、これは **Toban ワークスペース（`treeId`）ごとではなく、チェーンごとのサブグラフ 1 本（例: `toban-base/0.0.1`）を全ユーザー・全クライアントで共有** します。

常時ポーリング（例: ホーム滞在中 10 秒ごと × 全ユーザー）を入れると、同時アクセス数に比例して 429（Too Many Requests）のリスクが高まります。20 人がホームを開いたまま 10 秒ポーリングするだけで、理論上 40 req/10s に達します。

### 3. 本件以外に同じ Goldsky エンドポイントへリクエストが走るケース

今回のポーリングは **既存トラフィックに上乗せ** されるため、以下と **同じ 50/10s 枠を共有** します。

**フロントエンド（Apollo / `goldskyClient`）**

| フック | クエリ | 主な画面 |
|--------|--------|----------|
| `useWorkspace` | `GetWorkspace`, `GetWorkspaces` | ほぼ全 WS 画面 |
| `useThanksToken` | Balances / Mints / Transfers 等 | ホーム、履歴、送信、メンバー |
| `useFractionToken` | `BalanceOfFractionTokens`, transfers | ロールシェア、Assist Credit |
| `useQuests` | `GetQuestsForWorkspace`, `GetQuestDetail` | ホーム、クエスト Kanban・詳細 |
| `useScheduledDistributor` | 2 種 | 定期分配 |

特に負荷が高くなりやすい例:

- **クエスト Kanban**: デスクトップで 4 列 × `useQuests`（`cache-and-network` で毎回ネットワーク再取得）→ 画面表示だけで 4 req
- **クエスト詳細**: 未インデックス時 **2 秒間隔の無限ポーリング**（`useQuest`）
- **履歴画面**: `first: 1000` の mint 一括取得
- **ワークスペースホーム初回**: mints + transfers + balances + quests 等で **5〜6 req**

**Discord bot**（同じ `GOLDSKY_GRAPHQL_ENDPOINT`）

- `/thx`, `/balance`: 各 **2 req**（ThanksToken アドレス解決 + FractionToken 残高）

Hats サブグラフ（`useTreeInfo` 等）、Alchemy RPC、IPFS は **別エンドポイント** のため本件の枠には含まれません。

### 4. `useQuest` を参考にした点

クエスト詳細（`useQuest`）では、サブグラフのインデックス遅延対策として以下が既に実装されています。

- `fetchPolicy: "cache-and-network"`
- エンティティ未存在時 **`startPolling(2000)`**（2 秒間隔、見つかるまで継続、**上限時間なし**）

本 PR ではこの「**インデックス完了まで短時間ポーリング**」の考え方を借りつつ、THX 送信向けに以下のように調整しました。

| | `useQuest`（既存） | 本 PR（THX アクティビティ） |
|--|-------------------|---------------------------|
| トリガー | クエスト詳細を開いた & 未インデックス | **自分がサンクス送信成功** |
| 間隔 | 2 秒 | **3 秒** |
| 上限 | なし | **30 秒で打ち切り** |
| 対象クエリ | `GetQuestDetail` | **`GetThanksTokenMints` のみ** |

30 秒上限を設けたのは、レート制限・無限ポーリング防止のためです（`useQuest` より安全側）。

### 5. 「自分が送ったときだけ更新」に限定した理由

検討した選択肢:

| 方式 | メリット | デメリット |
|------|----------|------------|
| ホーム常時ポーリング | 他メンバーの授受も自動反映 | 全ユーザー × 定期 req → **レート制限リスク大** |
| 送信時のみ refetch + 短時間ポール | **レート制限影響が小さい**（1 送信あたり最大 ~11 req、送信者のみ） | 他者の授受は自動反映されない |
| GraphQL Subscription | リアルタイム | Apollo WebSocket 未設定、インフラ変更大 |

Issue #534 の主なペインは「自分がサンクスを送ったのにホームに出ない」ことと解釈し、**送信者本人の UX 改善** にスコープを絞りました。他メンバーの授受の自動反映は別 Issue / 将来検討とします。

## 実装内容（パターン B）

### `pollActivityMintsAfterSend`（`hooks/useThanksToken.ts`）

1. 送信成功後、**即座に** `GetThanksTokenMints` を `network-only` で refetch
2. **3 秒間隔・最大 30 秒**、サブグラフ上で次の条件を満たす mint が揃うまで継続:
   - `from` = 送信者
   - `blockNumber` = tx receipt の block number
   - `to` = 全受信者（batch mint 対応）
3. Apollo キャッシュを更新 → ホームの `useThanksTokenActivity` が同じ variables で購読しているため **自動再描画**

### `$treeId_.thankstoken.send.tsx`

- mint / batchMint 成功後、`pollActivityMintsAfterSend` を **非同期起動**（完了画面表示はブロックしない）
- ポーリング失敗時は `console.error` のみ

### `$treeId._index.tsx`

- `HOME_ACTIVITY_MINTS_LIMIT`（20）を export し、ポーリング側の query variables と一致させる

### `mintThanksToken` / `batchMintThanksToken`

- tx receipt から `blockNumber` を返却（ポーリングのインデックス判定に使用）

## レート制限への影響（見積もり）

| シナリオ | 10 秒あたりの追加 req |
|---------|---------------------|
| 1 人がサンクス送信（パターン B 最大） | ~3〜4（30 秒に分散） |
| 同時 5 人が送信 | ~15〜20 |
| ホーム常時ポーリング 20 人（参考・未採用） | ~40 |

送信者限定のため、通常運用では **既存のクエスト Kanban 等と同程度以下** と見込みます。

## 制限・トレードオフ

- **30 秒以内にサブグラフがインデックス完了しない場合**: ポーリング打ち切り。ホームを離れて戻る、または手動リロードで反映
- **他メンバーが送った THX** は、ホームを開いたままでは自動更新されない
- **transfer（譲渡）** は対象外（ホームは `mints` のみ表示。通常の「サンクスを送る」は mint）
- Discord bot 経由の `/thx` 送信後、Web UI のホームは本 PR では更新されない（bot は別クライアント）

## Test plan

- [ ] Sepolia / Base でサンクスを 1 人に送信 → 完了後ホームへ → 「最近のアクティビティ」に自分の送信が表示される
- [ ] 複数人への batch 送信 → 同上
- [ ] 送信直後にホームへ戻る（インデックス前）→ 数秒以内に一覧が更新される
- [ ] 送信メッセージ付き → メッセージがアクティビティ行に表示される
- [ ] `pnpm frontend typecheck` が通る

## 変更ファイル

- `pkgs/frontend/hooks/useThanksToken.ts`
- `pkgs/frontend/app/routes/$treeId_.thankstoken.send.tsx`
- `pkgs/frontend/app/routes/$treeId._index.tsx`