### PR TITLE
fix(frontend): AppShell 内の画面遷移・ステップ切替でスクロール位置を先頭へリセット (#549)

### DIFF
--- a/pkgs/frontend/app/routes/$treeId_.$hatId_.assign.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.$hatId_.assign.tsx
@@ -3,16 +3,10 @@ import axios from "axios";
 import { useAddressesByNames, useNamesByAddresses } from "hooks/useENS";
 import { useGetHat, useTreeInfo } from "hooks/useHats";
 import { useMintHatFromTimeFrameModule } from "hooks/useHatsTimeFrameModule";
+import { useScrollToTop } from "hooks/useScrollToTop";
 import { useGetWorkspace } from "hooks/useWorkspace";
 import type { NameData } from "namestone-sdk";
-import {
-  type FC,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type FC, useCallback, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import type { HatsDetailSchama } from "types/hats";
@@ -242,26 +236,7 @@ const AssignDuty: FC = () => {
     address: trimmed as Address,
   };
 
-  // Reset the scroll container to the top on mount — AppShell wraps routes in
-  // `<main overflow-y-auto>`, so window.scrollTo alone is a no-op; walk up the
-  // DOM to find the actual scroll container. Later steps are short enough that
-  // the browser clamps the scroll position on its own when content shrinks.
-  const rootRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const el = rootRef.current;
-    if (!el) return;
-    let node: HTMLElement | null = el;
-    while (node) {
-      if (node.scrollHeight > node.clientHeight) {
-        node.scrollTo({ top: 0, behavior: "auto" });
-        break;
-      }
-      node = node.parentElement;
-    }
-    if (typeof window !== "undefined") {
-      window.scrollTo({ top: 0, behavior: "auto" });
-    }
-  }, []);
+  const rootRef = useScrollToTop([step]);
 
   const goToDetail = useCallback(
     () => navigate(`/${treeId}/${hatId}`),

--- a/pkgs/frontend/app/routes/$treeId_.$hatId_.edit.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.$hatId_.edit.tsx
@@ -4,15 +4,9 @@ import {
   useUploadHatsDetailsToIpfs,
   useUploadImageFileToIpfs,
 } from "hooks/useIpfs";
+import { useScrollToTop } from "hooks/useScrollToTop";
 import { useActiveWallet } from "hooks/useWallet";
-import {
-  type FC,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type FC, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import type { HatsDetailSchama } from "types/hats";
@@ -91,24 +85,7 @@ const EditRole: FC = () => {
     setFallbackIcon(pickRandomDutyIcon());
   }, []);
 
-  // Scroll to top on mount so the form opens at the header, not wherever the
-  // previous page left the AppShell scroll container.
-  const rootRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const el = rootRef.current;
-    if (!el) return;
-    let node: HTMLElement | null = el;
-    while (node) {
-      if (node.scrollHeight > node.clientHeight) {
-        node.scrollTo({ top: 0, behavior: "auto" });
-        break;
-      }
-      node = node.parentElement;
-    }
-    if (typeof window !== "undefined") {
-      window.scrollTo({ top: 0, behavior: "auto" });
-    }
-  }, []);
+  const rootRef = useScrollToTop();
 
   // Newly-picked file wins over the on-chain imageUri; otherwise show whatever
   // the hat currently points at.

--- a/pkgs/frontend/app/routes/$treeId_.roles_.new.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.roles_.new.tsx
@@ -4,16 +4,10 @@ import {
   useUploadHatsDetailsToIpfs,
   useUploadImageFileToIpfs,
 } from "hooks/useIpfs";
+import { useScrollToTop } from "hooks/useScrollToTop";
 import { useActiveWallet } from "hooks/useWallet";
 import { useGetWorkspace } from "hooks/useWorkspace";
-import {
-  type FC,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type FC, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import type { Address } from "viem";
@@ -55,27 +49,7 @@ const NewRole: FC = () => {
     setFallbackIcon(pickRandomDutyIcon());
   }, []);
 
-  // Reset the AppShell's scroll container to the top on mount — otherwise the
-  // user lands on this form scrolled down to wherever they were on the
-  // previous page. `window.scrollTo` is a no-op because AppShell wraps the
-  // routes in `<main overflow-y-auto>`, so we walk up the DOM to find the
-  // actual scroll container.
-  const rootRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const el = rootRef.current;
-    if (!el) return;
-    let node: HTMLElement | null = el;
-    while (node) {
-      if (node.scrollHeight > node.clientHeight) {
-        node.scrollTo({ top: 0, behavior: "auto" });
-        break;
-      }
-      node = node.parentElement;
-    }
-    if (typeof window !== "undefined") {
-      window.scrollTo({ top: 0, behavior: "auto" });
-    }
-  }, []);
+  const rootRef = useScrollToTop();
 
   const { wallet } = useActiveWallet();
   const { data: workspace } = useGetWorkspace({ workspaceId: treeId || "" });

--- a/pkgs/frontend/app/routes/$treeId_.scheduled.new.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.scheduled.new.tsx
@@ -6,6 +6,7 @@ import {
   useScheduledDistributor,
   useScheduledDistributorFactory,
 } from "hooks/useScheduledDistributor";
+import { useScrollToTop } from "hooks/useScrollToTop";
 import { chainId as currentChainId } from "hooks/useViem";
 import { useActiveWallet } from "hooks/useWallet";
 import { useGetWorkspace } from "hooks/useWorkspace";
@@ -392,8 +393,10 @@ const ScheduledNew: FC = () => {
     }
   };
 
+  const rootRef = useScrollToTop([step]);
+
   return (
-    <div className="pb-8">
+    <div ref={rootRef} className="pb-8">
       <ScreenHeader
         title={
           step === 0 ? "予約分配を作成" : step === 1 ? "原資を預ける" : "完了"

--- a/pkgs/frontend/app/routes/$treeId_.splits.new.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.splits.new.tsx
@@ -5,15 +5,9 @@ import {
   useSetName,
 } from "hooks/useENS";
 import { useAssignableHats } from "hooks/useHats";
+import { useScrollToTop } from "hooks/useScrollToTop";
 import { useSplitsCreator } from "hooks/useSplitsCreator";
-import {
-  type FC,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type FC, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 import { ipfs2https } from "utils/ipfs";
@@ -98,27 +92,7 @@ const SplitterNew: FC = () => {
   // Flow state.
   const [step, setStep] = useState<Step>("form");
 
-  // Each step change resets the scroll position to the top. AppShell wraps
-  // routes in its own `<main>` with `overflow-y-auto`, so `window.scrollTo`
-  // is a no-op here — we walk up from this component's root and ask the
-  // ancestor scroll container to reset.
-  const rootRef = useRef<HTMLDivElement>(null);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll-on-step-change is the entire point of this effect; `step` must stay in the deps array even though the body doesn't read it.
-  useEffect(() => {
-    const el = rootRef.current;
-    if (!el) return;
-    let node: HTMLElement | null = el;
-    while (node) {
-      if (node.scrollHeight > node.clientHeight) {
-        node.scrollTo({ top: 0, behavior: "auto" });
-        break;
-      }
-      node = node.parentElement;
-    }
-    if (typeof window !== "undefined") {
-      window.scrollTo({ top: 0, behavior: "auto" });
-    }
-  }, [step]);
+  const rootRef = useScrollToTop([step]);
 
   // Step 1 — form state.
   const [splitterName, setSplitterName] = useState("");

--- a/pkgs/frontend/app/routes/$treeId_.thankstoken.send.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.thankstoken.send.tsx
@@ -1,6 +1,7 @@
 import { MintThanksToken_OrderBy, type OrderDirection } from "gql/graphql";
 import { useActiveWalletIdentity, useNamesByAddresses } from "hooks/useENS";
 import { useTreeInfo } from "hooks/useHats";
+import { useScrollToTop } from "hooks/useScrollToTop";
 import { useGetMintThanksTokens, useThanksToken } from "hooks/useThanksToken";
 import type { NameData } from "namestone-sdk";
 import {
@@ -313,8 +314,10 @@ const ThanksTokenSend: FC = () => {
   const showStepBar =
     step === "recipient" || step === "compose" || step === "confirm";
 
+  const rootRef = useScrollToTop([step]);
+
   return (
-    <PageContainer className="pt-2 pb-24">
+    <PageContainer ref={rootRef} className="pt-2 pb-24">
       {showHeader && (
         <ScreenHeader
           className="-mx-4 px-4 md:-mx-6 md:px-6"

--- a/pkgs/frontend/app/routes/workspace.new.tsx
+++ b/pkgs/frontend/app/routes/workspace.new.tsx
@@ -4,6 +4,7 @@ import {
   useUploadHatsDetailsToIpfs,
   useUploadImageFileToIpfs,
 } from "hooks/useIpfs";
+import { useScrollToTop } from "hooks/useScrollToTop";
 import { useActiveWallet } from "hooks/useWallet";
 import { type FC, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
@@ -210,9 +211,10 @@ const WorkspaceNew: FC = () => {
   };
 
   const stepIndex = STEP_INDEX[step];
+  const rootRef = useScrollToTop([step]);
 
   return (
-    <div className="flex min-h-dvh flex-col bg-bg pb-6">
+    <div ref={rootRef} className="flex min-h-dvh flex-col bg-bg pb-6">
       {step !== "done" && (
         <>
           <ScreenHeader

--- a/pkgs/frontend/hooks/useScrollToTop.ts
+++ b/pkgs/frontend/hooks/useScrollToTop.ts
@@ -1,32 +1,56 @@
 import {
   type DependencyList,
   type RefObject,
-  useEffect,
+  useLayoutEffect,
   useRef,
 } from "react";
 
 /** Stable empty deps for mount-only scroll reset. */
 const MOUNT_ONLY: DependencyList = [];
 
+const isVerticalScrollContainer = (el: HTMLElement): boolean => {
+  const { overflowY } = getComputedStyle(el);
+  return (
+    overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay"
+  );
+};
+
 /**
- * Scroll the nearest scrollable ancestor of `fromEl` (and `window`) to the top.
+ * Scroll overflow ancestors of `fromEl` (and `window`) to the top.
  *
  * AppShell renders routes inside `<main className="overflow-y-auto">`, so
  * `window.scrollTo` alone does not reset the visible scroll position.
+ *
+ * We reset every `overflow-y: auto|scroll` ancestor — not only the first
+ * whose `scrollHeight > clientHeight`. After a wizard step shrinks the page,
+ * the container may no longer overflow while `scrollTop` is still clamped
+ * partway down, which leaves the next step visibly scrolled.
  */
 export function scrollAncestorToTop(fromEl: HTMLElement | null): void {
-  if (!fromEl) return;
+  if (typeof document === "undefined") return;
+
+  const seen = new Set<HTMLElement>();
+
   let node: HTMLElement | null = fromEl;
   while (node) {
-    if (node.scrollHeight > node.clientHeight) {
-      node.scrollTo({ top: 0, behavior: "auto" });
-      break;
+    if (isVerticalScrollContainer(node)) {
+      seen.add(node);
+      node.scrollTop = 0;
     }
     node = node.parentElement;
   }
-  if (typeof window !== "undefined") {
-    window.scrollTo({ top: 0, behavior: "auto" });
+
+  // AppShell `<main>` — belt-and-suspenders when the walk misses it.
+  const appShellMain = document.querySelector<HTMLElement>(
+    '[data-slot="app-shell"] main',
+  );
+  if (appShellMain && !seen.has(appShellMain)) {
+    appShellMain.scrollTop = 0;
   }
+
+  window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+  document.documentElement.scrollTop = 0;
+  document.body.scrollTop = 0;
 }
 
 /**
@@ -40,8 +64,13 @@ export function useScrollToTop(
 ): RefObject<HTMLDivElement> {
   const rootRef = useRef<HTMLDivElement>(null);
   // biome-ignore lint/correctness/useExhaustiveDependencies: caller-supplied deps control when scroll resets
-  useEffect(() => {
+  useLayoutEffect(() => {
     scrollAncestorToTop(rootRef.current);
+    // Step swaps can change layout after the first pass (shorter/longer panels).
+    const frame = requestAnimationFrame(() => {
+      scrollAncestorToTop(rootRef.current);
+    });
+    return () => cancelAnimationFrame(frame);
   }, deps ?? MOUNT_ONLY);
   return rootRef;
 }

--- a/pkgs/frontend/hooks/useScrollToTop.ts
+++ b/pkgs/frontend/hooks/useScrollToTop.ts
@@ -1,0 +1,47 @@
+import {
+  type DependencyList,
+  type RefObject,
+  useEffect,
+  useRef,
+} from "react";
+
+/** Stable empty deps for mount-only scroll reset. */
+const MOUNT_ONLY: DependencyList = [];
+
+/**
+ * Scroll the nearest scrollable ancestor of `fromEl` (and `window`) to the top.
+ *
+ * AppShell renders routes inside `<main className="overflow-y-auto">`, so
+ * `window.scrollTo` alone does not reset the visible scroll position.
+ */
+export function scrollAncestorToTop(fromEl: HTMLElement | null): void {
+  if (!fromEl) return;
+  let node: HTMLElement | null = fromEl;
+  while (node) {
+    if (node.scrollHeight > node.clientHeight) {
+      node.scrollTo({ top: 0, behavior: "auto" });
+      break;
+    }
+    node = node.parentElement;
+  }
+  if (typeof window !== "undefined") {
+    window.scrollTo({ top: 0, behavior: "auto" });
+  }
+}
+
+/**
+ * Attach the returned ref to a page root and reset scroll when appropriate.
+ *
+ * - `useScrollToTop()` — reset on mount (e.g. navigating into a new route).
+ * - `useScrollToTop([step])` — reset whenever a wizard step changes.
+ */
+export function useScrollToTop(
+  deps?: DependencyList,
+): RefObject<HTMLDivElement> {
+  const rootRef = useRef<HTMLDivElement>(null);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: caller-supplied deps control when scroll resets
+  useEffect(() => {
+    scrollAncestorToTop(rootRef.current);
+  }, deps ?? MOUNT_ONLY);
+  return rootRef;
+}


### PR DESCRIPTION
## Summary
- AppShell の `<main overflow-y-auto>` 内でスクロールしているため、`window` 向けの `<ScrollRestoration />` ではリセットされず、同一ルートのステップ切替や画面遷移でスクロール位置が引き継がれていた問題を修正
- `useScrollToTop` を追加し、スクロール可能な祖先（AppShell の `<main>` 含む）を先頭へ戻す処理を共通化
- **ルート遷移**: `AppShellLayout` で pathname 変更時にリセット（`/{treeId}/...` 全般）
- **ウィザード**: サンクス送信・分配作成・担当追加・ワークスペース作成・予約分配作成。ロール作成・当番編集のインライン実装もフックに置換
- **タブ / フィルタ**: アクティビティ、当番一覧、Quest カンバン（モバイル）
- **デスクトップ master-detail**: 当番・分配・予約分配・メンバー一覧の詳細パネル
- **Sheet**: ロールシェア送信のステップ切替

Fixes #549

## Test plan
- [ ] モバイル幅: サンクス送信 — メンバー一覧を下までスクロール → 「N人に送る」→ 送る量画面の先頭（ヘッダー・スライダー）が表示される
- [ ] サンクス送信: compose ↔ confirm ↔ 戻る の各遷移で先頭に戻る
- [ ] 分配作成・担当追加・ワークスペース作成・予約分配作成: ステップ進行・戻るで先頭に戻る
- [ ] メンバー一覧を下までスクロール → メンバー詳細へ遷移 → 先頭から表示される
- [ ] アクティビティ: リストを下までスクロール → グラフタブ → 先頭から表示される
- [ ] 当番一覧: 「すべて」を下までスクロール → 「あなたの当番」→ 先頭から表示される
- [ ] デスクトップ: 当番 / 分配 / 予約分配 / メンバーのマスターで下の行を選び、詳細パネルが先頭から表示される
- [ ] ロール作成・当番編集: スクロールした一覧から遷移しても先頭から表示される
- [ ] デスクトップ幅: regressions なし