### PR TITLE
feat: Discord フロント起点インストール & UI 修正

### DIFF
--- a/pkgs/extensions/discord-bot/CLAUDE.md
+++ b/pkgs/extensions/discord-bot/CLAUDE.md
@@ -29,8 +29,8 @@ Cloudflare Workers + D1 Discord bot. Provides `/toban-link`, `/toban-setup`,
 
 ```
 src/
-  index.ts                  Workers entry; routes /discord/interactions
-                            and /api/install/callback
+  index.ts                  Workers entry; routes /discord/interactions,
+                            /api/install/start and /api/install/callback
   env.ts                    Env / bindings type
   interactions/verify.ts    Ed25519 verification (crypto.subtle, no
                             tweetnacl)
@@ -45,7 +45,8 @@ src/
     thx.ts                  /thx end-to-end (resolve, check, sign, send)
     quest-submit.ts         /quest submit + `quest` autocomplete handler
     responses.ts            Discord response/followup helpers
-  api/install/callback.ts   OAuth bot-install callback
+  api/install/start.ts      frontend-initiated install entry (signs state)
+  api/install/callback.ts   OAuth bot-install callback (binds + registers cmds)
 turnkey/policy.json         Declarative policy stub (version-controlled)
 docs/
   turnkey-setup.md          dev/prod sub-org + stamper provisioning

--- a/pkgs/extensions/discord-bot/README.md
+++ b/pkgs/extensions/discord-bot/README.md
@@ -36,9 +36,15 @@ admin が /toban-link <workspace-url>      →  guild ↔ workspace を bind
 
 ### 1. bot を Discord サーバーに招待する
 
-オーナーは Discord developer portal で生成した OAuth invite URL (scope: `bot` + `applications.commands`、permission: `Send Messages` 最小) を開き、対象サーバーを選んで認証します。この時点では bot は guild に存在しているだけで、どの Toban workspace に対応しているかはまだ知りません。
+導線は2つあります。
+
+**A. フロント起点 (推奨・自動)** — ワークスペースの `/<treeId>/discord-bot` 画面（管理者のみ表示）の「サーバーに追加」ボタンから。ボタンは bot Worker の `GET /api/install/start?treeId=<treeId>` に遷移し、Worker が `INSTALL_STATE_SECRET` で署名した短命の install-state JWT (`{ treeId, jti }`) を付けて Discord OAuth authorize へリダイレクトします。admin がサーバーを選んで認証すると Discord が `/api/install/callback` にリダイレクトし、callback が**ワークスペース紐付け (Step 2) とそのサーバーへの slash command 登録を自動で実行**します。`/toban-link` も手動 `register-commands` も不要。state はサーバーを事前に固定しません（admin が consent 画面で選ぶまで guild は不明なため）。callback は OAuth token 交換で Discord が返した guild をそのまま bind します。
+
+**B. 素の invite URL (手動)** — Discord developer portal で生成した OAuth invite URL (scope: `bot` + `applications.commands`、permission: `Send Messages` 最小) を開いて認証。この場合 bot は guild に居るだけで、slash command 登録 (前提条件の `register-commands`) と紐付け (Step 2 の `/toban-link`) は手動になります。
 
 ### 2. サーバーと Toban workspace を紐づける
+
+> フロント起点フロー (Step 1-A) を使った場合、この Step は callback が自動で済ませるので手動 `/toban-link` は不要です。
 
 サーバー内で admin が:
 
@@ -131,8 +137,9 @@ bot → identity の通信はすべて `env.IDENTITY.fetch(...)` (service bindin
 
 ```
 src/
-  index.ts                  Workers entry; /discord/interactions と
-                            /api/install/callback をルーティング
+  index.ts                  Workers entry; /discord/interactions,
+                            /api/install/start, /api/install/callback を
+                            ルーティング
   env.ts                    Env / bindings 型
   interactions/verify.ts    Ed25519 検証 (crypto.subtle、tweetnacl 不使用)
   verifier.ts               ES256 verifier_token issuer (/toban-setup 用)
@@ -148,7 +155,9 @@ src/
     balance.ts              mintAllowance + mintable budget (THX 単位) 表示
     thx.ts                  /thx の end-to-end (resolve, check, sign, send)
     responses.ts            Discord response / followup ヘルパー
-  api/install/callback.ts   OAuth bot-install callback (frontend 起点フロー)
+  api/install/start.ts      install-state JWT を署名し Discord OAuth へ
+                            リダイレクト (frontend 起点フローの入口)
+  api/install/callback.ts   OAuth bot-install callback: 紐付け + command 登録
 turnkey/policy.json         宣言的 policy stub (版管理)
 docs/
   turnkey-setup.md          dev / prod sub-org + stamper provisioning
@@ -214,7 +223,7 @@ Turnkey は bot の Ethereum 署名鍵を TEE 内に保持します。Worker は
 
 ### Step 4 — その他の周辺値
 
-- `INSTALL_STATE_SECRET` — `/toban-link` 発行 / `/api/install/callback` 消費 の install-state JWT 用 HMAC キー。新規生成:
+- `INSTALL_STATE_SECRET` — `/api/install/start` 署名 / `/api/install/callback` 検証 の install-state JWT 用 HMAC キー (同一 Worker が署名・検証するので対称 HMAC で十分)。新規生成:
   ```bash
   openssl rand -hex 32
   ```
@@ -313,7 +322,8 @@ Discord developer portal → **OAuth2** → **URL Generator** → scopes `bot` +
 ```bash
 # Worker が動いてる
 curl -i https://toban-discord-bot.<account>.workers.dev/anything
-#   → 404 (route は /discord/interactions と /api/install/callback だけ)
+#   → 404 (route は /discord/interactions, /api/install/start,
+#         /api/install/callback だけ)
 
 # identity 側の binding が見える
 pnpm --filter @toban/identity exec wrangler d1 execute toban-identity --remote \

--- a/pkgs/extensions/discord-bot/src/api/install/callback.ts
+++ b/pkgs/extensions/discord-bot/src/api/install/callback.ts
@@ -3,15 +3,18 @@
  *
  * Discord OAuth bot-install callback for the frontend-initiated install
  * flow ("Connect Discord" button on a workspace page). Steps:
- *   1. Verify the install-state JWT (issued by the frontend with
- *      `{ treeId, guild_id, jti }` claims and a pinned algorithm).
- *   2. Confirm the URL's `guild_id` matches the state JWT's `guild_id`.
- *   3. Single-use claim the JWT's `jti` so the state cannot replay.
- *   4. Exchange the OAuth `code` against Discord's token endpoint and
- *      confirm Discord returns the same `guild.id` we're binding to.
- *   5. `identity.upsertPlatformLink(...)` to persist guild_id -> tree_id.
- *   6. Register the slash commands on the new guild.
- *   7. Redirect the admin back to the workspace allowance page.
+ *   1. Verify the install-state JWT (issued by `/api/install/start` with
+ *      `{ treeId, jti }` claims and a pinned algorithm).
+ *   2. Single-use claim the JWT's `jti` so the state cannot replay.
+ *   3. Exchange the OAuth `code` against Discord's token endpoint and
+ *      confirm Discord returns the same `guild.id` present in the callback
+ *      query — this is the authoritative "the bot really landed on this
+ *      guild" signal. The state does NOT pin a guild: the admin picks the
+ *      target server on Discord's consent screen, so it's unknown when the
+ *      state is minted; we bind to whatever guild the grant actually names.
+ *   4. `identity.upsertPlatformLink(...)` to persist guild_id -> tree_id.
+ *   5. Register the slash commands on the new guild.
+ *   6. Redirect the admin back to the workspace allowance page.
  *
  * Discord-initiated installs (admin runs `/toban-link <workspace_url>`
  * in an already-invited server) bypass this handler and bind directly
@@ -102,7 +105,6 @@ const VALID_TREE_ID = /^[0-9]+$/;
 
 interface InstallStateClaims {
   treeId: string;
-  guildId: string;
   jti: string;
 }
 
@@ -129,18 +131,14 @@ async function verifyInstallState(
     requiredClaims: ["jti"],
   });
   const treeId = payload.treeId;
-  const guildId = payload.guild_id ?? payload.guildId;
   const jti = payload.jti;
   if (typeof treeId !== "string" || !VALID_TREE_ID.test(treeId)) {
     throw new Error("state.treeId is not a decimal tree id");
   }
-  if (typeof guildId !== "string" || guildId.length === 0) {
-    throw new Error("state.guild_id is missing");
-  }
   if (typeof jti !== "string" || jti.length === 0) {
     throw new Error("state.jti is missing");
   }
-  return { treeId, guildId, jti };
+  return { treeId, jti };
 }
 
 interface OAuthExchangeResult {
@@ -231,13 +229,6 @@ export async function handleInstallCallback(
     return new Response(`invalid state: ${(err as Error).message}`, {
       status: 400,
     });
-  }
-
-  // The JWT bound itself to a specific guild — refuse to bind anywhere
-  // else, even if Discord redirected with a guild_id of the attacker's
-  // choosing.
-  if (parsedState.guildId !== guildId) {
-    return new Response("guild_id does not match state", { status: 400 });
   }
 
   const identity = deps.identity ?? createIdentityClient(env);

--- a/pkgs/extensions/discord-bot/src/api/install/start.ts
+++ b/pkgs/extensions/discord-bot/src/api/install/start.ts
@@ -1,0 +1,89 @@
+/**
+ * GET /api/install/start?treeId=<decimal>
+ *
+ * Entry point for the frontend-initiated Discord install. The frontend
+ * ("サーバーに追加" button on `/<treeId>/discord-bot`) links here rather than
+ * to Discord directly, because the OAuth `state` must be signed with
+ * `INSTALL_STATE_SECRET` — a Worker secret the browser must never see.
+ *
+ * Steps:
+ *   1. Validate `treeId` (decimal tree id).
+ *   2. Mint a single-use `jti` and sign a short-lived install-state JWT
+ *      binding `{ treeId, jti }`. The guild is deliberately NOT committed
+ *      here: the admin chooses the target server on Discord's consent
+ *      screen, so we can't know it yet. `/api/install/callback` binds to
+ *      whichever guild Discord actually grants (confirmed via the OAuth
+ *      token exchange).
+ *   3. 302-redirect the browser to Discord's OAuth authorize URL with the
+ *      `bot` + `applications.commands` scopes so the callback can register
+ *      slash commands on the new guild.
+ *
+ * Pairs with `callback.ts` (which consumes the `state` and jti).
+ */
+import { SignJWT, importPKCS8 } from "jose";
+import type { Env } from "../../env";
+
+const ISSUER = "toban-discord-bot";
+/** Enough for the Discord consent hand-off; bounds a leaked state's life. */
+const STATE_TTL_SECONDS = 10 * 60;
+/** 2048 = Send Messages — the minimum the bot needs (DMs the setup link). */
+const BOT_PERMISSIONS = "2048";
+const VALID_TREE_ID = /^[0-9]+$/;
+
+/**
+ * Sign the install-state JWT. Mirrors `verifyInstallState`'s dual-format
+ * handling in `callback.ts`: a PEM PKCS8 key signs ES256 (asymmetric,
+ * preferred for prod), any other string is an HMAC secret signing HS256
+ * (convenient when the same Worker both signs and verifies).
+ */
+async function signInstallState(
+  env: Env,
+  claims: { treeId: string; jti: string },
+  nowSeconds: number,
+): Promise<string> {
+  const isPem = env.INSTALL_STATE_SECRET.includes("BEGIN");
+  const jwt = new SignJWT({ treeId: claims.treeId })
+    .setProtectedHeader({ alg: isPem ? "ES256" : "HS256" })
+    .setIssuer(ISSUER)
+    .setJti(claims.jti)
+    .setIssuedAt(nowSeconds)
+    .setExpirationTime(nowSeconds + STATE_TTL_SECONDS);
+  const key = isPem
+    ? await importPKCS8(env.INSTALL_STATE_SECRET, "ES256")
+    : new TextEncoder().encode(env.INSTALL_STATE_SECRET);
+  return jwt.sign(key);
+}
+
+export async function handleInstallStart(
+  env: Env,
+  request: Request,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const treeId = url.searchParams.get("treeId");
+  if (!treeId || !VALID_TREE_ID.test(treeId)) {
+    return new Response("missing or invalid treeId", { status: 400 });
+  }
+
+  const jti = crypto.randomUUID();
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const state = await signInstallState(env, { treeId, jti }, nowSeconds);
+
+  const redirectUri = `${env.BOT_WORKER_URL.replace(/\/$/, "")}/api/install/callback`;
+  const authorize = new URL("https://discord.com/api/oauth2/authorize");
+  authorize.searchParams.set("client_id", env.DISCORD_APP_ID);
+  authorize.searchParams.set("scope", "bot applications.commands");
+  authorize.searchParams.set("permissions", BOT_PERMISSIONS);
+  authorize.searchParams.set("response_type", "code");
+  authorize.searchParams.set("redirect_uri", redirectUri);
+  authorize.searchParams.set("state", state);
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      location: authorize.toString(),
+      // The state rides in the query of the outbound redirect; keep it out
+      // of any downstream Referer.
+      "referrer-policy": "no-referrer",
+    },
+  });
+}

--- a/pkgs/extensions/discord-bot/src/index.ts
+++ b/pkgs/extensions/discord-bot/src/index.ts
@@ -3,6 +3,7 @@
  *
  * Routes:
  *   POST /discord/interactions  -> Ed25519-verified Discord interaction
+ *   GET  /api/install/start     -> begin frontend-initiated bot install
  *   GET  /api/install/callback  -> OAuth bot-install callback
  *
  * Anything else returns 404.
@@ -15,6 +16,7 @@ import {
   InteractionType,
 } from "discord-api-types/v10";
 import { handleInstallCallback } from "./api/install/callback";
+import { handleInstallStart } from "./api/install/start";
 import { handleBalance } from "./commands/balance";
 import {
   executeQuestSubmit,
@@ -122,6 +124,9 @@ export default {
     const url = new URL(request.url);
     if (request.method === "POST" && url.pathname === "/discord/interactions") {
       return handleInteraction(env, ctx, request);
+    }
+    if (request.method === "GET" && url.pathname === "/api/install/start") {
+      return handleInstallStart(env, request);
     }
     if (request.method === "GET" && url.pathname === "/api/install/callback") {
       return handleInstallCallback(env, request);

--- a/pkgs/extensions/discord-bot/test/install-start.test.ts
+++ b/pkgs/extensions/discord-bot/test/install-start.test.ts
@@ -1,0 +1,83 @@
+import { jwtVerify } from "jose";
+import { describe, expect, it } from "vitest";
+import { handleInstallStart } from "../src/api/install/start";
+import type { Env } from "../src/env";
+
+const SECRET = "test-install-state-secret-hs256";
+
+// Only the fields handleInstallStart touches; the rest of Env is irrelevant.
+const env = {
+  INSTALL_STATE_SECRET: SECRET,
+  BOT_WORKER_URL: "https://bot.example.workers.dev",
+  DISCORD_APP_ID: "1234567890",
+} as unknown as Env;
+
+function callStart(treeId: string | null): Promise<Response> {
+  const url =
+    treeId === null
+      ? "https://bot.example.workers.dev/api/install/start"
+      : `https://bot.example.workers.dev/api/install/start?treeId=${treeId}`;
+  return handleInstallStart(env, new Request(url));
+}
+
+describe("handleInstallStart", () => {
+  it("rejects a missing treeId with 400", async () => {
+    const res = await callStart(null);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-decimal treeId with 400", async () => {
+    const res = await callStart("0xabc");
+    expect(res.status).toBe(400);
+  });
+
+  it("redirects to Discord OAuth with a verifiable state JWT", async () => {
+    const res = await callStart("1888");
+    expect(res.status).toBe(302);
+
+    const location = res.headers.get("location");
+    expect(location).toBeTruthy();
+    const authorize = new URL(location as string);
+    expect(authorize.origin + authorize.pathname).toBe(
+      "https://discord.com/api/oauth2/authorize",
+    );
+    expect(authorize.searchParams.get("client_id")).toBe("1234567890");
+    expect(authorize.searchParams.get("scope")).toBe(
+      "bot applications.commands",
+    );
+    expect(authorize.searchParams.get("response_type")).toBe("code");
+    expect(authorize.searchParams.get("redirect_uri")).toBe(
+      "https://bot.example.workers.dev/api/install/callback",
+    );
+
+    // The state must be a JWT this Worker's secret can verify, and carry the
+    // treeId + a jti (the callback single-use claims the jti). Crucially it
+    // does NOT pin a guild — the admin picks that on Discord's consent screen.
+    const state = authorize.searchParams.get("state");
+    expect(state).toBeTruthy();
+    const { payload } = await jwtVerify(
+      state as string,
+      new TextEncoder().encode(SECRET),
+      { issuer: "toban-discord-bot", algorithms: ["HS256"] },
+    );
+    expect(payload.treeId).toBe("1888");
+    expect(typeof payload.jti).toBe("string");
+    expect((payload.jti as string).length).toBeGreaterThan(0);
+    expect(payload.guild_id).toBeUndefined();
+    expect(payload.guildId).toBeUndefined();
+  });
+
+  it("mints a fresh jti per call (single-use replay protection)", async () => {
+    const decodeJti = async (res: Response) => {
+      const loc = new URL(res.headers.get("location") as string);
+      const { payload } = await jwtVerify(
+        loc.searchParams.get("state") as string,
+        new TextEncoder().encode(SECRET),
+        { issuer: "toban-discord-bot", algorithms: ["HS256"] },
+      );
+      return payload.jti as string;
+    };
+    const [a, b] = await Promise.all([callStart("1888"), callStart("1888")]);
+    expect(await decodeJti(a)).not.toBe(await decodeJti(b));
+  });
+});

--- a/pkgs/frontend/.env.example
+++ b/pkgs/frontend/.env.example
@@ -31,3 +31,10 @@ VITE_IDENTITY_WORKER_URL=
 #   sepolia: 0xae4E13De7C14Dff7ff296De69cADf3A7F5208461
 #   base:    0xE21E99d384409e119cee731D368359BDc719a5f0
 VITE_DISCORD_BOT_SIGNER_ADDRESS=
+# discord-bot Worker の公開 URL。「サーバーに追加」ボタンが
+# <URL>/api/install/start?treeId=... に遷移し、Worker が OAuth state を署名して
+# Discord へリダイレクト → 追加後にワークスペース紐付け + コマンド登録まで自動実行。
+# 未設定だと「サーバーに追加」リンクは表示されない。
+#   sepolia: https://toban-discord-bot.<account>.workers.dev
+#   base:    https://toban-discord-bot-base.<account>.workers.dev
+VITE_BOT_WORKER_URL=

--- a/pkgs/frontend/app/components/PrivyAppRoot.tsx
+++ b/pkgs/frontend/app/components/PrivyAppRoot.tsx
@@ -22,6 +22,9 @@ export default function PrivyAppRoot() {
       config={{
         embeddedWallets: {
           createOnLogin: "users-without-wallets",
+          // Suppress Privy's built-in signature/transaction confirmation modals
+          // for the embedded wallet — writes go through app-level UX instead.
+          showWalletUIs: false,
         },
         externalWallets: {
           coinbaseWallet: {

--- a/pkgs/frontend/app/routes/$treeId_.discord-bot.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.discord-bot.tsx
@@ -32,12 +32,14 @@ function formatAllowance(value: bigint | undefined): string {
 interface QuestAgentSectionProps {
   /** questAgentHat id for this workspace, from the subgraph Workspace entity. */
   questAgentHatId: string | undefined;
-  /** Workspace owner = top-hat wearer (super-admin of every authority hat). */
-  owner: string | undefined;
-  /** operatorHat id — the direct admin of questAgentHat. */
-  operatorHatId: string | undefined;
   /** Bot signer address that should wear the questAgentHat when enabled. */
   botSigner: Address;
+  /**
+   * Whether the connected wallet may mint/revoke the questAgentHat (operatorHat
+   * wearer or workspace owner). Computed once at the page level so the whole
+   * admin surface can be gated on it; passed down here to disable the buttons.
+   */
+  canManage: boolean;
 }
 
 // Grants/revokes the questAgentHat to the Discord bot signer so it can submit
@@ -46,9 +48,8 @@ interface QuestAgentSectionProps {
 // specialised to the single, fixed bot address.
 const QuestAgentSection: FC<QuestAgentSectionProps> = ({
   questAgentHatId: questAgentHatIdStr,
-  owner,
-  operatorHatId,
   botSigner,
+  canManage,
 }) => {
   const { wallet } = useActiveWallet();
   const walletAddress = wallet?.account?.address as Address | undefined;
@@ -73,26 +74,6 @@ const QuestAgentSection: FC<QuestAgentSectionProps> = ({
       })) as boolean,
   });
   const isEnabled = statusQuery.data === true;
-
-  // Only the operatorHat wearer or the workspace owner (top hat) can mint/revoke
-  // the questAgentHat — gate the buttons so we don't prompt a doomed tx.
-  const canManageQuery = useTanstackQuery({
-    queryKey: ["quest-agent-admin", walletAddress, owner, operatorHatId],
-    enabled: !!walletAddress && (!!owner || !!operatorHatId),
-    queryFn: async (): Promise<boolean> => {
-      if (!walletAddress) return false;
-      if (owner && walletAddress.toLowerCase() === owner.toLowerCase()) {
-        return true;
-      }
-      if (!operatorHatId) return false;
-      return (await publicClient.readContract({
-        ...hatsContractBaseConfig,
-        functionName: "isWearerOfHat",
-        args: [walletAddress, BigInt(operatorHatId)],
-      })) as boolean;
-    },
-  });
-  const canManage = canManageQuery.data === true;
 
   const grant = async () => {
     if (!questAgentHatId) return;
@@ -188,6 +169,62 @@ const QuestAgentSection: FC<QuestAgentSectionProps> = ({
   );
 };
 
+interface DiscordInstallCardProps {
+  /** discord-bot Worker URL — from `VITE_BOT_WORKER_URL`. */
+  botWorkerUrl: string | undefined;
+  /** This workspace's tree id — passed to the install-start endpoint. */
+  treeId: string | undefined;
+}
+
+// "Add to server" button. Links to the discord-bot Worker's
+// `/api/install/start?treeId=…`, which signs the OAuth state (the secret can't
+// live in the browser) and redirects to Discord. After the admin picks a
+// server, `/api/install/callback` binds this workspace AND registers the slash
+// commands on the new guild, then redirects back here — no `/toban-link` step
+// and no per-guild manual command registration.
+const DiscordInstallCard: FC<DiscordInstallCardProps> = ({
+  botWorkerUrl,
+  treeId,
+}) => {
+  const installUrl = useMemo(() => {
+    if (!botWorkerUrl || !treeId) return undefined;
+    return `${botWorkerUrl.replace(/\/$/, "")}/api/install/start?treeId=${encodeURIComponent(treeId)}`;
+  }, [botWorkerUrl, treeId]);
+
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <Heading variant="h3" level={2}>
+            Discord サーバーに追加
+          </Heading>
+          <Typography variant="bodySm" tone="secondary">
+            Toban bot を Discord
+            サーバーに追加します。サーバーを選んで認証すると、
+            このワークスペースへの紐付けとスラッシュコマンドの登録まで自動で完了し、
+            この画面に戻ります。
+          </Typography>
+        </div>
+
+        {installUrl ? (
+          <Button asChild full>
+            <a href={installUrl} rel="noopener">
+              <SiDiscord size={18} />
+              サーバーに追加
+              <Icon name="arrow-right" size={16} />
+            </a>
+          </Button>
+        ) : (
+          <Typography variant="caption" tone="danger">
+            VITE_BOT_WORKER_URL
+            が未設定のため、インストールリンクを生成できません。
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
 const DiscordBotWorkspace: FC = () => {
   const { treeId } = useParams<{ treeId: string }>();
 
@@ -198,6 +235,9 @@ const DiscordBotWorkspace: FC = () => {
   const botSigner = import.meta.env.VITE_DISCORD_BOT_SIGNER_ADDRESS as
     | Address
     | undefined;
+  const botWorkerUrl = import.meta.env.VITE_BOT_WORKER_URL as
+    | string
+    | undefined;
 
   const { data: workspaceData } = useGetWorkspace({
     workspaceId: treeId ?? "",
@@ -205,6 +245,30 @@ const DiscordBotWorkspace: FC = () => {
   const thanksToken = workspaceData?.workspace?.thanksToken?.id as
     | Address
     | undefined;
+  const owner = workspaceData?.workspace?.owner ?? undefined;
+  const operatorHatId = workspaceData?.workspace?.operatorHatId ?? undefined;
+
+  // Admin = workspace owner (top hat) or operatorHat wearer. Computed here so
+  // the whole admin surface (server-install link + quest agent) can be gated on
+  // it, rather than each child re-deriving it. Same check the settings page's
+  // authority controls use.
+  const adminQuery = useTanstackQuery({
+    queryKey: ["workspace-admin", walletAddress, owner, operatorHatId],
+    enabled: !!walletAddress && (!!owner || !!operatorHatId),
+    queryFn: async (): Promise<boolean> => {
+      if (!walletAddress) return false;
+      if (owner && walletAddress.toLowerCase() === owner.toLowerCase()) {
+        return true;
+      }
+      if (!operatorHatId) return false;
+      return (await publicClient.readContract({
+        ...hatsContractBaseConfig,
+        functionName: "isWearerOfHat",
+        args: [walletAddress, BigInt(operatorHatId)],
+      })) as boolean;
+    },
+  });
+  const isAdmin = adminQuery.data === true;
 
   const allowanceQuery = useTanstackQuery({
     queryKey: ["discord-bot-allowance", thanksToken, walletAddress, botSigner],
@@ -322,12 +386,31 @@ const DiscordBotWorkspace: FC = () => {
         </CardContent>
       </Card>
 
-      <QuestAgentSection
-        questAgentHatId={workspaceData?.workspace?.questAgentHatId ?? undefined}
-        owner={workspaceData?.workspace?.owner ?? undefined}
-        operatorHatId={workspaceData?.workspace?.operatorHatId ?? undefined}
-        botSigner={botSigner}
-      />
+      {/* 管理者セクション — bot のサーバー追加と Quest 代理権限。owner /
+          operatorHat 保有者にのみ表示する。 */}
+      {isAdmin && (
+        <section className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <Typography variant="label" tone="secondary">
+              管理者設定
+            </Typography>
+            <Typography variant="caption" tone="secondary">
+              ワークスペースの管理者（オーナー / operatorHat
+              保有者）のみが操作できます。
+            </Typography>
+          </div>
+
+          <DiscordInstallCard botWorkerUrl={botWorkerUrl} treeId={treeId} />
+
+          <QuestAgentSection
+            questAgentHatId={
+              workspaceData?.workspace?.questAgentHatId ?? undefined
+            }
+            botSigner={botSigner}
+            canManage={isAdmin}
+          />
+        </section>
+      )}
 
       <section className="flex flex-col gap-2">
         <Heading variant="h3" level={2}>

--- a/pkgs/frontend/app/routes/login.tsx
+++ b/pkgs/frontend/app/routes/login.tsx
@@ -172,12 +172,6 @@ const Login: FC = () => {
           description="Toban はコミュニティで起きた小さな貢献を、感謝として記録し、納得できる分配につなげるサービスです。"
         />
       }
-      footer={
-        <span>
-          続行することで Toban
-          の利用規約とプライバシーポリシーに同意したものとみなされます。
-        </span>
-      }
     >
       <Card className="w-full max-w-sm">
         <CardContent className="flex flex-col gap-3">

--- a/pkgs/frontend/app/styles/globals.css
+++ b/pkgs/frontend/app/styles/globals.css
@@ -141,7 +141,11 @@
     font-family: var(--font-sans);
   }
   body {
-    min-height: 100vh;
+    /* `100vh` is the address-bar-hidden ("large") viewport on mobile, but the
+       AppShell sizes itself with `h-dvh` (dynamic). Mixing the two makes the
+       body taller than the shell while the browser chrome is visible, leaving
+       an empty scrollable strip below the BottomNav. Match the shell's unit. */
+    min-height: 100dvh;
   }
 }
 


### PR DESCRIPTION
## 概要

Discord bot 連携画面からのインストール導線を整備し、コマンド登録・ワークスペース紐付けまで一気通貫にしました。あわせてモバイルのスクロール不整合とログイン/Privy 周りの細かな調整を含みます。

## 変更内容

### 1. Discord フロント起点インストールフロー（コマンド登録まで自動）
`/<treeId>/discord-bot` の「サーバーに追加」から、bot のサーバー追加 → ワークスペース紐付け → スラッシュコマンド登録までを自動化。

**Bot Worker**
- 新規 `GET /api/install/start` — `treeId` を検証し install-state JWT (`{ treeId, jti }`) を `INSTALL_STATE_SECRET` で署名して Discord OAuth authorize へリダイレクト。秘密鍵をブラウザに出さずに state を署名。
- `callback` — state の `guild_id` 事前固定を撤廃し、OAuth token 交換で Discord が返した guild に bind する方式へ変更（admin が consent 画面で選ぶまで guild は不明なため）。
- `install-start` のユニットテスト追加（計 44 tests green）。

**Frontend (`$treeId_.discord-bot.tsx`)**
- 画面を「管理者設定」と「Mint 許可設定」の2セクションに分割。
- Quest 代理申請の権限は管理者（owner / operatorHat 保有者）のみ表示。admin 判定をページ側に集約し `QuestAgentSection` へ `canManage` を渡す。
- 「サーバーに追加」カードを追加。`VITE_BOT_WORKER_URL` の `/api/install/start` へ遷移するだけで `/toban-link` も手動 `register-commands` も不要。

### 2. モバイル viewport 不整合の修正
`body` の `min-height` が `100vh`、`AppShell` は `h-dvh` だったため、モバイルでブラウザクローム表示中に `body` が shell より高くなり BottomNav 下に余分なスクロール領域が発生。`body` を `100dvh` に揃えて解消。

### 3. ログイン / Privy 調整
- ログイン画面の利用規約・プライバシーポリシー同意フッターを削除。
- Privy `embeddedWallets` に `showWalletUIs: false` を設定し、署名・トランザクション確認モーダルを抑制。

## デプロイ時の運用手順
1. Discord Developer Portal の OAuth2 Redirects に `https://<bot-worker>/api/install/callback` が登録済みであること（既存要件）。
2. Bot Worker を再デプロイ（`deploy:sepolia` / `deploy:base`）。関連 secret / vars は既に wrangler に存在。
3. Frontend の `.env` に実際の `VITE_BOT_WORKER_URL` を設定（現状は空プレースホルダ）。

## レビュー時の観点
- install-state の認可モデル（フロント起点フローでの admin 検証）は既存の `/toban-link` の TODO と同水準。フォローアップ要否をレビューで確認したい（詳細はレビューコメントで補足します）。

## 確認状況
- [x] `pnpm frontend typecheck` / `pnpm --filter @toban/discord-bot typecheck`
- [x] `pnpm --filter @toban/discord-bot test`（44 passed）
- [x] `pnpm biome:check`
- [ ] 実 Discord 認証を通した end-to-end 確認は未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)