### PR TITLE
feat(discord-bot): 応答メッセージを日本語化しクエスト名をタイトルで表示

### DIFF
--- a/pkgs/extensions/discord-bot/README.md
+++ b/pkgs/extensions/discord-bot/README.md
@@ -59,9 +59,9 @@ admin が /toban-link <workspace-url>      →  guild ↔ workspace を bind
 bot がやること:
 
 1. URL の `/<treeId>` セグメントから tree id を抽出。
-2. 呼び出し元の Discord snowflake を `IDENTITY.fetch('/api/lookup?provider=discord&account_id=…')` で wallet 解決。未 onboard なら `Run /toban-setup first` を返す (Step 3 へ)。
+2. 呼び出し元の Discord snowflake を `IDENTITY.fetch('/api/lookup?provider=discord&account_id=…')` で wallet 解決。未 onboard なら `先に /toban-setup を実行してください` を返す (Step 3 へ)。
 3. `(provider=discord, platform_id=guild_id, tree_id, installed_by=caller.wallet)` を `IDENTITY.fetch('/api/platform-link', { method: 'POST', body })` で POST。
-4. ephemeral で `✅ Linked this server to Toban workspace <tree>.` と返信。
+4. ephemeral で `✅ このサーバーを Toban ワークスペース <tree> に連携しました。` と返信。
 
 裏では identity Worker が `platform_links` 行を upsert します — wire 形式とテーブルスキーマは [identity README: サーバーと workspace の紐づけ](../identity/README.md#3-サーバーと-workspace-の紐づけ----toban-link--post-apiplatform-link) を参照。
 
@@ -115,8 +115,8 @@ bot は `mintFrom` 署名を **Turnkey が管理する Ethereum 秘密鍵** で�
 
 `amount` と `user` は必須、`address` を指定すると `user.wallet` を上書きします。これでまだ `/toban-setup` を済ませていない相手 (ENS 名所有者など) にも送れます。bot 内部の流れ (`src/commands/thx.ts`):
 
-1. **送信者の wallet を解決** — `IDENTITY.fetch('/api/lookup', …)` で snowflake → wallet。未 bind なら `Run /toban-setup first` を返して終了。
-2. **guild の workspace を解決** — 同じ identity API で `platform_links` を引く。未 link なら `Ask an admin to run /toban-link first` を返して終了。
+1. **送信者の wallet を解決** — `IDENTITY.fetch('/api/lookup', …)` で snowflake → wallet。未 bind なら `先に /toban-setup を実行してください` を返して終了。
+2. **guild の workspace を解決** — 同じ identity API で `platform_links` を引く。未 link なら `管理者に /toban-link の実行を依頼してください` を返して終了。
 3. **受信者の wallet を解決**:
    - `address` が `0x…` の場合: バリデートしてそのまま使用。
    - `address` が `*.eth` の場合: Ethereum mainnet (`env.MAINNET_RPC_URL`) で ENS を resolve — ENS レコードは mint 先 chain によらず mainnet にあるため。
@@ -399,7 +399,7 @@ pnpm --filter @toban/identity exec wrangler d1 execute toban-identity --remote \
 cast balance <TURNKEY_BOT_SIGNER_ADDRESS> --rpc-url <RPC_URL>
 ```
 
-もし `/thx` で「Not enough allowance for the bot」が出るのに approve 済みのつもりであれば、対象 workspace の ThanksToken が乗せ換えられた可能性があります — `https://<TOBAN_FRONTEND_URL>/<treeId>/discord-bot` で新 signer + 新 contract に対して approve し直すよう案内してください。
+もし `/thx` で「Bot に許可された送信枠が足りません」が出るのに approve 済みのつもりであれば、対象 workspace の ThanksToken が乗せ換えられた可能性があります — `https://<TOBAN_FRONTEND_URL>/<treeId>/discord-bot` で新 signer + 新 contract に対して approve し直すよう案内してください。
 
 ## 重要な不変条件
 

--- a/pkgs/extensions/discord-bot/src/api/install/callback.ts
+++ b/pkgs/extensions/discord-bot/src/api/install/callback.ts
@@ -148,16 +148,19 @@ export async function handleInstallCallback(
   const state = url.searchParams.get("state");
   const guildId = url.searchParams.get("guild_id");
   if (!code || !state || !guildId) {
-    return new Response("missing code/state/guild_id", { status: 400 });
+    return new Response("code / state / guild_id が不足しています", {
+      status: 400,
+    });
   }
 
   let parsedState: InstallStateClaims;
   try {
     parsedState = await verifyInstallState(env, state);
   } catch (err) {
-    return new Response(`invalid state: ${(err as Error).message}`, {
-      status: 400,
-    });
+    return new Response(
+      `インストール用の state が不正です: ${(err as Error).message}`,
+      { status: 400 },
+    );
   }
 
   const identity = deps.identity ?? createIdentityClient(env);
@@ -166,7 +169,10 @@ export async function handleInstallCallback(
   // before any side effect.
   const claim = await identity.claimInstallStateJti(parsedState.jti);
   if (!claim.ok) {
-    return new Response("install state already used", { status: 409 });
+    return new Response(
+      "このインストールリンクはすでに使用済みです。ワークスペースの画面からやり直してください。",
+      { status: 409 },
+    );
   }
 
   // Exchange the `code` against Discord so we know the install actually
@@ -177,13 +183,14 @@ export async function handleInstallCallback(
   try {
     exchangeResult = await exchange(env, code);
   } catch (err) {
-    return new Response(`oauth exchange failed: ${(err as Error).message}`, {
-      status: 400,
-    });
+    return new Response(
+      `Discord との認証に失敗しました: ${(err as Error).message}`,
+      { status: 400 },
+    );
   }
   if (exchangeResult.guildId !== guildId) {
     return new Response(
-      "discord granted bot install on a different guild than requested",
+      "Discord から許可されたサーバーが、リクエストしたサーバーと一致しません。",
       { status: 400 },
     );
   }

--- a/pkgs/extensions/discord-bot/src/api/install/start.ts
+++ b/pkgs/extensions/discord-bot/src/api/install/start.ts
@@ -61,7 +61,9 @@ export async function handleInstallStart(
   const url = new URL(request.url);
   const treeId = url.searchParams.get("treeId");
   if (!treeId || !VALID_TREE_ID.test(treeId)) {
-    return new Response("missing or invalid treeId", { status: 400 });
+    return new Response("treeId が指定されていないか、形式が正しくありません", {
+      status: 400,
+    });
   }
 
   const jti = crypto.randomUUID();

--- a/pkgs/extensions/discord-bot/src/commands/balance.ts
+++ b/pkgs/extensions/discord-bot/src/commands/balance.ts
@@ -33,11 +33,12 @@ export async function handleBalance(
   deps: BalanceDeps = {},
 ): Promise<APIInteractionResponse> {
   const snowflake = interaction.member?.user.id ?? interaction.user?.id;
-  if (!snowflake) return ephemeral("Could not read your Discord user id.");
+  if (!snowflake)
+    return ephemeral("Discord のユーザー ID を取得できませんでした。");
 
   const guildId = interaction.guild_id;
   if (!guildId) {
-    return ephemeral("This command must be run inside a server.");
+    return ephemeral("このコマンドはサーバー内で実行してください。");
   }
 
   const identity = deps.identity ?? createIdentityClient(env);
@@ -47,12 +48,12 @@ export async function handleBalance(
   ]);
   if (!record) {
     return ephemeral(
-      "Your Discord account isn't linked yet. Run `/toban-setup` to connect a wallet.",
+      "Discord アカウントがまだ連携されていません。`/toban-setup` を実行してウォレットを接続してください。",
     );
   }
   if (!platformLink) {
     return ephemeral(
-      "This server isn't linked to a Toban workspace yet. Ask an admin to run `/toban-link` first.",
+      "このサーバーはまだ Toban ワークスペースに連携されていません。管理者に `/toban-link` の実行を依頼してください。",
     );
   }
 
@@ -72,7 +73,7 @@ export async function handleBalance(
   ]);
   if (!token) {
     return ephemeral(
-      `Could not resolve the workspace's ThanksToken (tree ${platformLink.treeId}).`,
+      `ワークスペースの ThanksToken を取得できませんでした（tree ${platformLink.treeId}）。`,
     );
   }
 
@@ -93,9 +94,9 @@ export async function handleBalance(
 
   return ephemeral(
     [
-      `Wallet: \`${owner}\``,
-      `Allowance for bot: **${formatEther(allowance as bigint)}** THX`,
-      `Mintable budget : **${formatEther(mintable as bigint)}** THX`,
+      `ウォレット: \`${owner}\``,
+      `Bot への許可枠: **${formatEther(allowance as bigint)}** THX`,
+      `送信可能枠: **${formatEther(mintable as bigint)}** THX`,
     ].join("\n"),
   );
 }

--- a/pkgs/extensions/discord-bot/src/commands/payload.ts
+++ b/pkgs/extensions/discord-bot/src/commands/payload.ts
@@ -26,17 +26,17 @@
 export const COMMANDS_PAYLOAD = [
   {
     name: "toban-setup",
-    description: "Issue a link to connect your wallet to your Discord account",
+    description: "ウォレットと Discord アカウントを連携するリンクを発行します",
     type: 1,
   },
   {
     name: "toban-link",
-    description: "(admin) Link this server to a Toban workspace",
+    description: "(管理者向け) このサーバーを Toban ワークスペースに連携します",
     type: 1,
     options: [
       {
         name: "workspace_url",
-        description: "Toban workspace URL (e.g. https://toban.xyz/3002)",
+        description: "Toban のワークスペース URL（例: https://toban.xyz/3002）",
         type: 3,
         required: true,
       },
@@ -44,39 +44,39 @@ export const COMMANDS_PAYLOAD = [
   },
   {
     name: "balance",
-    description: "Show your mintAllowance and mintable budget",
+    description: "Bot への許可枠と送信可能枠を表示します",
     type: 1,
   },
   {
     name: "thx",
-    description: "Send THX to another member",
+    description: "他のメンバーに THX を送ります",
     type: 1,
     options: [
       // Discord requires `required: true` options to come before optional
       // ones, so amount sits at the top.
       {
         name: "amount",
-        description: "Amount of THX (positive integer)",
+        description: "THX の量（1 以上の整数）",
         type: 4,
         required: true,
         min_value: 1,
       },
       {
         name: "user",
-        description: "Recipient (pick from this server)",
+        description: "送り先（このサーバーのメンバーから選択）",
         type: 6,
         required: true,
       },
       {
         name: "address",
         description:
-          "Override: send to this 0x address or ENS name instead of the user's linked wallet.",
+          "上書き指定: 連携済みウォレットの代わりに、この 0x アドレス / ENS 名へ送ります",
         type: 3,
         required: false,
       },
       {
         name: "message",
-        description: "Optional thank-you note",
+        description: "感謝のメッセージ（任意）",
         type: 3,
         required: false,
       },
@@ -84,17 +84,17 @@ export const COMMANDS_PAYLOAD = [
   },
   {
     name: "quest",
-    description: "Quest actions",
+    description: "クエスト関連の操作",
     type: 1,
     options: [
       {
         name: "submit",
-        description: "Submit completion of a quest you can work on",
+        description: "取り組めるクエストの完了を報告します",
         type: 1, // SUB_COMMAND
         options: [
           {
             name: "quest",
-            description: "Pick a quest to submit",
+            description: "完了報告するクエストを選択",
             type: 3, // STRING
             required: true,
             autocomplete: true,

--- a/pkgs/extensions/discord-bot/src/commands/quest-submit.ts
+++ b/pkgs/extensions/discord-bot/src/commands/quest-submit.ts
@@ -12,7 +12,8 @@
  *     input. Must answer within Discord's 3s budget (no defer possible).
  *   - Command (interaction type 2): {@link executeQuestSubmit} runs after the
  *     caller deferred (ephemeral), resolves the actor + membership + quest
- *     module, signs via Turnkey, and reports the result as a followup.
+ *     module (plus the quest title, so the confirmation names the quest the
+ *     way the picker did), signs via Turnkey, and reports it as a followup.
  */
 import {
   type APIApplicationCommandAutocompleteInteraction,
@@ -64,11 +65,16 @@ function getSubmitOptions(
   return options ?? [];
 }
 
-/** Display label for a quest choice, clamped to Discord's 100-char limit. */
+/**
+ * Display label for a quest — the title alone, so both the autocomplete
+ * choice and the completion followup name the quest the way the workspace
+ * does. Falls back to the id only when the title isn't indexed yet.
+ * Clamped to Discord's 100-char autocomplete limit.
+ */
 export function questChoiceLabel(quest: SubmittableQuest): string {
   const base = quest.title?.trim()
-    ? `${quest.title.trim()} (#${quest.questId})`
-    : `Quest #${quest.questId}`;
+    ? quest.title.trim()
+    : `クエスト #${quest.questId}`;
   // Truncate by Unicode code point, not UTF-16 code unit: `String.slice` can
   // cut an emoji/astral char mid-surrogate, and the resulting lone surrogate
   // makes Discord reject the ENTIRE autocomplete response (400), so the user
@@ -195,12 +201,12 @@ export function parseQuestSubmitArgs(
       ? (opt.value as string | number | undefined)
       : undefined;
   if (raw === undefined || `${raw}`.length === 0) {
-    return { error: "`quest` is required." };
+    return { error: "`quest` は必須です。" };
   }
   try {
     return { questId: BigInt(raw) };
   } catch {
-    return { error: `Not a valid quest id: ${raw}` };
+    return { error: `クエスト ID の形式が正しくありません: ${raw}` };
   }
 }
 
@@ -212,15 +218,15 @@ export function parseQuestSubmitArgs(
  */
 export function describeSubmitRevert(short: string): string {
   if (short.includes("NotWorkspaceMember")) {
-    return "Your workspace membership couldn't be verified on-chain — your role may have changed since the quest list loaded. Ask an admin to check your role, then try again.";
+    return "ワークスペースのメンバーシップをオンチェーンで確認できませんでした。クエスト一覧を表示してからロールが変更された可能性があります。管理者にロールを確認してもらってから、再度お試しください。";
   }
   if (short.includes("InvalidStatus")) {
-    return "That quest is no longer open for submission (someone may have already submitted it, or it was cancelled). Pick another quest and try again.";
+    return "このクエストは完了報告できません（他の人が報告済み、またはキャンセルされた可能性があります）。別のクエストを選んで再度お試しください。";
   }
   if (short.includes("CannotSubmitOwnQuest")) {
-    return "You can't submit a quest you created.";
+    return "自分が作成したクエストには完了報告できません。";
   }
-  return `submitCompletion failed: ${short}`;
+  return `submitCompletion に失敗しました: ${short}`;
 }
 
 /**
@@ -242,7 +248,7 @@ export async function executeQuestSubmit(
       await followup(
         env.DISCORD_APP_ID,
         interaction.token,
-        "Something went wrong while processing /quest submit. Please try again in a moment.",
+        "`/quest submit` の処理中にエラーが発生しました。少し時間をおいて再度お試しください。",
       );
     } catch (followupErr) {
       console.error("quest-submit followup-after-error failed:", followupErr);
@@ -268,7 +274,7 @@ async function executeQuestSubmitInner(
     await followup(
       env.DISCORD_APP_ID,
       interaction.token,
-      "This command must be run inside a server.",
+      "このコマンドはサーバー内で実行してください。",
     );
     return;
   }
@@ -282,7 +288,7 @@ async function executeQuestSubmitInner(
     await followup(
       env.DISCORD_APP_ID,
       interaction.token,
-      "You haven't linked a wallet. Run `/toban-setup` first.",
+      "ウォレットが連携されていません。先に `/toban-setup` を実行してください。",
     );
     return;
   }
@@ -290,7 +296,7 @@ async function executeQuestSubmitInner(
     await followup(
       env.DISCORD_APP_ID,
       interaction.token,
-      "This server isn't linked to a Toban workspace yet. Ask an admin to run `/toban-link` first.",
+      "このサーバーはまだ Toban ワークスペースに連携されていません。管理者に `/toban-link` の実行を依頼してください。",
     );
     return;
   }
@@ -303,6 +309,9 @@ async function executeQuestSubmitInner(
   const resolveModule =
     deps.resolveQuestModule ??
     ((treeId: string) => resolveQuestModuleAddress(env, treeId));
+  const resolveQuests =
+    deps.resolveSubmittableQuests ??
+    ((treeId: string, a: Address) => resolveSubmittableQuests(env, treeId, a));
 
   const [membershipHatId, questModule] = await Promise.all([
     resolveMembership(actorWallet, platformLink.treeId),
@@ -312,7 +321,7 @@ async function executeQuestSubmitInner(
     await followup(
       env.DISCORD_APP_ID,
       interaction.token,
-      "You aren't a member of this workspace, so you can't submit a quest here.",
+      "このワークスペースのメンバーではないため、クエストの完了報告はできません。",
     );
     return;
   }
@@ -320,10 +329,22 @@ async function executeQuestSubmitInner(
     await followup(
       env.DISCORD_APP_ID,
       interaction.token,
-      `Could not resolve the workspace's quest module (tree ${platformLink.treeId}). Indexing may still be in progress.`,
+      `ワークスペースのクエストモジュールを取得できませんでした（tree ${platformLink.treeId}）。インデックス処理が完了していない可能性があります。`,
     );
     return;
   }
+
+  // The title only names the quest in the confirmation, so start the lookup
+  // here — after the gates that can reject, so failure paths cost no request —
+  // and let it overlap with the transaction. `.catch` is attached before any
+  // await, so it can never surface as an unhandled rejection, and a subgraph
+  // hiccup degrades to the id-only label instead of failing the submission.
+  const questsPromise = resolveQuests(platformLink.treeId, actorWallet).catch(
+    (err) => {
+      console.error("quest title lookup failed:", err);
+      return [] as SubmittableQuest[];
+    },
+  );
 
   const signer = deps.signer ?? createTurnkeySigner(env);
   const wallet = createWalletClient({
@@ -352,12 +373,19 @@ async function executeQuestSubmitInner(
     return;
   }
 
+  const quests = await questsPromise;
+  const questLabel = questChoiceLabel(
+    quests.find((q) => q.questId === parsed.questId) ?? {
+      questId: parsed.questId,
+      title: null,
+    },
+  );
   await followup(
     env.DISCORD_APP_ID,
     interaction.token,
     [
-      `Submitted completion for **Quest #${parsed.questId}**.`,
-      `Submitter: \`${actorWallet}\``,
+      `**${questLabel}** の完了を報告しました。`,
+      `報告者: \`${actorWallet}\``,
       `Tx: \`${txHash}\``,
     ].join("\n"),
   );

--- a/pkgs/extensions/discord-bot/src/commands/thx.ts
+++ b/pkgs/extensions/discord-bot/src/commands/thx.ts
@@ -81,10 +81,10 @@ export function parseThxArgs(
   const haveAddress =
     typeof addressLiteral === "string" && addressLiteral.length > 0;
   if (!haveSnowflake) {
-    return { error: "`user` is required." };
+    return { error: "`user` は必須です。" };
   }
   if (amountRaw === undefined || amountRaw <= 0) {
-    return { error: "amount must be a positive integer" };
+    return { error: "amount には 1 以上の整数を指定してください。" };
   }
   return {
     // `address` overrides `user` when both are supplied. This lets the
@@ -138,7 +138,7 @@ async function resolveRecipientWallet(
     if (!rec) {
       return {
         error:
-          "The recipient hasn't linked a wallet yet. Ask them to run `/toban-setup`, or specify their address/ENS via the `address` option.",
+          "送り先のメンバーはまだウォレットを連携していません。`/toban-setup` の実行を依頼するか、`address` オプションでアドレス / ENS を直接指定してください。",
       };
     }
     return { wallet: rec.wallet as Address };
@@ -147,19 +147,19 @@ async function resolveRecipientWallet(
   const literal = recipient.value;
   if (literal.startsWith("0x")) {
     if (!isAddress(literal)) {
-      return { error: `Not a valid 0x address: ${literal}` };
+      return { error: `0x アドレスの形式が正しくありません: ${literal}` };
     }
     return { wallet: literal as Address };
   }
   if (literal.endsWith(".eth")) {
     const resolved = await resolveEns(literal);
     if (!resolved) {
-      return { error: `Could not resolve ENS name: ${literal}` };
+      return { error: `ENS 名を解決できませんでした: ${literal}` };
     }
     return { wallet: resolved };
   }
   return {
-    error: `Unsupported address format: ${literal}. Use 0x... or *.eth.`,
+    error: `対応していないアドレス形式です: ${literal}。\`0x...\` または \`*.eth\` を指定してください。`,
   };
 }
 
@@ -187,7 +187,7 @@ export async function executeThx(
       await followup(
         env.DISCORD_APP_ID,
         interaction.token,
-        "Something went wrong while processing /thx. The operators have been notified — please try again in a moment.",
+        "`/thx` の処理中にエラーが発生しました。運営に通知済みです。少し時間をおいて再度お試しください。",
       );
     } catch (followupErr) {
       console.error("executeThx followup-after-error failed:", followupErr);
@@ -213,7 +213,7 @@ async function executeThxInner(
     await followup(
       env.DISCORD_APP_ID,
       interaction.token,
-      "This command must be run inside a server.",
+      "このコマンドはサーバー内で実行してください。",
     );
     return;
   }
@@ -227,7 +227,7 @@ async function executeThxInner(
     await followup(
       env.DISCORD_APP_ID,
       interaction.token,
-      "You haven't linked a wallet. Run `/toban-setup` first.",
+      "ウォレットが連携されていません。先に `/toban-setup` を実行してください。",
     );
     return;
   }
@@ -235,7 +235,7 @@ async function executeThxInner(
     await followup(
       env.DISCORD_APP_ID,
       interaction.token,
-      "This server isn't linked to a Toban workspace yet. Ask an admin to run `/toban-link` first.",
+      "このサーバーはまだ Toban ワークスペースに連携されていません。管理者に `/toban-link` の実行を依頼してください。",
     );
     return;
   }
@@ -274,7 +274,7 @@ async function executeThxInner(
     await followup(
       env.DISCORD_APP_ID,
       interaction.token,
-      `Could not resolve the workspace's ThanksToken (tree ${platformLink.treeId}). Indexing may still be in progress.`,
+      `ワークスペースの ThanksToken を取得できませんでした（tree ${platformLink.treeId}）。インデックス処理が完了していない可能性があります。`,
     );
     return;
   }
@@ -291,7 +291,7 @@ async function executeThxInner(
     await followup(
       env.DISCORD_APP_ID,
       interaction.token,
-      `Not enough allowance for the bot (have ${formatEther(allowance)} THX, need ${formatEther(parsed.amount)} THX). Increase it at ${env.TOBAN_FRONTEND_URL}/${platformLink.treeId}/discord-bot`,
+      `Bot に許可された送信枠が足りません（現在 ${formatEther(allowance)} THX / 必要 ${formatEther(parsed.amount)} THX）。${env.TOBAN_FRONTEND_URL}/${platformLink.treeId}/discord-bot で上限を引き上げてください。`,
     );
     return;
   }
@@ -336,7 +336,7 @@ async function executeThxInner(
     await followup(
       env.DISCORD_APP_ID,
       interaction.token,
-      `mintFrom failed: ${short}`,
+      `mintFrom に失敗しました: ${short}`,
     );
     return;
   }
@@ -349,9 +349,9 @@ async function executeThxInner(
     env.DISCORD_APP_ID,
     interaction.token,
     [
-      `Sent **${formatEther(parsed.amount)}** THX to ${recipientLabel}.`,
+      `${recipientLabel} に **${formatEther(parsed.amount)}** THX を送りました。`,
       parsed.recipient.kind === "address"
-        ? `Address: \`${recipientWallet}\``
+        ? `アドレス: \`${recipientWallet}\``
         : null,
       parsed.message ? `> ${parsed.message}` : null,
       `Tx: \`${txHash}\``,

--- a/pkgs/extensions/discord-bot/src/commands/toban-link.ts
+++ b/pkgs/extensions/discord-bot/src/commands/toban-link.ts
@@ -74,7 +74,7 @@ export async function handleTobanLink(
 ): Promise<APIInteractionResponse> {
   const guildId = interaction.guild_id;
   if (!guildId) {
-    return ephemeral("This command must be run inside a server.");
+    return ephemeral("このコマンドはサーバー内で実行してください。");
   }
 
   const opts = interaction.data?.options ?? [];
@@ -88,27 +88,27 @@ export async function handleTobanLink(
   const frontendHost = normalizeHost(env.TOBAN_FRONTEND_URL);
   if (!frontendHost) {
     return ephemeral(
-      "The bot is misconfigured: TOBAN_FRONTEND_URL is not a valid URL. Please contact an operator.",
+      "Bot の設定に問題があります: TOBAN_FRONTEND_URL が有効な URL ではありません。運営にお問い合わせください。",
     );
   }
   const allowedHosts = new Set<string>([frontendHost]);
   const treeId = extractTreeId(workspaceUrl, allowedHosts);
   if (!treeId) {
     return ephemeral(
-      `Workspace URL must start with ${env.TOBAN_FRONTEND_URL} and include a tree id, e.g. ${env.TOBAN_FRONTEND_URL.replace(/\/$/, "")}/<treeId>`,
+      `ワークスペース URL は ${env.TOBAN_FRONTEND_URL} で始まり、tree ID を含む必要があります（例: ${env.TOBAN_FRONTEND_URL.replace(/\/$/, "")}/<treeId>）。`,
     );
   }
 
   const callerSnowflake = interaction.member?.user.id ?? interaction.user?.id;
   if (!callerSnowflake) {
-    return ephemeral("Could not read your Discord user id.");
+    return ephemeral("Discord のユーザー ID を取得できませんでした。");
   }
 
   const identity = deps.identity ?? createIdentityClient(env);
   const caller = await identity.getIdentity("discord", callerSnowflake);
   if (!caller) {
     return ephemeral(
-      "Run `/toban-setup` first so we know which wallet is requesting the link.",
+      "先に `/toban-setup` を実行してください。どのウォレットからの連携リクエストかを確認する必要があります。",
     );
   }
 
@@ -120,12 +120,12 @@ export async function handleTobanLink(
     isMember = await wearsHat(caller.wallet as Address, treeId);
   } catch (err) {
     return ephemeral(
-      `Could not verify workspace membership right now (${(err as Error).message}). Try again in a moment.`,
+      `ワークスペースのメンバーシップを確認できませんでした（${(err as Error).message}）。少し時間をおいて再度お試しください。`,
     );
   }
   if (!isMember) {
     return ephemeral(
-      "Your linked wallet doesn't wear any hat in this workspace. Only members of the workspace can link a Discord server to it.",
+      "連携済みのウォレットはこのワークスペースのロールを持っていません。Discord サーバーを連携できるのはワークスペースのメンバーのみです。",
     );
   }
 
@@ -137,6 +137,6 @@ export async function handleTobanLink(
   });
 
   return ephemeral(
-    `✅ Linked this server to Toban workspace \`${treeId}\`. Members can now run \`/toban-setup\` and \`/thx\`.`,
+    `✅ このサーバーを Toban ワークスペース \`${treeId}\` に連携しました。メンバーは \`/toban-setup\` と \`/thx\` を実行できます。`,
   );
 }

--- a/pkgs/extensions/discord-bot/src/commands/toban-setup.ts
+++ b/pkgs/extensions/discord-bot/src/commands/toban-setup.ts
@@ -22,7 +22,7 @@ export async function handleTobanSetup(
   const snowflake = interaction.member?.user.id ?? interaction.user?.id;
   if (!snowflake) {
     return ephemeral(
-      "Could not read your Discord user id — please try again from a server channel.",
+      "Discord のユーザー ID を取得できませんでした。サーバーのチャンネルから再度お試しください。",
     );
   }
   const token = await issueVerifierToken(env.VERIFIER_PRIVATE_KEY, snowflake);
@@ -52,10 +52,10 @@ export async function handleTobanSetup(
   const url = `${base}/connect/discord${treeQuery}#token=${encodeURIComponent(token)}`;
   return ephemeral(
     [
-      "Open this link in your browser within 15 minutes to connect your wallet:",
+      "15 分以内にこのリンクをブラウザで開き、ウォレットを接続してください:",
       url,
       "",
-      "The link is for you only. Do not share it.",
+      "このリンクはあなた専用です。他の人と共有しないでください。",
     ].join("\n"),
   );
 }

--- a/pkgs/extensions/discord-bot/src/index.ts
+++ b/pkgs/extensions/discord-bot/src/index.ts
@@ -81,7 +81,7 @@ async function handleInteraction(
     });
   }
   if (interaction.type !== InteractionType.ApplicationCommand) {
-    return jsonResponse(ephemeral("Unsupported interaction type"));
+    return jsonResponse(ephemeral("対応していない操作です。"));
   }
 
   const cmd = interaction as APIChatInputApplicationCommandInteraction;

--- a/pkgs/extensions/discord-bot/test/quest-submit.test.ts
+++ b/pkgs/extensions/discord-bot/test/quest-submit.test.ts
@@ -165,14 +165,12 @@ const actor: IdentityRecord = {
 };
 
 describe("questChoiceLabel", () => {
-  it("uses the title with the id when present", () => {
-    expect(questChoiceLabel({ questId: 42n, title: "Design" })).toBe(
-      "Design (#42)",
-    );
+  it("uses the title alone when present", () => {
+    expect(questChoiceLabel({ questId: 42n, title: "Design" })).toBe("Design");
   });
 
   it("falls back to the bare id when untitled", () => {
-    expect(questChoiceLabel({ questId: 7n, title: null })).toBe("Quest #7");
+    expect(questChoiceLabel({ questId: 7n, title: null })).toBe("クエスト #7");
   });
 
   it("clamps to 100 chars", () => {
@@ -198,19 +196,19 @@ describe("questChoiceLabel", () => {
 describe("describeSubmitRevert", () => {
   it("translates NotWorkspaceMember into an actionable message", () => {
     expect(describeSubmitRevert("... NotWorkspaceMember()")).toContain(
-      "membership couldn't be verified",
+      "メンバーシップをオンチェーンで確認できませんでした",
     );
   });
 
-  it("translates InvalidStatus into a 'no longer open' message", () => {
+  it("translates InvalidStatus into a 'cannot submit' message", () => {
     expect(describeSubmitRevert("reverted: InvalidStatus()")).toContain(
-      "no longer open",
+      "このクエストは完了報告できません",
     );
   });
 
   it("passes through unrecognised reverts verbatim", () => {
     expect(describeSubmitRevert("some other error")).toBe(
-      "submitCompletion failed: some other error",
+      "submitCompletion に失敗しました: some other error",
     );
   });
 });
@@ -225,7 +223,7 @@ describe("buildQuestChoices", () => {
   it("returns all quests (mapped to id values) on empty query", () => {
     const choices = buildQuestChoices(quests, "");
     expect(choices).toHaveLength(3);
-    expect(choices[0]).toEqual({ name: "Design work (#1)", value: "1" });
+    expect(choices[0]).toEqual({ name: "Design work", value: "1" });
   });
 
   it("filters by title substring, case-insensitively", () => {
@@ -302,9 +300,7 @@ describe("handleQuestAutocomplete", () => {
         ],
       },
     );
-    expect(res.data.choices).toEqual([
-      { name: "Design work (#1)", value: "1" },
-    ]);
+    expect(res.data.choices).toEqual([{ name: "Design work", value: "1" }]);
   });
 });
 
@@ -317,7 +313,7 @@ describe("executeQuestSubmit", () => {
         messages.push(c);
       },
     });
-    expect(messages[0]).toContain("haven't linked");
+    expect(messages[0]).toContain("ウォレットが連携されていません");
   });
 
   it("messages the user if they aren't a workspace member", async () => {
@@ -330,7 +326,7 @@ describe("executeQuestSubmit", () => {
         messages.push(c);
       },
     });
-    expect(messages[0]).toContain("aren't a member");
+    expect(messages[0]).toContain("このワークスペースのメンバーではないため");
   });
 
   it("messages the user if the quest module can't be resolved", async () => {
@@ -343,6 +339,6 @@ describe("executeQuestSubmit", () => {
         messages.push(c);
       },
     });
-    expect(messages[0]).toContain("quest module");
+    expect(messages[0]).toContain("クエストモジュールを取得できませんでした");
   });
 });

--- a/pkgs/extensions/discord-bot/test/thx.test.ts
+++ b/pkgs/extensions/discord-bot/test/thx.test.ts
@@ -150,7 +150,7 @@ describe("executeThx", () => {
         messages.push(content);
       },
     });
-    expect(messages[0]).toContain("haven't linked");
+    expect(messages[0]).toContain("ウォレットが連携されていません");
   });
 
   it("messages the user if the recipient isn't linked", async () => {
@@ -161,7 +161,9 @@ describe("executeThx", () => {
         messages.push(c);
       },
     });
-    expect(messages[0]).toContain("recipient hasn't linked");
+    expect(messages[0]).toContain(
+      "送り先のメンバーはまだウォレットを連携していません",
+    );
   });
 
   it("rejects when allowance is insufficient", async () => {
@@ -177,7 +179,7 @@ describe("executeThx", () => {
         messages.push(c);
       },
     });
-    expect(messages[0]).toContain("Not enough allowance");
+    expect(messages[0]).toContain("Bot に許可された送信枠が足りません");
   });
 
   it("happy path: signs and broadcasts then posts tx hash", async () => {
@@ -272,6 +274,8 @@ describe("executeThx", () => {
     // identity / allowance checks.
     expect(messages.length).toBe(1);
     const m = messages[0];
-    expect(m.includes(fakeHash) || m.startsWith("mintFrom failed")).toBe(true);
+    expect(
+      m.includes(fakeHash) || m.startsWith("mintFrom に失敗しました"),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## 概要

`@toban/discord-bot` のユーザーに見えるメッセージを全て日本語にしました。あわせて、クエスト完了報告の確認メッセージが `Quest #12` ではなくクエスト名を表示するようにしています。

## 日本語化の対象

- 各コマンドの ephemeral / followup メッセージ（`thx` / `balance` / `quest submit` / `toban-link` / `toban-setup`）
- Discord UI 上に出るコマンド説明（`commands/payload.ts`）
- インストール時にブラウザへ返す HTTP レスポンス（`api/install/{start,callback}.ts`）
- README 内で引用していた旧メッセージ 4 箇所

Discord API 向けのレスポンス（`invalid signature` 等、人間の目に触れない）と `console.error` の運用ログは英語のまま据え置いています。

## クエスト名の表示

`questChoiceLabel` を「タイトルのみ」に変更しました（以前は `タイトル (#42)`）。タイトルが未取得のときだけ `クエスト #42` にフォールバックします。オートコンプリートの候補と完了報告の確認メッセージが同じ関数を使うため、選んだときと確認されたときで表示が一致します。

```
**ロゴのデザイン** の完了を報告しました。
報告者: `0x...`
Tx: `0x...`
```

`executeQuestSubmitInner` にタイトル取得を追加していますが、配置に以下の配慮をしています:

- **メンバーシップ / モジュール解決のチェックを通過した後**に開始 → 失敗パスで無駄なサブグラフリクエストを出さない
- **トランザクションと並行**して走らせ後から `await` → 追加のレイテンシがゼロ
- `await` より前に `.catch()` を付与 → unhandled rejection にならず、サブグラフ障害時は ID 表示にフォールバックするだけで**送信自体は失敗しない**（タイトルは表示専用のため）

## テスト

`test/quest-submit.test.ts` 7 箇所、`test/thx.test.ts` 4 箇所のアサーションを新文言に追随させました。

- `pnpm --filter @toban/discord-bot test` — 44 passed
- `pnpm --filter @toban/discord-bot typecheck` — pass
- Biome check / format — clean

なお `/quest submit` の成功パスは元から実行テストがありません（`executeQuestSubmit` が内部で walletClient を組み立てるため、`test/thx.test.ts` にあるような RPC スタブ一式が必要）。そのためタイトル表示部分は typecheck とレビューでの確認のみです。

## デプロイ時の注意

`payload.ts` のコマンド説明を変更したため、**既存ギルドではコマンドの再登録が必要**です（新規インストールは `api/install/callback.ts` が自動登録します）:

```
pnpm --filter @toban/discord-bot register-commands <guild-id>
```

コントラクト / サブグラフ / Turnkey policy への影響はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)