### PR TITLE
feat(frontend): 同一内容のクエストをまとめて N 件作成できるようにする

### DIFF
--- a/pkgs/frontend/app/routes/$treeId_.$hatId_.$address_.quest.new.tsx
+++ b/pkgs/frontend/app/routes/$treeId_.$hatId_.$address_.quest.new.tsx
@@ -29,6 +29,9 @@ import { cn } from "~/lib/utils";
 const TOTAL_SHARE_UNITS = 10_000;
 const DEFAULT_SHARE_AMOUNT = 100;
 const QUICK_SHARE_AMOUNTS = [100, 300, 500, 1000];
+// Ceiling on one batch. Share holdings cap it far lower in practice; this is
+// the gas-side limit — 20 `createQuest` calls still fit one UserOperation.
+const MAX_QUEST_COUNT = 20;
 
 const QuestCreate: FC = () => {
   const { treeId, hatId, address } = useParams();
@@ -108,6 +111,7 @@ const QuestCreate: FC = () => {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [share, setShare] = useState(0);
+  const [count, setCount] = useState(1);
 
   // Default the stepper to a useful starting value once we know the user's
   // share — Math.min(DEFAULT_SHARE_AMOUNT, myUnits). Only runs while the input
@@ -121,7 +125,22 @@ const QuestCreate: FC = () => {
     }
   }, [myUnits]);
 
-  const after = Math.max(0, myUnits - share);
+  // Every quest escrows `share`, so N of them need `share * N` on hand. The
+  // stepper is clamped to that, and the count follows the share downwards when
+  // raising the share would otherwise leave the pair unaffordable.
+  const maxCount = useMemo(
+    () =>
+      share > 0
+        ? Math.max(1, Math.min(MAX_QUEST_COUNT, Math.floor(myUnits / share)))
+        : 1,
+    [myUnits, share],
+  );
+  useEffect(() => {
+    setCount((prev) => Math.max(1, Math.min(prev, maxCount)));
+  }, [maxCount]);
+
+  const totalShare = share * count;
+  const after = Math.max(0, myUnits - totalShare);
   const titleTrimmed = title.trim();
   const valid =
     !!questModuleAddress &&
@@ -130,13 +149,16 @@ const QuestCreate: FC = () => {
     !!hatIdDecimal &&
     titleTrimmed.length > 0 &&
     share > 0 &&
-    share <= myUnits;
+    count >= 1 &&
+    count <= MAX_QUEST_COUNT &&
+    totalShare <= myUnits;
 
   // ── Submit ────────────────────────────────────────────────────
-  const { createQuest, isLoading: isCreating } = useCreateQuest(
-    questModuleAddress,
-    fractionTokenAddress,
-  );
+  const {
+    createQuests,
+    isLoading: isCreating,
+    progress,
+  } = useCreateQuest(questModuleAddress, fractionTokenAddress);
   const { upload, isLoading: isUploading } = useUploadQuestMetadata();
   const isSubmitting = isCreating || isUploading;
 
@@ -144,29 +166,63 @@ const QuestCreate: FC = () => {
     if (!valid || !me || !wearer || !hatIdDecimal || !questModuleAddress)
       return;
     try {
+      // One upload for the whole batch — identical quests share the CID, which
+      // is also what lets the Discord autocomplete collapse them (#560).
       const meta = await upload({ title: titleTrimmed, description });
       if (!meta) {
         toast.error("メタデータのアップロードに失敗しました");
         return;
       }
-      const amount = BigInt(share);
-      const questId = await createQuest({
+      const result = await createQuests({
         hatId: BigInt(hatIdDecimal),
         wearer,
-        amount,
+        amount: BigInt(share),
         metadataUri: meta.ipfsUri,
+        count,
       });
-      if (questId === undefined) {
+      const created = result?.questIds.length ?? 0;
+      if (created === 0) {
         toast.error("クエストの作成に失敗しました");
         return;
       }
-      toast.success("クエストを作成しました");
-      navigate(`/${treeId}/quest/${questId.toString()}`);
+      if (created < count) {
+        // Only reachable on the EOA path: the quests already mined stay
+        // created, so say what landed instead of claiming a clean failure.
+        toast.error(
+          `${created}件作成しました（残り${count - created}件は失敗）`,
+        );
+      } else {
+        toast.success(
+          count > 1
+            ? `${count}件のクエストを作成しました`
+            : "クエストを作成しました",
+        );
+      }
+      // A single quest still lands on its detail screen; a batch has no single
+      // detail to show, so the list is the useful destination.
+      navigate(
+        created === 1 && count === 1
+          ? `/${treeId}/quest/${result?.questIds[0]?.toString()}`
+          : `/${treeId}/quest`,
+      );
     } catch (err) {
       console.error(err);
       toast.error("クエストの作成に失敗しました");
     }
   };
+
+  // Batch is one signature and atomic, so a count would be noise. The EOA path
+  // sends one transaction per quest and genuinely has a position to report.
+  const submitLabel = useMemo(() => {
+    if (!isSubmitting) return undefined;
+    if (progress?.mode === "sequential" && progress.requested > 1) {
+      return `作成中… (${Math.min(progress.done + 1, progress.requested)}/${progress.requested})`;
+    }
+    if (progress?.mode === "batch" && progress.requested > 1) {
+      return `${progress.requested}件を作成中…`;
+    }
+    return "作成中…";
+  }, [isSubmitting, progress]);
 
   // ── Gate ──────────────────────────────────────────────────────
   // URL-direct hit when viewer holds no share: block the form. Wallet not
@@ -233,7 +289,11 @@ const QuestCreate: FC = () => {
             >
               −
             </Typography>
-            <ShareNumber label="渡すシェア" value={share} highlight />
+            <ShareNumber
+              label={count > 1 ? `渡すシェア（${count}件分）` : "渡すシェア"}
+              value={totalShare}
+              highlight
+            />
             <Typography
               as="span"
               variant="body"
@@ -243,6 +303,16 @@ const QuestCreate: FC = () => {
             </Typography>
             <ShareNumber label="作成後" value={after} dim />
           </div>
+          {count > 1 && (
+            <Typography
+              as="div"
+              variant="caption"
+              className="-mt-1 text-[#7A5A2E]"
+            >
+              {share.toLocaleString()} × {count}件 ={" "}
+              {totalShare.toLocaleString()}
+            </Typography>
+          )}
         </Card>
       </div>
 
@@ -306,6 +376,45 @@ const QuestCreate: FC = () => {
         </div>
 
         <div className="flex flex-col gap-2">
+          <FieldLabel>作成する個数</FieldLabel>
+          <div className="flex items-center gap-3">
+            <StepButton
+              symbol="−"
+              onClick={() => setCount((c) => Math.max(1, c - 1))}
+              disabled={count <= 1}
+            />
+            <Input
+              type="number"
+              inputMode="numeric"
+              min={1}
+              max={maxCount}
+              step={1}
+              value={count === 0 ? "" : count}
+              onChange={(e) => {
+                const raw = e.target.value;
+                if (raw === "") {
+                  setCount(0);
+                  return;
+                }
+                const n = Math.floor(Number(raw));
+                if (!Number.isFinite(n)) return;
+                setCount(Math.max(1, Math.min(maxCount, n)));
+              }}
+              onBlur={() => setCount((c) => (c < 1 ? 1 : c))}
+              className="h-14 flex-1 text-center text-3xl font-bold tracking-[-0.5px]"
+            />
+            <StepButton
+              symbol="+"
+              onClick={() => setCount((c) => Math.min(maxCount, c + 1))}
+              disabled={count >= maxCount}
+            />
+          </div>
+          <Typography as="div" variant="caption" tone="secondary">
+            同じ内容のクエストをまとめて作成します（最大{maxCount}件）。
+          </Typography>
+        </div>
+
+        <div className="flex flex-col gap-2">
           <FieldLabel>
             クエスト名
             <span className="ml-1 text-danger">*</span>
@@ -341,11 +450,11 @@ const QuestCreate: FC = () => {
           disabled={!valid || isSubmitting}
         >
           {isSubmitting ? (
-            "作成中…"
+            submitLabel
           ) : (
             <>
               <Icon name="plus" size={16} />
-              作成する
+              {count > 1 ? `${count}件作成する` : "作成する"}
             </>
           )}
         </Button>
@@ -357,8 +466,11 @@ const QuestCreate: FC = () => {
         tone="secondary"
         className="px-2 pt-4 leading-relaxed"
       >
-        作成すると、選んだシェア（{share.toLocaleString()}単位 / 全
-        {TOTAL_SHARE_UNITS.toLocaleString()}）が
+        作成すると、選んだシェア（
+        {count > 1
+          ? `${share.toLocaleString()}単位 × ${count}件 = ${totalShare.toLocaleString()}単位`
+          : `${share.toLocaleString()}単位`}{" "}
+        / 全{TOTAL_SHARE_UNITS.toLocaleString()}）が
         クエストモジュールに預け入れられます。完了承認で申請者に渡り、キャンセル時には差し戻されます。
       </Typography>
     </PageContainer>

--- a/pkgs/frontend/hooks/useHatsQuestModule.test.ts
+++ b/pkgs/frontend/hooks/useHatsQuestModule.test.ts
@@ -1,0 +1,107 @@
+import { HATS_QUEST_MODULE_ABI } from "abi/hatsQuestModule";
+import {
+  type Address,
+  type Log,
+  encodeAbiParameters,
+  encodeEventTopics,
+  getAddress,
+  parseAbiParameters,
+} from "viem";
+import { describe, expect, it } from "vitest";
+import { extractMyQuestIds } from "./useHatsQuestModule";
+
+const MODULE = "0x1111111111111111111111111111111111111111" as Address;
+const OTHER_MODULE = "0x2222222222222222222222222222222222222222" as Address;
+const ME = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as Address;
+const SOMEONE_ELSE = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as Address;
+const WEARER = "0xcccccccccccccccccccccccccccccccccccccccc" as Address;
+
+// Builds the log a real `QuestCreated` emission produces, so the filter is
+// exercised against genuine topic encoding rather than a hand-shaped object.
+const questCreatedLog = (opts: {
+  address: Address;
+  questId: bigint;
+  creator: Address;
+  hatId?: bigint;
+}): Log =>
+  ({
+    address: opts.address,
+    topics: encodeEventTopics({
+      abi: HATS_QUEST_MODULE_ABI,
+      eventName: "QuestCreated",
+      args: {
+        questId: opts.questId,
+        creator: opts.creator,
+        hatId: opts.hatId ?? 1n,
+      },
+    }),
+    data: encodeAbiParameters(parseAbiParameters("address, uint256, string"), [
+      WEARER,
+      100n,
+      "ipfs://cid",
+    ]),
+    blockNumber: 1n,
+    blockHash: `0x${"1".repeat(64)}`,
+    transactionHash: `0x${"2".repeat(64)}`,
+    transactionIndex: 0,
+    logIndex: 0,
+    removed: false,
+  }) as Log;
+
+describe("extractMyQuestIds", () => {
+  it("returns the ids in emission order", () => {
+    const logs = [1n, 2n, 3n].map((questId) =>
+      questCreatedLog({ address: MODULE, questId, creator: ME }),
+    );
+    expect(extractMyQuestIds(logs, MODULE, ME)).toEqual([1n, 2n, 3n]);
+  });
+
+  // The bundle receipt carries every UserOperation the bundler packed, so a
+  // co-bundled creator's quest must not be handed back as ours.
+  it("drops QuestCreated emitted by another creator", () => {
+    const logs = [
+      questCreatedLog({ address: MODULE, questId: 7n, creator: SOMEONE_ELSE }),
+      questCreatedLog({ address: MODULE, questId: 8n, creator: ME }),
+      questCreatedLog({ address: MODULE, questId: 9n, creator: SOMEONE_ELSE }),
+    ];
+    expect(extractMyQuestIds(logs, MODULE, ME)).toEqual([8n]);
+  });
+
+  // Another workspace's quest module emits the identical event signature.
+  it("drops QuestCreated emitted by another quest module", () => {
+    const logs = [
+      questCreatedLog({ address: OTHER_MODULE, questId: 4n, creator: ME }),
+      questCreatedLog({ address: MODULE, questId: 5n, creator: ME }),
+    ];
+    expect(extractMyQuestIds(logs, MODULE, ME)).toEqual([5n]);
+  });
+
+  // Receipt logs come back lowercase, but the module address arrives from the
+  // subgraph and the creator from the wallet — either can be checksummed.
+  it("matches addresses case-insensitively", () => {
+    const logs = [
+      questCreatedLog({ address: MODULE, questId: 11n, creator: ME }),
+    ];
+    expect(extractMyQuestIds(logs, getAddress(MODULE), getAddress(ME))).toEqual(
+      [11n],
+    );
+  });
+
+  it("ignores unrelated logs and returns empty when nothing matches", () => {
+    const logs = [
+      questCreatedLog({ address: MODULE, questId: 1n, creator: SOMEONE_ELSE }),
+      {
+        address: MODULE,
+        topics: [`0x${"f".repeat(64)}`],
+        data: "0x",
+        blockNumber: 1n,
+        blockHash: `0x${"1".repeat(64)}`,
+        transactionHash: `0x${"2".repeat(64)}`,
+        transactionIndex: 0,
+        logIndex: 1,
+        removed: false,
+      } as Log,
+    ];
+    expect(extractMyQuestIds(logs, MODULE, ME)).toEqual([]);
+  });
+});

--- a/pkgs/frontend/hooks/useHatsQuestModule.ts
+++ b/pkgs/frontend/hooks/useHatsQuestModule.ts
@@ -1,6 +1,13 @@
+import { FRACTION_TOKEN_ABI } from "abi/fractiontoken";
 import { HATS_QUEST_MODULE_ABI } from "abi/hatsQuestModule";
 import { useCallback, useState } from "react";
-import { type Address, parseEventLogs, zeroAddress } from "viem";
+import {
+  type Address,
+  type Log,
+  encodeFunctionData,
+  parseEventLogs,
+  zeroAddress,
+} from "viem";
 import {
   fractionTokenBaseConfig,
   hatsQuestContractBaseConfig,
@@ -13,31 +20,161 @@ import { useActiveWallet } from "./useWallet";
 // id we need on the next screen. We split one hook per action so callers can
 // import only what they need, mirroring useHatsHatCreatorModule.
 
+/**
+ * Pull our own `QuestCreated` ids out of a receipt.
+ *
+ * A smart-wallet receipt belongs to the *bundle* transaction, so it also
+ * carries the logs of every other UserOperation the bundler packed alongside
+ * ours. Filtering on the module address plus `creator` is what keeps someone
+ * else's questId from being handed back to us. The EOA path runs through the
+ * same filter — its receipt is single-sender, but the guard costs nothing.
+ */
+export const extractMyQuestIds = (
+  logs: Log[],
+  hatsQuestModuleAddress: Address,
+  creator: Address,
+): bigint[] => {
+  const module = hatsQuestModuleAddress.toLowerCase();
+  const me = creator.toLowerCase();
+  return parseEventLogs({
+    abi: HATS_QUEST_MODULE_ABI,
+    eventName: "QuestCreated",
+    logs,
+    strict: false,
+  })
+    .filter(
+      (log) =>
+        log.address.toLowerCase() === module &&
+        log.args?.creator?.toLowerCase() === me,
+    )
+    .map((log) => log.args?.questId)
+    .filter((id): id is bigint => typeof id === "bigint");
+};
+
+export interface CreateQuestsResult {
+  /** Ids of the quests that actually made it on-chain, in creation order. */
+  questIds: bigint[];
+  /** How many were asked for — compare against `questIds.length` for partials. */
+  requested: number;
+  /** Set when the run stopped early; `questIds` still holds what succeeded. */
+  error?: unknown;
+}
+
+/** What the submit button should say while a run is in flight. */
+export interface CreateQuestsProgress {
+  /** Quests confirmed so far. Stays 0 for `batch`, which is all-or-nothing. */
+  done: number;
+  requested: number;
+  /** `batch` = one UserOperation; `sequential` = one transaction per quest. */
+  mode: "batch" | "sequential";
+}
+
 export const useCreateQuest = (
   hatsQuestModuleAddress?: Address,
   fractionTokenAddress?: Address,
 ) => {
   const { wallet } = useActiveWallet();
   const [isLoading, setIsLoading] = useState(false);
+  const [progress, setProgress] = useState<CreateQuestsProgress>();
 
-  const createQuest = useCallback(
+  const createQuests = useCallback(
     async (params: {
       hatId: bigint;
       wearer: Address;
+      /** Share units escrowed per quest. Total pulled is `amount * count`. */
       amount: bigint;
       metadataUri: string;
-    }): Promise<bigint | undefined> => {
+      /** How many identical quests to create. Defaults to 1. */
+      count?: number;
+    }): Promise<CreateQuestsResult | undefined> => {
       if (!hatsQuestModuleAddress || !fractionTokenAddress || !wallet) return;
+      const count = Math.max(1, Math.floor(params.count ?? 1));
+      const creator = wallet.account.address as Address;
+      const isSmartWallet = "sendUserOperation" in wallet;
       setIsLoading(true);
+      setProgress({
+        done: 0,
+        requested: count,
+        mode: isSmartWallet ? "batch" : "sequential",
+      });
       try {
         // `createQuest` calls `safeTransferFrom(msg.sender, address(this), …)`
         // on the FractionToken — ERC1155 requires the module to be an approved
-        // operator of the caller. Approve once (idempotent) before escrowing.
+        // operator of the caller. One read for the whole run, never per quest.
         const approved = (await publicClient.readContract({
           ...fractionTokenBaseConfig(fractionTokenAddress),
           functionName: "isApprovedForAll",
-          args: [wallet.account.address as Address, hatsQuestModuleAddress],
+          args: [creator, hatsQuestModuleAddress],
         })) as boolean;
+
+        const createQuestData = encodeFunctionData({
+          abi: HATS_QUEST_MODULE_ABI,
+          functionName: "createQuest",
+          args: [
+            params.hatId,
+            params.wearer,
+            params.amount,
+            params.metadataUri,
+          ],
+        });
+
+        // Privy's smart-wallet client exposes `sendTransaction({ calls: [] })`
+        // (ERC-4337 batch). viem's plain WalletClient does not — detect via
+        // `sendUserOperation` and fall back to sequential txs for EOA. Same
+        // branch as `adminRevokeAuthorityHat` in useHats.
+        if (isSmartWallet) {
+          // The approval rides in the same UserOp rather than as its own
+          // transaction, so the user signs once no matter the starting state.
+          const calls = [
+            ...(approved
+              ? []
+              : [
+                  {
+                    to: fractionTokenAddress,
+                    data: encodeFunctionData({
+                      abi: FRACTION_TOKEN_ABI,
+                      functionName: "setApprovalForAll",
+                      args: [hatsQuestModuleAddress, true],
+                    }),
+                  },
+                ]),
+            ...Array.from({ length: count }, () => ({
+              to: hatsQuestModuleAddress,
+              data: createQuestData,
+            })),
+          ];
+          const txHash = await wallet.sendTransaction({ calls });
+          const receipt = await publicClient.waitForTransactionReceipt({
+            hash: txHash,
+          });
+          // A reverted UserOp still yields a mined bundle receipt, so success
+          // is judged by the ids we can read back, not by the receipt arriving.
+          // Ours are contiguous, so if this wallet somehow appears twice in the
+          // bundle the trailing `count` are the ones we just sent.
+          const questIds = extractMyQuestIds(
+            receipt.logs,
+            hatsQuestModuleAddress,
+            creator,
+          ).slice(-count);
+          setProgress({
+            done: questIds.length,
+            requested: count,
+            mode: "batch",
+          });
+          // The UserOp is atomic, so a short read means it reverted rather than
+          // half-succeeded. Report zero created — never a partial.
+          if (questIds.length < count) {
+            return {
+              questIds: [],
+              requested: count,
+              error: new Error(
+                `batch createQuest reverted: expected ${count} QuestCreated logs, got ${questIds.length}`,
+              ),
+            };
+          }
+          return { questIds, requested: count };
+        }
+
         if (!approved) {
           const approveTx = await wallet.writeContract({
             ...fractionTokenBaseConfig(fractionTokenAddress),
@@ -47,28 +184,46 @@ export const useCreateQuest = (
           await publicClient.waitForTransactionReceipt({ hash: approveTx });
         }
 
-        const txHash = await wallet.writeContract({
-          ...hatsQuestContractBaseConfig(hatsQuestModuleAddress),
-          functionName: "createQuest",
-          args: [
-            params.hatId,
-            params.wearer,
-            params.amount,
-            params.metadataUri,
-          ],
-        });
-        const receipt = await publicClient.waitForTransactionReceipt({
-          hash: txHash,
-        });
-        const logs = parseEventLogs({
-          abi: HATS_QUEST_MODULE_ABI,
-          eventName: "QuestCreated",
-          logs: receipt.logs,
-          strict: false,
-        });
-        return logs[0]?.args?.questId;
+        // EOA: one transaction per quest. Earlier quests are already on-chain
+        // when a later one fails, so we stop at the failure and report the
+        // partial rather than pretending the whole run failed.
+        const questIds: bigint[] = [];
+        for (let i = 0; i < count; i++) {
+          try {
+            const txHash = await wallet.writeContract({
+              ...hatsQuestContractBaseConfig(hatsQuestModuleAddress),
+              functionName: "createQuest",
+              args: [
+                params.hatId,
+                params.wearer,
+                params.amount,
+                params.metadataUri,
+              ],
+            });
+            const receipt = await publicClient.waitForTransactionReceipt({
+              hash: txHash,
+            });
+            questIds.push(
+              ...extractMyQuestIds(
+                receipt.logs,
+                hatsQuestModuleAddress,
+                creator,
+              ),
+            );
+            setProgress({
+              done: i + 1,
+              requested: count,
+              mode: "sequential",
+            });
+          } catch (error) {
+            console.error(error);
+            return { questIds, requested: count, error };
+          }
+        }
+        return { questIds, requested: count };
       } catch (error) {
         console.error(error);
+        return { questIds: [], requested: count, error };
       } finally {
         setIsLoading(false);
       }
@@ -76,7 +231,7 @@ export const useCreateQuest = (
     [hatsQuestModuleAddress, fractionTokenAddress, wallet],
   );
 
-  return { createQuest, isLoading };
+  return { createQuests, isLoading, progress };
 };
 
 export const useSubmitQuestCompletion = (hatsQuestModuleAddress?: Address) => {


### PR DESCRIPTION
## Description

クエスト作成画面（`/$treeId/$hatId/$address/quest/new`）に「作成する個数」を追加し、1 回の操作で同一内容のクエストを N 件作成できるようにしました。

コントラクトの変更はありません。既存の `createQuest` を N 件分送信し、IPFS アップロードは 1 回だけ行って同じ CID を共有します。作成された N 件は名前・シェア量・当番が完全に一致するため、Discord 側では #560 の集約が効いて 1 件にまとまります。

Fixes #561

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## 送信経路

分岐は `useHats` の `adminRevokeAuthorityHat`（`"sendUserOperation" in wallet`）を踏襲しています。

| | スマートウォレット | EOA |
| --- | --- | --- |
| 送信 | N 件を **1 UserOperation** にまとめる | `createQuest` を逐次送信 |
| 署名 | 1 回 | N 回 |
| `setApprovalForAll` | 未承認なら**同じ UserOp の先頭 call** | ループ前に 1 回だけ |
| 原子性 | all-or-nothing | 途中失敗で停止、成功分は残る |
| ローディング | `5件を作成中…` | `作成中… (2/5)` |
| 失敗時 | 「クエストの作成に失敗しました」のみ（部分成功は出さない） | `X件作成しました（残りY件は失敗）` |

`isApprovedForAll` の read は、どちらの経路でもループ／バッチの外で 1 回だけです。

## `QuestCreated` 抽出の修正

バッチ送信のレシートは**バンドル tx** のものなので、同じバンドルに載った他ユーザーの UserOp のログが混ざります。従来は `parseEventLogs(...)[0]` をそのまま使っており、他人の questId を拾い得る状態でした（**単発パスにも同じ穴があった**ため併せて修正しています）。

`extractMyQuestIds()` として切り出し、`log.address === questModule` かつ `args.creator === 自分のアドレス` でフィルタするようにしました。純粋関数なので Vitest で 5 ケース用意しています。

- 発火順どおりに id を返す
- **他の creator** の `QuestCreated` を落とす（バンドル混入のケース）
- **他の questModule** の `QuestCreated` を落とす
- アドレスの大文字小文字（チェックサム形式）を吸収する
- 無関係なログを無視し、該当なしなら空配列

バッチ経路では取得できた id が `count` に満たない場合、UserOp は原子的なので「リバートした」と判断して**部分成功を出さず 0 件として扱います**。

## その他

- 個数の上限は `min(floor(myUnits / share), 20)`。シェアを上げて総量が足りなくなった場合は個数が自動的に追従します
- 「作成後」プレビュー・預け入れ説明文・ボタン文言はすべて `シェア量 × 個数` を反映します
- 遷移先は個数 1 ならクエスト詳細（従来どおり）、2 件以上ならクエスト一覧

## 動作確認

- `pnpm frontend typecheck` ✅
- `pnpm frontend test` ✅ (24 passed — うち新規 5)
- `biome check` ✅（pre-commit フック通過）

## ⚠️ 未実施：Sepolia での実機確認

Issue の受け入れ条件にある **「N=20 で Sepolia の実機確認が済んでいる（ガス見積もり・paymaster が通る、または必要なチャンク分割が入っている）」は未実施です。** 手元に `.env` がなく（ENS 移行に伴う `NAMESPACE_API_KEY` の発行も未了）、dev サーバーもウォレットも動かせないためです。

そのため **チャンク分割は入れていません**。N=20 を 1 UserOp に収める前提の実装です。実機で paymaster のポリシー上限等に当たる場合は、チャンク分割と、それに伴う UI 文言（原子性がチャンク単位になる旨）の追加が必要です。この確認をお願いできると助かります。

あわせて、EOA 経路の途中失敗時の挙動も実機では未確認です（ロジック上は成功分を残して停止します）。

## Screenshots

_未取得（上記のとおり dev サーバー未起動）_
