### PR TITLE
feat(identity): wallet → Discord の逆引き API を追加

### DIFF
--- a/pkgs/extensions/discord-bot/src/identity.ts
+++ b/pkgs/extensions/discord-bot/src/identity.ts
@@ -40,6 +40,37 @@ export interface IdentityClient {
     accountId: string,
   ): Promise<IdentityRecord | null>;
 
+  /**
+   * 逆引き: `(provider, wallet) -> identities[]`。
+   *
+   * 通知処理は subgraph からアドレスしか得られない（「コマンドを実行した人」
+   * という文脈が無い）ので、Discord メンションに落とすには逆引きが要る。
+   *
+   * - 未連携はエラーではなく **空配列**。通知では正常系。
+   * - `identities` の PK は `(provider, account_id)` なので 1 ウォレットに
+   *   複数アカウントが紐づき得る。配列の先頭が最終更新の新しいものになる。
+   * - `wallet` の大文字小文字は identity Worker 側が吸収する。subgraph 由来の
+   *   全小文字アドレスをそのまま渡してよい。
+   */
+  getIdentitiesByWallet(
+    provider: ProviderId,
+    wallet: string,
+  ): Promise<IdentityRecord[]>;
+
+  /**
+   * 逆引きのバッチ版。1 回の通知で数十件のアドレスを引くので、1 件ずつ
+   * HTTP を叩くと automation の実行時間を食う。
+   *
+   * 戻り値のキーは **全小文字のアドレス**。subgraph が返すアドレスをそのまま
+   * キーに使えるようにするため（checksum 表記でキーにすると、呼び出し側が
+   * 毎回 `getAddress()` を通す羽目になる）。
+   * 引数に渡した有効なアドレスは、未連携でも空配列のエントリとして必ず入る。
+   */
+  getIdentitiesByWallets(
+    provider: ProviderId,
+    wallets: readonly string[],
+  ): Promise<Map<string, IdentityRecord[]>>;
+
   /** Resolve a Discord guild -> tree_id binding, or null if not linked. */
   getPlatformLink(
     provider: ProviderId,
@@ -112,6 +143,69 @@ class IdentityFetchClient implements IdentityClient {
     // IdentityRecord from the request context instead of lying with a cast.
     const body = (await res.json()) as { wallet: Address };
     return { provider, accountId, wallet: body.wallet };
+  }
+
+  async getIdentitiesByWallet(
+    provider: ProviderId,
+    wallet: string,
+  ): Promise<IdentityRecord[]> {
+    const path = `/api/lookup/by-wallet?provider=${encodeURIComponent(provider)}&wallet=${encodeURIComponent(wallet)}`;
+    const res = await this.go(path, {
+      headers: { "x-toban-lookup-secret": this.secrets.lookupSecret },
+    });
+    if (!res.ok) {
+      throw new Error(
+        `identity reverse lookup failed: ${res.status} ${await res.text()}`,
+      );
+    }
+    const body = (await res.json()) as {
+      wallet: Address;
+      identities: Array<{ accountId: string; wallet: Address }>;
+    };
+    return body.identities.map((i) => ({
+      provider,
+      accountId: i.accountId,
+      wallet: i.wallet,
+    }));
+  }
+
+  async getIdentitiesByWallets(
+    provider: ProviderId,
+    wallets: readonly string[],
+  ): Promise<Map<string, IdentityRecord[]>> {
+    const out = new Map<string, IdentityRecord[]>();
+    if (wallets.length === 0) return out;
+
+    const res = await this.go("/api/lookup/by-wallet", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-toban-lookup-secret": this.secrets.lookupSecret,
+      },
+      body: JSON.stringify({ provider, wallets }),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `identity reverse lookup (batch) failed: ${res.status} ${await res.text()}`,
+      );
+    }
+    const body = (await res.json()) as {
+      results: Array<{
+        wallet: Address;
+        identities: Array<{ accountId: string; wallet: Address }>;
+      }>;
+    };
+    for (const r of body.results) {
+      out.set(
+        r.wallet.toLowerCase(),
+        r.identities.map((i) => ({
+          provider,
+          accountId: i.accountId,
+          wallet: i.wallet,
+        })),
+      );
+    }
+    return out;
   }
 
   async getPlatformLink(

--- a/pkgs/extensions/discord-bot/test/quest-submit.test.ts
+++ b/pkgs/extensions/discord-bot/test/quest-submit.test.ts
@@ -65,6 +65,21 @@ class StubIdentity implements IdentityClient {
   async getIdentity(_p: "discord", accountId: string) {
     return this.records[accountId] ?? null;
   }
+  async getIdentitiesByWallet(_p: "discord", wallet: string) {
+    return Object.values(this.records).filter(
+      (r) => r.wallet.toLowerCase() === wallet.toLowerCase(),
+    );
+  }
+  async getIdentitiesByWallets(
+    p: "discord",
+    wallets: readonly string[],
+  ): Promise<Map<string, IdentityRecord[]>> {
+    const out = new Map<string, IdentityRecord[]>();
+    for (const w of wallets) {
+      out.set(w.toLowerCase(), await this.getIdentitiesByWallet(p, w));
+    }
+    return out;
+  }
   async getPlatformLink() {
     return this.link;
   }

--- a/pkgs/extensions/discord-bot/test/thx.test.ts
+++ b/pkgs/extensions/discord-bot/test/thx.test.ts
@@ -100,6 +100,21 @@ class StubIdentity implements IdentityClient {
   async getIdentity(_p: "discord", accountId: string) {
     return this.records[accountId] ?? null;
   }
+  async getIdentitiesByWallet(_p: "discord", wallet: string) {
+    return Object.values(this.records).filter(
+      (r) => r.wallet.toLowerCase() === wallet.toLowerCase(),
+    );
+  }
+  async getIdentitiesByWallets(
+    p: "discord",
+    wallets: readonly string[],
+  ): Promise<Map<string, IdentityRecord[]>> {
+    const out = new Map<string, IdentityRecord[]>();
+    for (const w of wallets) {
+      out.set(w.toLowerCase(), await this.getIdentitiesByWallet(p, w));
+    }
+    return out;
+  }
   async getPlatformLink() {
     return this.link;
   }

--- a/pkgs/extensions/identity/CLAUDE.md
+++ b/pkgs/extensions/identity/CLAUDE.md
@@ -24,7 +24,7 @@ The proof model is:
 
 Cloudflare Workers (no Node-only APIs), and this package **is a deployed Worker of its own** — `src/worker.ts` is the `main` in `wrangler.toml`, and it owns the routing. (It started as a library of mountable handlers; `handlers/*` still export pure `Request → Promise<Response>` functions, and `src/index.ts` re-exports them, but the deployed entry point is `worker.ts`.) Persistence is the `DB` D1 binding.
 
-Routes served by `worker.ts`: `POST /api/connect`, `GET /api/lookup`, `POST /api/platform-link`, `POST /api/install-state/claim-jti`, `GET /health`.
+Routes served by `worker.ts`: `POST /api/connect`, `GET /api/lookup`, `GET|POST /api/lookup/by-wallet`, `POST /api/platform-link`, `POST /api/install-state/claim-jti`, `GET /health`.
 
 ## Stack
 
@@ -48,6 +48,7 @@ src/
   handlers/
     connect.ts                  # POST /api/connect — full verification flow
     lookup.ts                   # GET  /api/lookup?provider=&account_id=
+    lookup-by-wallet.ts         # GET|POST /api/lookup/by-wallet — wallet -> identities[]（逆引き）
     platform-link.ts            # POST /api/platform-link — guild -> treeId
     install-state.ts            # POST /api/install-state/claim-jti — single-use OAuth state
   queries.ts                    # drizzle DB ops (getIdentity, upsertIdentity, ...)
@@ -95,6 +96,33 @@ Every connect request must satisfy **all** of the following — any single failu
 7. `typedData.message.nonce` is not already in `used_binding_nonces`.
 
 The success path performs an atomic-feeling pair of writes (D1 transactions are not yet GA — we order them so that nonce insertion fails on conflict before identity upsert is observed by readers).
+
+## Reverse lookup (`/api/lookup/by-wallet`)
+
+Wallet → Web2 account. Used by the notification automation, which only has
+subgraph addresses to work with (no "who ran the command" context).
+
+- **Server-to-server only.** Unlike `GET /api/lookup`, the verifier_token
+  Bearer mode is **not** accepted: a verifier_token proves ownership of a
+  snowflake, which cannot constrain a lookup keyed by address, and reverse
+  lookup leaks more than the forward direction ("know an address → learn who
+  it is"). `LOOKUP_READ_SECRET` unset closes the endpoint entirely (401) —
+  there is no fallback.
+- **Not found is 200 + `[]`, never 404.** "Not linked" is a normal case for
+  notifications.
+- Always an **array**: `identities`' PK is `(provider, account_id)`, so one
+  wallet can carry several accounts. Sorted newest-`updated_at` first.
+- **Address case is normalised on the query side.** `identities.wallet` is
+  stored checksummed (`connect.ts` runs `getAddress()`), while the subgraph
+  emits all-lowercase (`Address.toHex()`). `normalizeWallet()` in `queries.ts`
+  lowercases then re-checksums, so any casing resolves to the one canonical
+  key — and because it is a plain equality comparison (not `lower(wallet) = ?`),
+  `idx_identities_wallet` still applies. See the comment on `normalizeWallet`
+  for why this beats changing the storage format.
+- The batch POST chunks its `IN` clause at 90 addresses (D1 caps bound
+  parameters at 100) and accepts at most `MAX_WALLETS_PER_BATCH` (200) per
+  request. Malformed entries are returned in `invalid` rather than failing the
+  whole batch.
 
 ## Adding a new provider
 

--- a/pkgs/extensions/identity/src/__tests__/lookup-by-wallet.test.ts
+++ b/pkgs/extensions/identity/src/__tests__/lookup-by-wallet.test.ts
@@ -1,0 +1,476 @@
+import { getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import {
+  MAX_WALLETS_PER_BATCH,
+  handleLookupByWallet,
+} from "../handlers/lookup-by-wallet.js";
+import type { IdentityEnv } from "../providers/types.js";
+import { type IdentityDb, upsertIdentity } from "../queries.js";
+import { makeTestDb } from "./fixtures.js";
+
+const TEST_SECRET = "test-lookup-secret-1234";
+const baseEnv: IdentityEnv = { LOOKUP_READ_SECRET: TEST_SECRET };
+
+/**
+ * 保存されている形（checksum, mixed-case）と、subgraph が返す形（全小文字）。
+ * この 2 つが噛み合わないのが本エンドポイントの一番の罠なので、
+ * テストでは常に両方を明示的に持ち回る。
+ */
+const WALLET_CHECKSUM = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+const WALLET_LOWER = WALLET_CHECKSUM.toLowerCase();
+const OTHER_CHECKSUM = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC";
+const OTHER_LOWER = OTHER_CHECKSUM.toLowerCase();
+const UNLINKED_LOWER = "0x90f79bf6eb2c4f870365e785982e1f101e93b906";
+
+function getRequest(query: string, headers?: HeadersInit): Request {
+  return new Request(`https://example.test/api/lookup/by-wallet?${query}`, {
+    headers: headers ?? { "x-toban-lookup-secret": TEST_SECRET },
+  });
+}
+
+function postRequest(body: unknown, headers?: HeadersInit): Request {
+  return new Request("https://example.test/api/lookup/by-wallet", {
+    method: "POST",
+    headers: headers ?? {
+      "content-type": "application/json",
+      "x-toban-lookup-secret": TEST_SECRET,
+    },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+type ResponseItem = {
+  provider: string;
+  accountId: string;
+  wallet: string;
+  updatedAt: number;
+  metadata?: unknown;
+};
+
+async function seed(
+  db: IdentityDb,
+  rows: Array<{
+    accountId: string;
+    wallet: string;
+    provider?: string;
+    metadata?: string | null;
+    updatedAt?: number;
+  }>,
+): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  for (const r of rows) {
+    await upsertIdentity(db, {
+      provider: r.provider ?? "discord",
+      accountId: r.accountId,
+      wallet: r.wallet,
+      metadata: r.metadata ?? null,
+      createdAt: now,
+      updatedAt: r.updatedAt ?? now,
+    });
+  }
+}
+
+describe("handlers/lookup-by-wallet — GET（単体）", () => {
+  it("subgraph 由来の小文字アドレスで、checksum 保存された行を引ける", async () => {
+    const { db } = makeTestDb();
+    // 保存側は connect ハンドラと同じく checksum 表記。
+    await seed(db, [{ accountId: "100", wallet: WALLET_CHECKSUM }]);
+
+    const res = await handleLookupByWallet(
+      getRequest(`provider=discord&wallet=${WALLET_LOWER}`),
+      { db, env: baseEnv },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      wallet: string;
+      identities: ResponseItem[];
+    };
+    // レスポンスの wallet は常に checksum 正規形に寄る。
+    expect(body.wallet).toBe(WALLET_CHECKSUM);
+    expect(body.identities).toHaveLength(1);
+    expect(body.identities[0]?.accountId).toBe("100");
+    expect(body.identities[0]?.wallet).toBe(WALLET_CHECKSUM);
+  });
+
+  it("checksum 表記でも引ける", async () => {
+    const { db } = makeTestDb();
+    await seed(db, [{ accountId: "100", wallet: WALLET_CHECKSUM }]);
+    const res = await handleLookupByWallet(
+      getRequest(`provider=discord&wallet=${WALLET_CHECKSUM}`),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { identities: ResponseItem[] };
+    expect(body.identities).toHaveLength(1);
+  });
+
+  it("大文字小文字が壊れた表記（全大文字 hex）でも引ける", async () => {
+    const { db } = makeTestDb();
+    await seed(db, [{ accountId: "100", wallet: WALLET_CHECKSUM }]);
+    const shouty = `0x${WALLET_LOWER.slice(2).toUpperCase()}`;
+    const res = await handleLookupByWallet(
+      getRequest(`provider=discord&wallet=${shouty}`),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { identities: ResponseItem[] };
+    expect(body.identities).toHaveLength(1);
+  });
+
+  it("小文字で保存されてしまった行は、checksum 正規形では引けない（保存側の正規化が前提であることの明示）", async () => {
+    const { db } = makeTestDb();
+    await seed(db, [{ accountId: "100", wallet: WALLET_LOWER }]);
+    const res = await handleLookupByWallet(
+      getRequest(`provider=discord&wallet=${WALLET_LOWER}`),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { identities: ResponseItem[] };
+    // connect ハンドラは必ず getAddress() を通してから upsert するので
+    // 本来この行は存在しない。挙動を固定しておくためのテスト。
+    expect(body.identities).toEqual([]);
+  });
+
+  it("未連携アドレスは 404 ではなく 200 + 空配列", async () => {
+    const { db } = makeTestDb();
+    await seed(db, [{ accountId: "100", wallet: WALLET_CHECKSUM }]);
+    const res = await handleLookupByWallet(
+      getRequest(`provider=discord&wallet=${UNLINKED_LOWER}`),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      wallet: "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
+      identities: [],
+    });
+  });
+
+  it("1 ウォレットに複数アカウントが紐づく場合は全件を配列で返す（更新が新しい順）", async () => {
+    const { db } = makeTestDb();
+    await seed(db, [
+      { accountId: "100", wallet: WALLET_CHECKSUM, updatedAt: 1000 },
+      { accountId: "200", wallet: WALLET_CHECKSUM, updatedAt: 2000 },
+    ]);
+    const res = await handleLookupByWallet(
+      getRequest(`provider=discord&wallet=${WALLET_LOWER}`),
+      { db, env: baseEnv },
+    );
+    const body = (await res.json()) as { identities: ResponseItem[] };
+    expect(body.identities.map((i) => i.accountId)).toEqual(["200", "100"]);
+  });
+
+  it("provider が違う行は返さない", async () => {
+    const { db } = makeTestDb();
+    await seed(db, [
+      { accountId: "100", wallet: WALLET_CHECKSUM, provider: "github" },
+    ]);
+    const res = await handleLookupByWallet(
+      getRequest(`provider=discord&wallet=${WALLET_LOWER}`),
+      { db, env: baseEnv },
+    );
+    const body = (await res.json()) as { identities: ResponseItem[] };
+    expect(body.identities).toEqual([]);
+  });
+
+  it("metadata は JSON としてパースして返す", async () => {
+    const { db } = makeTestDb();
+    await seed(db, [
+      {
+        accountId: "100",
+        wallet: WALLET_CHECKSUM,
+        metadata: JSON.stringify({ username: "alice" }),
+      },
+    ]);
+    const res = await handleLookupByWallet(
+      getRequest(`provider=discord&wallet=${WALLET_LOWER}`),
+      { db, env: baseEnv },
+    );
+    const body = (await res.json()) as { identities: ResponseItem[] };
+    expect(body.identities[0]?.metadata).toEqual({ username: "alice" });
+  });
+
+  it("provider / wallet が欠けていれば 400", async () => {
+    const { db } = makeTestDb();
+    const res = await handleLookupByWallet(getRequest("provider=discord"), {
+      db,
+      env: baseEnv,
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_query" });
+  });
+
+  it("アドレスとして壊れた入力は 400 invalid_wallet（500 にはしない）", async () => {
+    const { db } = makeTestDb();
+    const res = await handleLookupByWallet(
+      getRequest("provider=discord&wallet=not-an-address"),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_wallet" });
+  });
+});
+
+describe("handlers/lookup-by-wallet — 認証（server-to-server 専用）", () => {
+  it("シークレット無しは 401", async () => {
+    const { db } = makeTestDb();
+    const res = await handleLookupByWallet(
+      getRequest(`provider=discord&wallet=${WALLET_LOWER}`, {}),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized" });
+  });
+
+  it("シークレットが違えば 401", async () => {
+    const { db } = makeTestDb();
+    const res = await handleLookupByWallet(
+      getRequest(`provider=discord&wallet=${WALLET_LOWER}`, {
+        "x-toban-lookup-secret": "nope",
+      }),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("verifier_token（Bearer）では叩けない — 順方向 /api/lookup と違い 2 モード認証にしない", async () => {
+    const { db } = makeTestDb();
+    await seed(db, [{ accountId: "100", wallet: WALLET_CHECKSUM }]);
+    // 逆引きハンドラは provider registry を一切参照しないので、
+    // 正当な verifier_token を持っていても認証は通らない。
+    const res = await handleLookupByWallet(
+      getRequest(`provider=discord&wallet=${WALLET_LOWER}`, {
+        authorization: "Bearer valid-verifier-token",
+      }),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized" });
+  });
+
+  it("バッチも verifier_token では叩けない", async () => {
+    const { db } = makeTestDb();
+    const res = await handleLookupByWallet(
+      postRequest(
+        { provider: "discord", wallets: [WALLET_LOWER] },
+        {
+          "content-type": "application/json",
+          authorization: "Bearer valid-verifier-token",
+        },
+      ),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("LOOKUP_READ_SECRET 未設定ならエンドポイントごと閉じる（401）", async () => {
+    const { db } = makeTestDb();
+    const res = await handleLookupByWallet(
+      getRequest(`provider=discord&wallet=${WALLET_LOWER}`, {}),
+      { db, env: {} },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("GET / POST 以外は 405", async () => {
+    const { db } = makeTestDb();
+    const res = await handleLookupByWallet(
+      new Request("https://example.test/api/lookup/by-wallet", {
+        method: "DELETE",
+        headers: { "x-toban-lookup-secret": TEST_SECRET },
+      }),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(405);
+  });
+});
+
+describe("handlers/lookup-by-wallet — POST（バッチ）", () => {
+  it("小文字アドレスの配列で複数件まとめて引ける", async () => {
+    const { db } = makeTestDb();
+    await seed(db, [
+      { accountId: "100", wallet: WALLET_CHECKSUM },
+      { accountId: "200", wallet: OTHER_CHECKSUM },
+    ]);
+
+    const res = await handleLookupByWallet(
+      postRequest({
+        provider: "discord",
+        wallets: [WALLET_LOWER, OTHER_LOWER],
+      }),
+      { db, env: baseEnv },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      results: Array<{ wallet: string; identities: ResponseItem[] }>;
+      invalid: unknown[];
+    };
+    expect(body.results).toHaveLength(2);
+    expect(body.results[0]?.wallet).toBe(WALLET_CHECKSUM);
+    expect(body.results[0]?.identities.map((i) => i.accountId)).toEqual([
+      "100",
+    ]);
+    expect(body.results[1]?.wallet).toBe(OTHER_CHECKSUM);
+    expect(body.results[1]?.identities.map((i) => i.accountId)).toEqual([
+      "200",
+    ]);
+    expect(body.invalid).toEqual([]);
+  });
+
+  it("未連携アドレスも結果に含まれ、identities が空配列になる", async () => {
+    const { db } = makeTestDb();
+    await seed(db, [{ accountId: "100", wallet: WALLET_CHECKSUM }]);
+    const res = await handleLookupByWallet(
+      postRequest({
+        provider: "discord",
+        wallets: [WALLET_LOWER, UNLINKED_LOWER],
+      }),
+      { db, env: baseEnv },
+    );
+    const body = (await res.json()) as {
+      results: Array<{ wallet: string; identities: ResponseItem[] }>;
+    };
+    expect(body.results).toHaveLength(2);
+    expect(body.results[1]?.identities).toEqual([]);
+  });
+
+  it("表記が混在していても、同じアドレスは 1 件に寄せられる", async () => {
+    const { db } = makeTestDb();
+    await seed(db, [{ accountId: "100", wallet: WALLET_CHECKSUM }]);
+    const res = await handleLookupByWallet(
+      postRequest({
+        provider: "discord",
+        wallets: [WALLET_LOWER, WALLET_CHECKSUM],
+      }),
+      { db, env: baseEnv },
+    );
+    const body = (await res.json()) as {
+      results: Array<{ wallet: string; identities: ResponseItem[] }>;
+    };
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]?.identities).toHaveLength(1);
+  });
+
+  it("1 ウォレットに複数アカウントが紐づく場合もバッチで配列を返す", async () => {
+    const { db } = makeTestDb();
+    await seed(db, [
+      { accountId: "100", wallet: WALLET_CHECKSUM, updatedAt: 1000 },
+      { accountId: "200", wallet: WALLET_CHECKSUM, updatedAt: 2000 },
+      { accountId: "300", wallet: OTHER_CHECKSUM, updatedAt: 3000 },
+    ]);
+    const res = await handleLookupByWallet(
+      postRequest({
+        provider: "discord",
+        wallets: [WALLET_LOWER, OTHER_LOWER],
+      }),
+      { db, env: baseEnv },
+    );
+    const body = (await res.json()) as {
+      results: Array<{ wallet: string; identities: ResponseItem[] }>;
+    };
+    expect(body.results[0]?.identities.map((i) => i.accountId)).toEqual([
+      "200",
+      "100",
+    ]);
+    expect(body.results[1]?.identities.map((i) => i.accountId)).toEqual([
+      "300",
+    ]);
+  });
+
+  it("壊れたアドレスはバッチ全体を落とさず invalid に落ちる", async () => {
+    const { db } = makeTestDb();
+    await seed(db, [{ accountId: "100", wallet: WALLET_CHECKSUM }]);
+    const res = await handleLookupByWallet(
+      postRequest({
+        provider: "discord",
+        wallets: [WALLET_LOWER, "0xdeadbeef", 42],
+      }),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      results: Array<{ wallet: string; identities: ResponseItem[] }>;
+      invalid: unknown[];
+    };
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]?.identities).toHaveLength(1);
+    expect(body.invalid).toEqual(["0xdeadbeef", 42]);
+  });
+
+  it("空配列は 200 + 空の results", async () => {
+    const { db } = makeTestDb();
+    const res = await handleLookupByWallet(
+      postRequest({ provider: "discord", wallets: [] }),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ results: [], invalid: [] });
+  });
+
+  it("D1 のバインド変数上限を跨ぐ件数（チャンク分割）でも全件引ける", async () => {
+    const { db } = makeTestDb();
+    // queries.ts の WALLET_IN_CHUNK_SIZE = 90 を跨ぐ 120 件。
+    const wallets: string[] = [];
+    for (let i = 1; i <= 120; i++) {
+      const lower = `0x${i.toString(16).padStart(40, "0")}`;
+      wallets.push(lower);
+      // 保存側は本番同様 checksum 表記、リクエストは subgraph 同様の小文字。
+      await seed(db, [{ accountId: `acct-${i}`, wallet: getAddress(lower) }]);
+    }
+
+    const res = await handleLookupByWallet(
+      postRequest({ provider: "discord", wallets }),
+      { db, env: baseEnv },
+    );
+    const body = (await res.json()) as {
+      results: Array<{ wallet: string; identities: ResponseItem[] }>;
+    };
+    expect(body.results).toHaveLength(120);
+    expect(body.results.every((r) => r.identities.length === 1)).toBe(true);
+  });
+
+  it("上限を超える件数は 400 too_many_wallets", async () => {
+    const { db } = makeTestDb();
+    const wallets = Array.from(
+      { length: MAX_WALLETS_PER_BATCH + 1 },
+      () => WALLET_LOWER,
+    );
+    const res = await handleLookupByWallet(
+      postRequest({ provider: "discord", wallets }),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "too_many_wallets" });
+  });
+
+  it("body が JSON でなければ 400", async () => {
+    const { db } = makeTestDb();
+    const res = await handleLookupByWallet(postRequest("{not json"), {
+      db,
+      env: baseEnv,
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_body" });
+  });
+
+  it("wallets が配列でなければ 400", async () => {
+    const { db } = makeTestDb();
+    const res = await handleLookupByWallet(
+      postRequest({ provider: "discord", wallets: WALLET_LOWER }),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_body" });
+  });
+
+  it("provider が無ければ 400", async () => {
+    const { db } = makeTestDb();
+    const res = await handleLookupByWallet(
+      postRequest({ wallets: [WALLET_LOWER] }),
+      { db, env: baseEnv },
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_body" });
+  });
+});

--- a/pkgs/extensions/identity/src/handlers/lookup-by-wallet.ts
+++ b/pkgs/extensions/identity/src/handlers/lookup-by-wallet.ts
@@ -1,0 +1,234 @@
+import { isAddress } from "viem";
+import type { IdentityEnv } from "../providers/types.js";
+import {
+  type IdentityDb,
+  getIdentitiesByWallet,
+  getIdentitiesByWallets,
+  normalizeWallet,
+} from "../queries.js";
+import type { Identity } from "../schema.js";
+
+export type LookupByWalletHandlerDeps = {
+  db: IdentityDb;
+  env: IdentityEnv;
+};
+
+/**
+ * 1 リクエストで引けるアドレスの上限。通知 1 回あたりは数十件の想定なので
+ * 十分な余裕がある。上限を設けるのは、逆引きが列挙に弱い（後述）ため
+ * 1 リクエストあたりのコストを抑えたいから。
+ */
+export const MAX_WALLETS_PER_BATCH = 200;
+
+/** レスポンス上の identity 1 件。`wallet` は常に checksum 表記。 */
+export type IdentityByWalletItem = {
+  provider: string;
+  accountId: string;
+  wallet: string;
+  updatedAt: number;
+  metadata?: unknown;
+};
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function serialize(row: Identity): IdentityByWalletItem {
+  let metadata: unknown;
+  if (row.metadata !== null && row.metadata !== undefined) {
+    try {
+      metadata = JSON.parse(row.metadata);
+    } catch {
+      metadata = row.metadata;
+    }
+  }
+  const base = {
+    provider: row.provider,
+    accountId: row.accountId,
+    wallet: row.wallet,
+    updatedAt: row.updatedAt,
+  };
+  return metadata === undefined ? base : { ...base, metadata };
+}
+
+/**
+ * 同じウォレットに複数アカウントが紐づく場合の並び順を決めておく。
+ * 「最新の 1 件だけ使う」呼び出し元が `[0]` を取れるよう、更新が新しい順。
+ * 同時刻は accountId の昇順で決定的にする（テストを安定させるため）。
+ */
+function sortItems(items: IdentityByWalletItem[]): IdentityByWalletItem[] {
+  return items.sort((a, b) =>
+    b.updatedAt !== a.updatedAt
+      ? b.updatedAt - a.updatedAt
+      : a.accountId < b.accountId
+        ? -1
+        : a.accountId > b.accountId
+          ? 1
+          : 0,
+  );
+}
+
+/**
+ * 逆引きは **server-to-server 専用**。
+ *
+ * 順方向 `/api/lookup` は 2 モード認証（共有シークレット + ブラウザが持つ
+ * verifier_token JWT）だが、逆引きに verifier_token を許してはいけない。
+ * verifier_token は「その snowflake の持ち主である」ことしか証明せず、
+ * 逆引きの入力はアドレスなので、JWT の accountId と引数を突き合わせて
+ * 自分自身に限定する、という順方向の絞り込みが成立しない。
+ * 「アドレスを知っていれば誰と紐づくか分かる」= 順方向より情報が漏れやすいので、
+ * 共有シークレットを持つ Worker からのみ叩けるようにする。
+ *
+ * また順方向と違い、`LOOKUP_READ_SECRET` 未設定時のフォールバックも無い。
+ * 未設定ならエンドポイントごと閉じる（401）。
+ */
+function isAuthorized(request: Request, env: IdentityEnv): boolean {
+  const sharedSecret = env.LOOKUP_READ_SECRET;
+  if (!sharedSecret) return false;
+  return request.headers.get("x-toban-lookup-secret") === sharedSecret;
+}
+
+/**
+ * `GET /api/lookup/by-wallet?provider=discord&wallet=0x...`
+ * `POST /api/lookup/by-wallet  { provider, wallets: [...] }`
+ *
+ * ウォレットアドレス → Web2 アカウントの逆引き。通知 automation が
+ * subgraph から得たアドレスを Discord メンションに変換するために使う。
+ *
+ * - 見つからない場合も **200 + 空配列**。通知処理では「未連携」は正常系なので、
+ *   404 にすると呼び出し側がエラーハンドリングを強いられる。
+ * - 1 ウォレットに複数アカウントが紐づき得る（`identities` の PK は
+ *   `(provider, account_id)`）ので、常に配列で返す。
+ * - アドレスの大文字小文字は `normalizeWallet()` が吸収する。
+ *   小文字（subgraph 由来）でも checksum でも引ける。詳細は `queries.ts` を参照。
+ *
+ * GET レスポンス:  `{ wallet, identities: [...] }`
+ * POST レスポンス: `{ results: [{ wallet, identities: [...] }], invalid: [...] }`
+ *   `results` は **リクエストで渡した有効なアドレス全件** を含む（未連携は
+ *   `identities: []`）。`invalid` はアドレスとして解釈できなかった入力。
+ */
+export async function handleLookupByWallet(
+  request: Request,
+  deps: LookupByWalletHandlerDeps,
+): Promise<Response> {
+  if (request.method !== "GET" && request.method !== "POST") {
+    return json(405, { error: "method_not_allowed" });
+  }
+
+  if (!isAuthorized(request, deps.env)) {
+    return json(401, { error: "unauthorized" });
+  }
+
+  return request.method === "GET"
+    ? handleSingle(request, deps)
+    : handleBatch(request, deps);
+}
+
+async function handleSingle(
+  request: Request,
+  deps: LookupByWalletHandlerDeps,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const provider = url.searchParams.get("provider");
+  const wallet = url.searchParams.get("wallet");
+  if (!provider || !wallet) {
+    return json(400, {
+      error: "invalid_query",
+      details: "provider and wallet are required",
+    });
+  }
+  if (!isAddress(wallet, { strict: false })) {
+    return json(400, {
+      error: "invalid_wallet",
+      details: `not an EVM address: ${wallet}`,
+    });
+  }
+
+  const rows = await getIdentitiesByWallet(deps.db, provider, wallet);
+  return json(200, {
+    wallet: normalizeWallet(wallet),
+    identities: sortItems(rows.map(serialize)),
+  });
+}
+
+async function handleBatch(
+  request: Request,
+  deps: LookupByWalletHandlerDeps,
+): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json(400, { error: "invalid_body", details: "body is not JSON" });
+  }
+  if (typeof body !== "object" || body === null) {
+    return json(400, {
+      error: "invalid_body",
+      details: "body is not an object",
+    });
+  }
+
+  const { provider, wallets } = body as {
+    provider?: unknown;
+    wallets?: unknown;
+  };
+  if (typeof provider !== "string" || provider.length === 0) {
+    return json(400, {
+      error: "invalid_body",
+      details: "provider is required",
+    });
+  }
+  if (!Array.isArray(wallets)) {
+    return json(400, {
+      error: "invalid_body",
+      details: "wallets must be an array",
+    });
+  }
+  if (wallets.length > MAX_WALLETS_PER_BATCH) {
+    return json(400, {
+      error: "too_many_wallets",
+      details: `at most ${MAX_WALLETS_PER_BATCH} wallets per request`,
+    });
+  }
+
+  // アドレスとして壊れている入力があってもバッチ全体を落とさない。
+  // 通知処理は 1 回の実行で数十件を引くので、1 件の異常でバッチ全体が
+  // 400 になると通知が丸ごと止まってしまう。壊れた入力は `invalid` で返し、
+  // 呼び出し元がログに出せるようにする。
+  const valid: string[] = [];
+  const invalid: unknown[] = [];
+  for (const w of wallets) {
+    if (typeof w === "string" && isAddress(w, { strict: false })) {
+      valid.push(w);
+    } else {
+      invalid.push(w);
+    }
+  }
+
+  const rows =
+    valid.length === 0
+      ? []
+      : await getIdentitiesByWallets(deps.db, provider, valid);
+
+  // checksum 表記をキーにグルーピング。DB の行も引数も同じ正規形なので一致する。
+  const byWallet = new Map<string, IdentityByWalletItem[]>();
+  for (const wallet of valid) {
+    const key = normalizeWallet(wallet);
+    if (!byWallet.has(key)) byWallet.set(key, []);
+  }
+  for (const row of rows) {
+    const bucket = byWallet.get(row.wallet);
+    if (bucket) bucket.push(serialize(row));
+  }
+
+  return json(200, {
+    results: [...byWallet.entries()].map(([wallet, items]) => ({
+      wallet,
+      identities: sortItems(items),
+    })),
+    invalid,
+  });
+}

--- a/pkgs/extensions/identity/src/index.ts
+++ b/pkgs/extensions/identity/src/index.ts
@@ -50,10 +50,13 @@ export type {
 } from "./schema.js";
 
 export {
+  getIdentitiesByWallet,
+  getIdentitiesByWallets,
   getIdentity,
   getPlatformLink,
   isNonceUsed,
   markNonceUsed,
+  normalizeWallet,
   upsertIdentity,
   upsertPlatformLink,
 } from "./queries.js";
@@ -68,3 +71,12 @@ export type {
 
 export { handleLookup } from "./handlers/lookup.js";
 export type { LookupHandlerDeps } from "./handlers/lookup.js";
+
+export {
+  handleLookupByWallet,
+  MAX_WALLETS_PER_BATCH,
+} from "./handlers/lookup-by-wallet.js";
+export type {
+  IdentityByWalletItem,
+  LookupByWalletHandlerDeps,
+} from "./handlers/lookup-by-wallet.js";

--- a/pkgs/extensions/identity/src/queries.ts
+++ b/pkgs/extensions/identity/src/queries.ts
@@ -1,6 +1,6 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
-import { toBytes } from "viem";
+import { getAddress, toBytes } from "viem";
 import type { Hex } from "viem";
 import {
   identities,
@@ -47,6 +47,102 @@ export async function getIdentity(
     )
     .limit(1);
   return (rows[0] as Identity | undefined) ?? null;
+}
+
+/**
+ * D1 は 1 クエリあたりのバインド変数を 100 個までしか受け付けない。
+ * `provider` 分を 1 つ使うので、IN 句に詰めるアドレスは余裕を見て 90 件で区切る。
+ */
+const WALLET_IN_CHUNK_SIZE = 90;
+
+/**
+ * ウォレットアドレスを EIP-55 の checksum 表記に正規化する。
+ *
+ * ## なぜ正規化が必要か（本モジュールで一番の罠）
+ *
+ * `identities.wallet` は **checksum（mixed-case）** で保存されている。
+ * （`handlers/connect.ts` が upsert 直前に `getAddress()` を通している。）
+ * 一方、逆引きの呼び出し元である通知処理は subgraph からアドレスを得るが、
+ * subgraph は `Address.toHex()` の結果、つまり **全小文字** を返す。
+ * SQLite / D1 の `=` は TEXT に対して大文字小文字を区別するので、
+ * 小文字のまま素直に比較すると **必ず 0 件になる**。
+ *
+ * ## なぜ「クエリ側で checksum 化」を選んだか
+ *
+ * - **既存データを壊さない**。保存形式（checksum）を変えないのでデータ移行が不要で、
+ *   順方向 `/api/lookup` のレスポンス（checksum を返す）とも矛盾しない。
+ * - **`idx_identities_wallet` がそのまま効く**。`lower(wallet) = ?` や
+ *   `COLLATE NOCASE` にすると、`identities(wallet)` の素の B-tree インデックスは
+ *   使われず全件スキャンになる（式インデックスを別途張る必要がある）。
+ * - `getAddress()` は EIP-55 の唯一の正規形を返すので、呼び出し元が全小文字で渡そうが
+ *   全大文字で渡そうが、常に同じキーに寄る。
+ *
+ * `getAddress()` に mixed-case をそのまま渡すと EIP-55 チェックサム検証が走り、
+ * 「大文字小文字が雑なだけの正しいアドレス」でも throw する。逆引きの入力は
+ * 外部（subgraph / automation）由来で表記が保証できないので、いったん全小文字に
+ * 落としてから checksum 化し、**16 進として正しければどんな表記でも受け入れる**。
+ * 16 進として壊れている文字列に対しては throw するので、呼び出し元（ハンドラ）で
+ * `isAddress(x, { strict: false })` を使って事前に弾くこと。
+ */
+export function normalizeWallet(wallet: string): string {
+  return getAddress(wallet.toLowerCase());
+}
+
+/**
+ * 逆引き: `(provider, wallet) → identities[]`。
+ *
+ * `identities` の PK は `(provider, account_id)` なので、1 つのウォレットに
+ * 複数のアカウントが紐づき得る（例: 主アカウントとサブアカウント）。
+ * よって常に配列で返す。未連携はエラーではなく空配列。
+ *
+ * 大文字小文字の扱いは {@link normalizeWallet} のコメントを参照。
+ */
+export async function getIdentitiesByWallet(
+  db: IdentityDb,
+  provider: string,
+  wallet: string,
+): Promise<Identity[]> {
+  const rows = await db
+    .select()
+    .from(identities)
+    .where(
+      and(
+        eq(identities.provider, provider),
+        eq(identities.wallet, normalizeWallet(wallet)),
+      ),
+    );
+  return rows as Identity[];
+}
+
+/**
+ * 逆引きのバッチ版。通知処理は 1 回の実行で数十件のアドレスを引くので、
+ * 1 件ずつ SELECT を投げると D1 のラウンドトリップが積み上がる。
+ *
+ * 入力は重複除去してから `IN` 句に詰める。`IN` も等値比較の集まりなので
+ * `idx_identities_wallet` が効く。戻り値はフラットな行の配列で、
+ * ウォレットごとのグルーピングはハンドラ側の責任。
+ */
+export async function getIdentitiesByWallets(
+  db: IdentityDb,
+  provider: string,
+  wallets: readonly string[],
+): Promise<Identity[]> {
+  const checksums = [...new Set(wallets.map(normalizeWallet))];
+  const out: Identity[] = [];
+  for (let i = 0; i < checksums.length; i += WALLET_IN_CHUNK_SIZE) {
+    const chunk = checksums.slice(i, i + WALLET_IN_CHUNK_SIZE);
+    const rows = await db
+      .select()
+      .from(identities)
+      .where(
+        and(
+          eq(identities.provider, provider),
+          inArray(identities.wallet, chunk),
+        ),
+      );
+    out.push(...(rows as Identity[]));
+  }
+  return out;
 }
 
 /**

--- a/pkgs/extensions/identity/src/worker.ts
+++ b/pkgs/extensions/identity/src/worker.ts
@@ -4,6 +4,8 @@
  * Routes:
  *   POST /api/connect         — IdentityBinding verification + upsert
  *   GET  /api/lookup          — (provider, account_id) -> wallet
+ *   GET  /api/lookup/by-wallet  — wallet -> identities[]（逆引き・単体）
+ *   POST /api/lookup/by-wallet  — wallets[] -> identities[]（逆引き・バッチ）
  *   GET  /api/platform-link   — (provider, platform_id) -> tree_id binding
  *   POST /api/platform-link   — upsert a workspace ↔ platform binding
  *
@@ -14,6 +16,7 @@
 import { drizzle } from "drizzle-orm/d1";
 import { handleConnect } from "./handlers/connect.js";
 import { handleInstallStateClaim } from "./handlers/install-state.js";
+import { handleLookupByWallet } from "./handlers/lookup-by-wallet.js";
 import { handleLookup } from "./handlers/lookup.js";
 import { handlePlatformLink } from "./handlers/platform-link.js";
 import type { IdentityEnv } from "./providers/types.js";
@@ -68,6 +71,9 @@ export default {
           break;
         case "/api/lookup":
           response = await handleLookup(request, { db, env });
+          break;
+        case "/api/lookup/by-wallet":
+          response = await handleLookupByWallet(request, { db, env });
           break;
         case "/api/platform-link":
           response = await handlePlatformLink(request, {


### PR DESCRIPTION
Closes #573

通知 automation（#574）が、subgraph から得たウォレットアドレスを Discord メンションに変換するための逆引き API。

```
GET  /api/lookup/by-wallet?provider=discord&wallet=0x...
POST /api/lookup/by-wallet  { provider, wallets: [...] }   # バッチ
```

`identities` の PK が `(provider, account_id)` なので 1 ウォレットに複数アカウントが有り得ます。常に配列で、`updated_at` 降順。未連携は 404 ではなく **200 + 空配列**（通知処理では正常系）。

## アドレスの大文字小文字（この issue の本体）

`identities.wallet` は**チェックサム（mixed-case）**で保存される一方、subgraph は `toHex()` で**小文字**を返します。素朴に等値比較すると、#574 は本番で**必ず 0 件**を引きます。

`normalizeWallet()` が「**小文字化 → `getAddress()`**」で正規形に寄せます。いったん小文字に落とすのが要点で、mixed-case を `getAddress()` に直接渡すと EIP-55 検証が走り「大小文字が雑なだけの正しいアドレス」で throw します。外部由来の表記を保証できない逆引きでは受け入れ側を緩くすべき、という判断です。

保存形式を変えなかったので**移行は不要**で、等値比較のままなので `idx_identities_wallet` もそのまま効きます（`lower(wallet) = ?` にすると式インデックスが別途必要になる）。

## 認証は server-to-server 専用

既存の `GET /api/lookup` は列挙対策で 2 モード認証（共有シークレット + ブラウザの verifier_token）ですが、**逆引きでは verifier_token を受け付けません**。verifier_token は「この snowflake の持ち主である」ことしか証明せず、アドレスをキーにした引きを制約できないためです。逆引きは順方向より漏れやすい（アドレスを知っていれば誰と紐づくか分かる）ので、`LOOKUP_READ_SECRET` 未設定なら 401 で閉じます。

## テスト（identity 58 passed / 新規 27）

- **小文字（subgraph 由来）/ checksum / 全大文字 hex のいずれでも同じ行が引ける**
- 未連携は 200 + 空配列、1 ウォレット複数アカウントは全件・降順
- **verifier_token では 401**、シークレット不一致・未設定も 401
- バッチ: 表記混在の重複は 1 件に寄る、壊れたアドレスは `invalid` に落ちてバッチ全体は落ちない、**D1 のバインド変数上限を跨ぐ 120 件でも全件引ける**（90 件でチャンク分割）

## レビューで見てほしい点

- **壊れた入力をバッチ全体の 400 にせず `invalid` 配列で返す**設計にしています。通知が 1 件の異常で丸ごと止まるのを避ける意図ですが、「黙って落とすな」という判断もあり得ます
- シークレット比較が `===`（タイミング安全でない）。既存 `/api/lookup` に合わせましたが、逆引きの方が機微なので定数時間比較にする手もあります
- `MAX_WALLETS_PER_BATCH = 200` は根拠の薄い数字です

## 運用上の確認（コードの問題ではありません）

`identities` への書き込み経路は `connect.ts:377` の `getAddress()` 一本なので、通常は全行が checksum です。ただし**旧コードや手作業で小文字の行が入っていると引けません**。本番 D1 に混在が無いか一度確認いただけると安心です。

## 他 PR への影響

`IdentityClient` に必須メソッドが増えるため、**#572 がマージされる際に `test/mcp.test.ts` の `StubIdentity` へメソッド追加が必要**です（`thx.test.ts` / `quest-submit.test.ts` は本 PR で対応済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
