### PR TITLE
fix(frontend): Privy を v3 に上げて新規アカウントのログイン無限ローディングを解消

### DIFF
--- a/pkgs/frontend/app/components/PrivyAppRoot.tsx
+++ b/pkgs/frontend/app/components/PrivyAppRoot.tsx
@@ -1,7 +1,7 @@
 import { PrivyProvider } from "@privy-io/react-auth";
 import { SmartWalletsProvider } from "@privy-io/react-auth/smart-wallets";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { currentChain } from "hooks/useViem";
+import { privyChain } from "hooks/useViem";
 import { PWAUpdater } from "./PWAUpdater";
 import { SwitchNetwork } from "./SwitchNetwork";
 import { AppShellLayout } from "./layout/AppShellLayout";
@@ -31,8 +31,10 @@ export default function PrivyAppRoot() {
             connectionOptions: "smartWalletOnly",
           },
         },
-        defaultChain: currentChain,
-        supportedChains: [currentChain],
+        // `privyChain` — not `currentChain` — so Privy's own public client
+        // doesn't fall back to viem's default RPC. See `hooks/useViem.ts`.
+        defaultChain: privyChain,
+        supportedChains: [privyChain],
       }}
     >
       <SmartWalletsProvider>

--- a/pkgs/frontend/app/routes/login.tsx
+++ b/pkgs/frontend/app/routes/login.tsx
@@ -21,17 +21,21 @@ import { Typography } from "~/components/ui/typography";
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const OTP_LENGTH = 6;
+// How long we wait for Privy to provision the embedded wallet's smart wallet
+// before giving up and showing an error instead of the spinner.
+const SMART_WALLET_TIMEOUT_MS = 20000;
 
 const Login: FC = () => {
   const { authenticated } = usePrivy();
   const { wallets } = useWallets();
-  const { wallet } = useActiveWallet();
+  const { wallet, isPreparingSmartWallet } = useActiveWallet();
   const { fetchNames } = useNamesByAddresses();
   const handleLogout = useLogoutWallet();
 
   const [email, setEmail] = useState("");
   const [otp, setOtp] = useState("");
   const [step, setStep] = useState<"input" | "otp">("input");
+  const [smartWalletFailed, setSmartWalletFailed] = useState(false);
 
   const { sendCode, loginWithCode, state: emailState } = useLoginWithEmail();
   const { initOAuth, state: oauthState } = useLoginWithOAuth();
@@ -62,6 +66,31 @@ const Login: FC = () => {
   const resolvedAddress = hasEmbeddedWallet
     ? wallet?.account?.address
     : (wallet?.account?.address ?? wallets[0]?.address);
+
+  // Privy provisions a brand-new account's smart wallet by having the freshly
+  // created embedded EOA sign a SIWE message and then linking it server-side;
+  // `useSmartWallets().client` — and with it the address our profile lookup is
+  // keyed on — stays undefined until that lands. `SmartWalletsProvider`
+  // swallows any failure in that flow (it only `console.error`s
+  // "Error creating smart wallet:"), so the card would otherwise spin forever:
+  // the ENS timeout below can't cover this, because it only starts once we
+  // already have an address. Give provisioning its own deadline and surface
+  // the failure so the user can retry instead of staring at the spinner.
+  useEffect(() => {
+    if (!authenticated || !isPreparingSmartWallet) {
+      setSmartWalletFailed(false);
+      return;
+    }
+    const timeoutId = setTimeout(() => {
+      console.error(
+        "Smart wallet was not provisioned within",
+        SMART_WALLET_TIMEOUT_MS,
+        'ms — check the console for Privy\'s "Error creating smart wallet".',
+      );
+      setSmartWalletFailed(true);
+    }, SMART_WALLET_TIMEOUT_MS);
+    return () => clearTimeout(timeoutId);
+  }, [authenticated, isPreparingSmartWallet]);
 
   useEffect(() => {
     const address = resolvedAddress;
@@ -306,26 +335,58 @@ const Login: FC = () => {
 
           {isAuthenticated && (
             <>
-              <output
-                className="flex flex-col items-center gap-3 py-2"
-                aria-live="polite"
-              >
-                <Spinner size="lg" />
-                <Typography
-                  variant="bodySm"
-                  weight="bold"
-                  className="text-center"
+              {smartWalletFailed ? (
+                <div
+                  className="flex flex-col items-center gap-3 py-2"
+                  role="alert"
                 >
-                  ワークスペースを準備しています…
-                </Typography>
-                <Typography
-                  variant="caption"
-                  tone="secondary"
-                  className="text-center"
+                  <Typography
+                    variant="bodySm"
+                    weight="bold"
+                    className="text-center"
+                  >
+                    ウォレットの準備に失敗しました
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    tone="secondary"
+                    className="text-center"
+                  >
+                    もう一度お試しください。繰り返し失敗する場合は、サインアウトしてから時間をおいて再度お試しください。
+                  </Typography>
+                </div>
+              ) : (
+                <output
+                  className="flex flex-col items-center gap-3 py-2"
+                  aria-live="polite"
                 >
-                  自動で移動します。問題が起きた場合はサインアウトしてやり直してください。
-                </Typography>
-              </output>
+                  <Spinner size="lg" />
+                  <Typography
+                    variant="bodySm"
+                    weight="bold"
+                    className="text-center"
+                  >
+                    ワークスペースを準備しています…
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    tone="secondary"
+                    className="text-center"
+                  >
+                    自動で移動します。問題が起きた場合はサインアウトしてやり直してください。
+                  </Typography>
+                </output>
+              )}
+              {smartWalletFailed && (
+                <Button
+                  size="lg"
+                  full
+                  data-testid="login-retry"
+                  onClick={() => window.location.reload()}
+                >
+                  再試行
+                </Button>
+              )}
               <Button variant="secondary" size="lg" full onClick={handleLogout}>
                 <Icon name="logout" size={18} />
                 サインアウト

--- a/pkgs/frontend/app/routes/login.tsx
+++ b/pkgs/frontend/app/routes/login.tsx
@@ -8,7 +8,7 @@ import {
 import { useNamesByAddresses } from "hooks/useENS";
 import { useLogoutWallet } from "hooks/useLogoutWallet";
 import { useActiveWallet } from "hooks/useWallet";
-import { type FC, useCallback, useEffect, useState } from "react";
+import { type FC, useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AuthHero } from "~/components/composite/auth-hero";
 import { AuthLayout } from "~/components/layout/AuthLayout";
@@ -26,7 +26,7 @@ const OTP_LENGTH = 6;
 const SMART_WALLET_TIMEOUT_MS = 20000;
 
 const Login: FC = () => {
-  const { authenticated } = usePrivy();
+  const { authenticated, user } = usePrivy();
   const { wallets } = useWallets();
   const { wallet, isPreparingSmartWallet } = useActiveWallet();
   const { fetchNames } = useNamesByAddresses();
@@ -67,6 +67,27 @@ const Login: FC = () => {
     ? wallet?.account?.address
     : (wallet?.account?.address ?? wallets[0]?.address);
 
+  // Read through a ref, never the effect's dependency array: `usePrivy().user`
+  // and `useWallets().wallets` get fresh identities on most renders, so
+  // depending on them would tear the timeout below down and restart it before
+  // it could ever fire — the same trap the navigation effect above documents.
+  const diagnosticsRef = useRef({
+    hasSmartWallet: !!user?.smartWallet,
+    wallets: wallets.map((w) => ({
+      connectorType: w.connectorType,
+      walletClientType: w.walletClientType,
+      imported: w.imported,
+    })),
+  });
+  diagnosticsRef.current = {
+    hasSmartWallet: !!user?.smartWallet,
+    wallets: wallets.map((w) => ({
+      connectorType: w.connectorType,
+      walletClientType: w.walletClientType,
+      imported: w.imported,
+    })),
+  };
+
   // Privy provisions a brand-new account's smart wallet by having the freshly
   // created embedded EOA sign a SIWE message and then linking it server-side;
   // `useSmartWallets().client` — and with it the address our profile lookup is
@@ -82,10 +103,17 @@ const Login: FC = () => {
       return;
     }
     const timeoutId = setTimeout(() => {
+      // Privy's own failure paths are quiet: `SmartWalletsProvider` only
+      // `console.error`s "Error creating smart wallet:" for the *link* step,
+      // and the client-creation step (factory `getAddress()` read → RPC) can
+      // reject or hang with nothing in the console at all. Dump enough state
+      // to tell those apart from a repro.
       console.error(
-        "Smart wallet was not provisioned within",
-        SMART_WALLET_TIMEOUT_MS,
-        'ms — check the console for Privy\'s "Error creating smart wallet".',
+        `Smart wallet was not provisioned within ${SMART_WALLET_TIMEOUT_MS}ms`,
+        {
+          hasSmartWallet: !!diagnosticsRef.current.hasSmartWallet,
+          wallets: diagnosticsRef.current.wallets,
+        },
       );
       setSmartWalletFailed(true);
     }, SMART_WALLET_TIMEOUT_MS);

--- a/pkgs/frontend/hooks/useViem.ts
+++ b/pkgs/frontend/hooks/useViem.ts
@@ -67,20 +67,23 @@ export const currentChainRPCBaseURL = [http(alchemyRpcUrl, HTTP_RETRY)];
  * viem's `sepolia.rpcUrls.default` is `https://sepolia.drpc.org`, which now
  * answers every request with HTTP 400 ("chain is not available on free plan,
  * please upgrade to paid plan"). That broke the factory `getAddress()` read
- * inside `toThirdwebSmartAccount`, so Privy never built a smart wallet client
- * and never linked the smart wallet — leaving brand-new accounts stuck on
- * /login with an embedded EOA and no smart account. `publicClient` above
- * survives the same outage only because it falls through to publicnode.
+ * that `toThirdwebSmartAccount` issues while building the account, so Privy
+ * never got a smart wallet client and never linked the smart wallet —
+ * leaving brand-new Sepolia accounts stuck on /login with an embedded EOA and
+ * no smart account. `publicClient` below survives the same outage only
+ * because it falls through to publicnode.
  *
- * Point Privy at Alchemy instead. This costs one read per session (the
- * account address and nonce; user-op gas pricing goes to Pimlico's bundler),
- * which is negligible next to a broken signup.
+ * Hand Privy publicnode — the keyless middle tier `publicClient` already
+ * trusts — rather than Alchemy. Alchemy would tie login to a keyed app (the
+ * Base one is currently inactive and answers 403 "App is inactive"), and this
+ * client cannot fall back, so the RPC it gets should be the one least likely
+ * to need babysitting.
  */
 export const privyChain = {
   ...currentChain,
   rpcUrls: {
     ...currentChain.rpcUrls,
-    default: { http: [alchemyRpcUrl] as [string] },
+    default: { http: [publicNodeRpcUrl] as [string] },
   },
 };
 

--- a/pkgs/frontend/hooks/useViem.ts
+++ b/pkgs/frontend/hooks/useViem.ts
@@ -73,17 +73,17 @@ export const currentChainRPCBaseURL = [http(alchemyRpcUrl, HTTP_RETRY)];
  * no smart account. `publicClient` below survives the same outage only
  * because it falls through to publicnode.
  *
- * Hand Privy publicnode — the keyless middle tier `publicClient` already
- * trusts — rather than Alchemy. Alchemy would tie login to a keyed app (the
- * Base one is currently inactive and answers 403 "App is inactive"), and this
- * client cannot fall back, so the RPC it gets should be the one least likely
- * to need babysitting.
+ * Hand Privy Alchemy. It costs a couple of reads per session (the account
+ * address and nonce; user-op gas pricing goes to Pimlico's bundler), which is
+ * negligible next to a broken signup. Because this client can't fall back,
+ * login now depends on the Alchemy app staying live — keep `VITE_ALCHEMY_KEY`
+ * pointed at an active app per environment.
  */
 export const privyChain = {
   ...currentChain,
   rpcUrls: {
     ...currentChain.rpcUrls,
-    default: { http: [publicNodeRpcUrl] as [string] },
+    default: { http: [alchemyRpcUrl] as [string] },
   },
 };
 

--- a/pkgs/frontend/hooks/useViem.ts
+++ b/pkgs/frontend/hooks/useViem.ts
@@ -52,6 +52,39 @@ const HTTP_RETRY = { retryCount: 1 } as const;
 export const currentChainRPCBaseURL = [http(alchemyRpcUrl, HTTP_RETRY)];
 
 /**
+ * The chain object handed to `PrivyProvider` (`supportedChains` /
+ * `defaultChain`).
+ *
+ * Privy's internal public client (`getPublicClient` in
+ * `@privy-io/react-auth`) resolves its RPC *from the chain object it is
+ * given*, in this order: `rpcUrls.privyWalletOverride` → the SDK's internal
+ * `rpcConfig` (not exposed on `PrivyProviderProps`, so we can't set it) →
+ * `rpcUrls.privy` → `rpcUrls.public` → `rpcUrls.default`. viem's chains only
+ * define `default`, and that client has no fallback transport — so whatever
+ * `rpcUrls.default` points at is a single point of failure for smart-account
+ * provisioning.
+ *
+ * viem's `sepolia.rpcUrls.default` is `https://sepolia.drpc.org`, which now
+ * answers every request with HTTP 400 ("chain is not available on free plan,
+ * please upgrade to paid plan"). That broke the factory `getAddress()` read
+ * inside `toThirdwebSmartAccount`, so Privy never built a smart wallet client
+ * and never linked the smart wallet — leaving brand-new accounts stuck on
+ * /login with an embedded EOA and no smart account. `publicClient` above
+ * survives the same outage only because it falls through to publicnode.
+ *
+ * Point Privy at Alchemy instead. This costs one read per session (the
+ * account address and nonce; user-op gas pricing goes to Pimlico's bundler),
+ * which is negligible next to a broken signup.
+ */
+export const privyChain = {
+  ...currentChain,
+  rpcUrls: {
+    ...currentChain.rpcUrls,
+    default: { http: [alchemyRpcUrl] as [string] },
+  },
+};
+
+/**
  * Public client for fetching data from the blockchain.
  *
  * Fallback order: viem default public RPC → publicnode → Alchemy. We lead with


### PR DESCRIPTION
## 背景

新規で Google / メールアドレスでアカウントを作ったユーザーが `/signup` のプロフィール設定画面に遷移せず、`/login` で「ワークスペースを準備しています…」のまま止まる。再現環境は **Base 本番**。

## 原因

本番で詰まっているセッションの `/api/v1/oauth/authenticate` レスポンスを確認すると、**`linked_accounts` が `google_oauth` のみ**で wallet が 1 つも無い。つまりスマートアカウント以前に、**埋め込みウォレットがそもそも作られていない**。

`login.tsx` の遷移はアドレスを起点にしているため、これで詰む:

- `hooks/useWallet.ts` — embedded wallet かつ smart wallet client なしで `wallet` が `undefined`
- `app/routes/login.tsx` — `resolvedAddress` が `undefined`
- 遷移用 effect が `if (!address) return;` で即抜けるため、**既存の 5 秒フォールバックタイマーがそもそも起動しない**

既存ユーザーは wallet と `user.smartWallet` を既に持つため、**新規ユーザーだけが壊れる**非対称性になる。

### FoR との比較

同じ Privy アプリ（`cm3wz404002mlc25ikvrs2ikh`）を使っている [FoR](../FoR) は、同一の thirdweb スマートウォレット設定・同じ `showWalletUIs: false` で新規登録が通っている。実装差分はほぼ無く、決定的な違いは **SDK のメジャーバージョン**だった。

| | Toban（旧） | FoR |
|---|---|---|
| `@privy-io/react-auth` | `>=2.4.2 <=2.5.0` → **2.5.0** | **^3.10.1** |
| `permissionless` | `^0.2.35` → 0.2.47 | `^0.2.57` |
| `viem` | `^2.21.51` → 2.30.5 | `^2.43.5` |

上限ピンは元々 **Vercel のビルドエラー回避**のために付いたもので（`8e96fc4`）、3.x を評価した結果ではない。`61c94cd fix infinite load` も同じ症状を Privy のバージョン移動で直しており、前例がある。

### 比較で除外できた仮説

| 疑った点 | 結果 |
|---|---|
| `showWalletUIs: false`（`733ac32` で追加） | FoR も同じ設定で動作 → 無関係 |
| `createOnLogin` のフラット形式 | 2.5.0 の正規化（`useWallets-CIsjbJl7.mjs`）は `U ?? t?.embeddedWallets?.ethereum?.createOnLogin ?? P` でフラット形式を**最優先**に解釈 → 設定は正しく効いていた |
| Privy アプリ設定 | `allowedDomains` に `www.toban.xyz` / `toban.xyz` の両方あり。`smart_wallets` も `enabled: true`・`thirdweb`・両チェーン設定済み |
| Privy に渡す RPC | FoR は素の `currentChain` を渡すだけで Base は動作 |
| iframe のブロック | リポジトリにも `toban.xyz` のレスポンスにも CSP / COEP / X-Frame-Options なし。iframe エンドポイントも HTTP 200 |
| provider の再マウント | `root.tsx` の `PrivyAppRoot` はハイドレーション後に一度だけマウントされ以降アンマウントされない |

## 変更内容

### 1. Privy を v3 に上げる（本体）

`@privy-io/react-auth` `^3.10.1` / `permissionless` `^0.2.57` / `viem` `^2.43.5`。

v3 の破壊的変更への対応:

- `embeddedWallets.createOnLogin` のフラット形式が削除 → `embeddedWallets.ethereum.createOnLogin`
- `externalWallets.coinbaseWallet.connectionOptions: "smartWalletOnly"` が削除 → Coinbase SDK のオプション形式 `config: { preference: { options: "smartWalletOnly" } }`

FoR の解決バージョンは 3.10.1、本 PR では `^3.10.1` が 3.41.0 に解決される。2.5.0 に取り残された原因が狭いピンだったため範囲は広く取るが、**3.41 で不審な挙動が出た場合の既知の正常系は 3.10.1**。

### 2. 埋め込みウォレット判定の堅牢化（FoR から取り込み）

`useActiveWallet` の判定を `wallets` だけでなく `user.wallet?.walletClientType === "privy"` からも行う。`wallets` に埋め込みエントリが載るのは Privy が connector を登録した後で、それには隠し iframe（`auth.privy.io` のウォレットプロキシ）のハンドシェイク完了が必要。未完了のうちは、アカウントが埋め込みウォレットを持っていても `wallets` が空になりうる（本番のコンソールに `Failed to add embedded wallet connector: Wallet proxy not initialized` が出ていた）。`wallets` だけを見ていると、そのセッションを外部ウォレット扱いして `wallets[0]` のアドレスにフォールバックしてしまい、プロフィールのキーになっているアドレスとは別物になる。

併せて `useWallets().ready` を `walletsReady` として公開。

### 3. アドレス未取得に対するデッドライン（止血 + 可視化）

`authenticated && !resolvedAddress` が 20 秒続いたら、スピナーの代わりにエラー表示 + 「再試行」（リロードで provider を再マウント）+ サインアウトを出す。

Privy 側の失敗経路はどれも静かなので、払い出し状態（`user.smartWallet` の有無、`hasEmbeddedWalletOnUser`、`isPreparingSmartWallet`、`wallets` のメタデータ）もログに出す:

- link 段の失敗は `console.error("Error creating smart wallet:", …)` のみ
- 設定取得の失敗は `console.warn(…)` — error ではなく warn
- client 生成段（ファクトリ読み取り、`getEthereumProvider()`、SIWE 署名）と iframe ハンドシェイクは**無言で reject / ハングしうる**

診断値は effect の依存配列ではなく ref 経由で読んでいる（`usePrivy().user` / `useWallets().wallets` は毎レンダー identity が変わるため、依存に入れるとタイマーが張り直されて発火しない。既存の遷移 effect が同じ罠をコメントで警告している）。

### 4. Privy 内部 public client の RPC を固定する

`getPublicClient`（`@privy-io/react-auth`）は渡されたチェーンオブジェクトから RPC を解決するが、この client には **fallback transport がない**。viem 2.30.5 の `sepolia.rpcUrls.default` は `https://sepolia.drpc.org` で、現在このエンドポイントは全リクエストに HTTP 400（`chain is not available on free plan`）を返す。`privyChain`（`rpcUrls.default` を Alchemy に差し替えたチェーン）を渡して単一障害点を除去する。

viem 2.43.5 以降は sepolia のデフォルトが `https://11155111.rpc.thirdweb.com` に変わっており、今回のアップグレードでこの経路自体は解消するが、Privy 側に fallback が無い以上「viem がデフォルトに何を選ぶか」に依存させない方が安全。fallback がないためログインは Alchemy アプリの生存に依存するので、`VITE_ALCHEMY_KEY` は各環境で有効なアプリを指しておく必要がある（コメントに明記）。

## 動作確認

- `pnpm frontend typecheck` ✅
- `pnpm frontend build` ✅
- `pnpm frontend test` ✅（3 files / 24 tests）
- `pnpm biome check` ✅（lefthook pre-commit で 462 ファイル通過）

**要マージ前確認**: 上限ピンの理由だった Vercel ビルドが v3 で通るか（ローカルビルドは通過）。プレビューデプロイで新規アカウント作成を通してほしい。

## 補足（この PR の対象外）

リポジトリの `pkgs/frontend/.env` / `.env.base` は本番と値がずれている。`VITE_PRIVY_APP_ID` は `cme72f6pf02rvl50d1q7siukj`（本番は `cm3wz404002mlc25ikvrs2ikh`）、`.env.base` の `VITE_ALCHEMY_KEY` は 403 `App is inactive` を返す。ローカル調査時に本番と違う結論を出しかけたので、整合させるか古い旨を明記したい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)