### PR TITLE
fix(frontend): ヘッドレスログイン時に埋め込みウォレットを明示的に作成する

### DIFF
--- a/pkgs/frontend/app/components/PrivyAppRoot.tsx
+++ b/pkgs/frontend/app/components/PrivyAppRoot.tsx
@@ -1,6 +1,7 @@
 import { PrivyProvider } from "@privy-io/react-auth";
 import { SmartWalletsProvider } from "@privy-io/react-auth/smart-wallets";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEnsureEmbeddedWallet } from "hooks/useEnsureEmbeddedWallet";
 import { privyChain } from "hooks/useViem";
 import { PWAUpdater } from "./PWAUpdater";
 import { SwitchNetwork } from "./SwitchNetwork";
@@ -13,7 +14,13 @@ const queryClient = new QueryClient();
 // `AccountMenu` shows a small inline spinner in the account area
 // (top-left on desktop, account icon slot on mobile) rather than the
 // previous full-screen blocker.
-const AppContent = () => <AppShellLayout />;
+//
+// `useEnsureEmbeddedWallet` lives here rather than in `login.tsx` so it covers
+// every entry point into an authenticated session, not just the login card.
+const AppContent = () => {
+  useEnsureEmbeddedWallet();
+  return <AppShellLayout />;
+};
 
 export default function PrivyAppRoot() {
   return (

--- a/pkgs/frontend/hooks/useEnsureEmbeddedWallet.ts
+++ b/pkgs/frontend/hooks/useEnsureEmbeddedWallet.ts
@@ -1,0 +1,60 @@
+import { useCreateWallet, usePrivy, useWallets } from "@privy-io/react-auth";
+import { useEffect, useRef } from "react";
+
+/**
+ * Creates the embedded wallet that Privy's `createOnLogin` never gets around
+ * to creating for us.
+ *
+ * `config.embeddedWallets.ethereum.createOnLogin` only fires for logins that
+ * go through Privy's own modal. Our login screen drives the headless hooks
+ * instead (`useLoginWithEmail`, `useLoginWithOAuth` — see `login.tsx`), and
+ * Privy's docs are explicit about the gap: automatic wallet creation "only
+ * applies to login via the Privy modal and not from whitelabel login methods.
+ * It does not trigger wallet creation for users who authenticate through
+ * direct login methods like loginWithCode, useLoginWithOAuth, or similar
+ * custom flows."
+ * https://docs.privy.io/basics/react/advanced/automatic-wallet-creation
+ *
+ * So since we moved the login card off the modal, a brand-new account finishes
+ * authentication owning no wallet at all. Every address the app cares about is
+ * the smart wallet's, and that needs the embedded EOA as its signer, so
+ * `useActiveWallet` never resolves and the user sits on /login forever.
+ * Existing accounts are unaffected — they already have a wallet — which is why
+ * this only ever showed up for new sign-ups.
+ *
+ * Recovery is Privy-managed here (the app's
+ * `require_user_owned_recovery_on_create` is false), so `createWallet` shows
+ * no UI of its own.
+ */
+export const useEnsureEmbeddedWallet = () => {
+  const { authenticated, user } = usePrivy();
+  const { ready: walletsReady } = useWallets();
+  const { createWallet } = useCreateWallet();
+
+  // Mirror `createOnLogin: "users-without-wallets"`: only step in when the
+  // account has no Ethereum wallet at all, so a user who signed in with an
+  // external wallet doesn't get a surprise embedded one. This is the same
+  // check Privy makes internally before auto-creating.
+  const hasEthereumWallet = !!user?.linkedAccounts.some(
+    (account) => account.type === "wallet" && account.chainType === "ethereum",
+  );
+
+  // `createWallet` throws if a wallet already exists, and hammering Privy's
+  // API on failure is worse than surfacing the stall, so attempt once per
+  // session. Held in a ref alongside the callback so the effect can depend on
+  // plain booleans — `usePrivy().user` gets a fresh identity on most renders,
+  // and depending on it would re-run this on every render.
+  const attemptedRef = useRef(false);
+  const createWalletRef = useRef(createWallet);
+  createWalletRef.current = createWallet;
+
+  useEffect(() => {
+    if (!authenticated || !walletsReady || hasEthereumWallet) return;
+    if (attemptedRef.current) return;
+    attemptedRef.current = true;
+
+    createWalletRef.current().catch((error: unknown) => {
+      console.error("Failed to create the embedded wallet", error);
+    });
+  }, [authenticated, walletsReady, hasEthereumWallet]);
+};


### PR DESCRIPTION
新規アカウントが `/signup` に遷移せず `/login` で無限ローディングする問題への修正。**Toban 側の確実な不具合を 1 つ潰すもので、これで完全に解決すると断定はできない**（下記「未解決の可能性」参照）。

## 原因

Privy の `config.embeddedWallets.ethereum.createOnLogin` は **Privy 自身のモーダル経由のログインでしか発火しない**。[公式ドキュメント](https://docs.privy.io/basics/react/advanced/automatic-wallet-creation)に明記がある:

> Automatic wallet creation only applies to login via the Privy modal and not from whitelabel login methods. It does not trigger wallet creation for users who authenticate through direct login methods like `loginWithCode`, `useLoginWithOAuth`, or similar custom flows.

そして `2971e7b`（"embed login auth options inline + recover stuck post-auth nav"）で、ログイン画面を Privy モーダル（`usePrivy().connectOrCreateWallet`）からヘッドレスフックに置き換えている:

```diff
-  const { connectOrCreateWallet, logout } = usePrivy();
+  const { logout } = usePrivy();
+  const { sendCode, loginWithCode, state: emailState } = useLoginWithEmail();
+  const { initOAuth, state: oauthState } = useLoginWithOAuth();
```

つまりこの commit 以降、**新規アカウントは認証だけ通ってウォレットを 1 つも持たない状態**になる。実際、本番で詰まっているセッションの `/api/v1/oauth/authenticate` レスポンスは `linked_accounts` が `google_oauth` のみだった。

アプリが扱うアドレスはすべてスマートウォレットのもので、それには埋め込み EOA が signer として必要なため:

- `hooks/useWallet.ts` — `useActiveWallet` が解決しない
- `app/routes/login.tsx` — `resolvedAddress` が `undefined`
- 遷移用 effect が `if (!address) return;` で抜け続ける → 無限ローディング

既存アカウントは既にウォレットを持つので影響を受けない。**これが「新規ユーザーだけ壊れる」非対称性の説明になる。**

そして Privy 側は失敗ではなく「作成を試みない」だけなので、**コンソールに何のエラーも出ない**。

## 変更内容

`hooks/useEnsureEmbeddedWallet.ts` を追加し、認証済みかつ Ethereum ウォレットを 1 つも持たないアカウントに対して `useCreateWallet()` を明示的に呼ぶ。

- 判定は `createOnLogin: "users-without-wallets"` と同じ（`linkedAccounts` に `type === "wallet" && chainType === "ethereum"` が無い場合のみ）。**外部ウォレットでログインしたユーザーに埋め込みウォレットが生えることはない**
- recovery は Privy 管理（アプリ設定の `require_user_owned_recovery_on_create` は `false`）なので UI は出ない
- `login.tsx` ではなく `PrivyAppRoot` の `AppContent` に置いて、ログインカード以外の入口からセッションが始まった場合もカバーする
- `createWallet` は既にウォレットがある場合に throw し、失敗時に Privy の API を叩き続けるのは避けたいのでセッションあたり 1 回に制限。effect の依存はプリミティブのみにし、コールバックは ref 経由で読む（`usePrivy().user` は毎レンダー identity が変わるため。既存の遷移 effect が同じ罠をコメントで警告している）

## 未解決の可能性（重要）

**FoR でも同じ症状が報告されているが、FoR は `useLogin().login()`（Privy モーダル）を使っており、上記のホワイトラベル制約には該当しない。** つまり別の共通要因がある可能性が高い。

共有している Privy アプリの設定で `embedded_wallet_config.create_on_login` が **`"off"`**（フラットも `ethereum` も `solana` も）になっている。両アプリともクライアント設定で上書きして動かしているが、実際の作成はウォレットプロキシ iframe → Privy の API 経由なので、**API 側がアプリ設定に従って拒否していればクライアント設定は効かない**。

- ダッシュボード（`Embedded wallets` → create on login）を `users-without-wallets` に変更して新規アカウントを作れば、デプロイ不要で切り分けられる
- **このアプリは FoR と共有しているため変更は双方に影響する。**先方と調整のうえで実施したい
- FoR 側にも issue を作成した: hackdays-io/FoR#175

なお本 PR の `useCreateWallet()` は「自動作成」ではなく明示的な作成 API なので、`create_on_login` の設定に関わらず動くはず。ただしそこも実機確認が必要。

## 調査で除外した要因（すべて実測）

| 要因 | 結果 |
|---|---|
| SDK バージョン | ✅ Privy 2.5.0 / 3.10.1 / 3.41.0、viem 2.30.5 / 2.43.5 / 2.56.3 いずれでも発生 |
| RPC（Alchemy） | ✅ 現行キーで 200 / CORS ヘッダあり / ファクトリ `getAddress()` が `0x…1493e4b4` を返す |
| `mode: "legacy-embedded-wallets-only"` | ✅ 移行と recovery UI の分岐のみで作成をブロックしない |
| `allowed_domains` | ✅ `https://www.toban.xyz` あり |
| 規約同意ゲート | ✅ `require_users_accept_terms: null` |
| iframe ブロック | ✅ CSP / COEP / X-Frame-Options なし、エンドポイント 200、`Privy iframe failed to load` も出ない |
| スマートウォレット設定 | ✅ `enabled: true` / `thirdweb` / 両チェーン設定済み |

## 動作確認

- `pnpm frontend typecheck` ✅
- `pnpm frontend build` ✅
- `pnpm frontend test` ✅（3 files / 24 tests）
- `pnpm biome check` ✅（lefthook pre-commit で 463 ファイル通過）

**プレビューで新規アカウント作成を通して確認してほしい。** #585 で入れた 20 秒デッドラインのログ（`No wallet address 20000ms after authentication`）が出なくなることも併せて確認できる。

## 関連 PR の扱い

- **#587**（Privy / viem を FoR の実績バージョンに固定）— FoR でも同じ症状が出るため前提が崩れている。**閉じてよい**
- **#586**（Privy に渡す RPC を publicnode に）— バグ修正ではなく堅牢化。fallback を持てないクライアントをキー付きアプリの生存に依存させたくないという方針判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)